### PR TITLE
Phase 3c: Add CI/CD workflows for TypeScript build

### DIFF
--- a/.github/workflows/build-typescript.yaml
+++ b/.github/workflows/build-typescript.yaml
@@ -1,0 +1,48 @@
+name: Build TypeScript frontend
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set git config
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Remove stale hashed assets
+        run: git rm --ignore-unmatch -f docs/assets/j_points-*.js docs/assets/j_points-*.css
+
+      - name: Build
+        run: npm run build
+        working-directory: frontend
+
+      - name: Commit and push if changed
+        run: |
+          git add docs/j_points.html docs/assets/
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Build TypeScript frontend assets"
+            git push origin HEAD
+          fi

--- a/.github/workflows/build-typescript.yaml
+++ b/.github/workflows/build-typescript.yaml
@@ -1,6 +1,7 @@
 name: Build TypeScript frontend
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/test-typescript.yaml
+++ b/.github/workflows/test-typescript.yaml
@@ -1,6 +1,7 @@
 name: TypeScript type check and test
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-typescript.yaml
+++ b/.github/workflows/test-typescript.yaml
@@ -1,0 +1,40 @@
+name: TypeScript type check and test
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'feature/**'
+    paths:
+      - 'frontend/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Type check
+        run: npm run typecheck
+        working-directory: frontend
+
+      - name: Run tests
+        run: npm test
+        working-directory: frontend


### PR DESCRIPTION
## Summary

- Add `test-typescript.yaml`: runs `tsc --noEmit` and `vitest run` on PRs and push to `main` (triggered only when `frontend/**` changes)
- Add `build-typescript.yaml`: cleans stale hashed assets (`docs/assets/j_points-*.js`), runs `npm run build`, then commits changed build artifacts on push to `main`

Closes #59 (sub-issue of #56)

## Test plan

- [ ] Verify `test-typescript.yaml` triggers on a PR that touches `frontend/`
- [ ] Verify `test-typescript.yaml` does NOT trigger on a PR that only touches `src/` or `docs/csv/`
- [ ] After merging to `main`, verify `build-typescript.yaml` runs, removes old hashed JS, and commits fresh build output
- [ ] Verify no duplicate hashed files accumulate in `docs/assets/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)