### PR TITLE
Migrate CSV update workflow and script to uv

### DIFF
--- a/.github/workflows/upadate-match-csv.yaml
+++ b/.github/workflows/upadate-match-csv.yaml
@@ -359,37 +359,35 @@ on:
     - cron: '0 12 31 8 *'
 
 jobs:
-  build:
+  update-csv:
 
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.12]
 
     steps:
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Set git config
-      run: |
-        git config --global user.name "mokekuma-git"
-        git config --global user.email "mokekuma.git@gmail.com"
     - name: git checkout
       uses: actions/checkout@v4
       with:
         ref: main
-    - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@v4
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
       with:
-        path: "requirements.txt"
+        python-version: "3.12"
+
+    - name: Install dependencies
+      run: uv sync
+
+    - name: Set git config
+      run: |
+        git config --global user.name "mokekuma-git"
+        git config --global user.email "mokekuma.git@gmail.com"
+
     - name: Update matches csv
       run: |
         DATE=`TZ=Asia/Tokyo date +'%m/%d %H:%M'`
-        bash scripts/call_update_csv.sh github.event.schedule
+        bash scripts/call_update_csv.sh "${{ github.event.schedule }}"
         if (git diff --shortstat | grep '[0-9]'); then \
-          git add .; \
+          git add docs/csv/; \
           git commit -m "Make new csv (append games on $DATE)"; \
           git push origin HEAD; \
         fi

--- a/scripts/call_update_csv.sh
+++ b/scripts/call_update_csv.sh
@@ -13,12 +13,12 @@ echo $TRIGGER
 if [ $RUNNING_HOUR -eq 1 ]; then
 # if [ $TRIGGER = $DAILY]; then
   # 日ごと深夜自動実行 ⇒ 全CSVのアップデートを実行
-  python src/read_jleague_matches.py -f
-  python src/read_jfamatch.py PrincePremierE PrincePremierW PrinceKanto
-  # python src/read_we-league.py
-  # python src/read_aclgl_matches.py
+  uv run python src/read_jleague_matches.py -f
+  uv run python src/read_jfamatch.py PrincePremierE PrincePremierW PrinceKanto
+  # uv run python src/read_we-league.py
+  # uv run python src/read_aclgl_matches.py
 else
   # 試合時間ごとの自動実行は、現在はJリーグ分のみ
-  python src/read_jleague_matches.py
-  # python src/read_jfamatch.py PrincePremierE PrincePremierW PrinceKanto
+  uv run python src/read_jleague_matches.py
+  # uv run python src/read_jfamatch.py PrincePremierE PrincePremierW PrinceKanto
 fi


### PR DESCRIPTION
## Summary

- Fixes #63
- CSV定期更新ワークフロー (`upadate-match-csv.yaml`) が `requirements.txt` 不在でエラー終了していた問題を修正
- `call_update_csv.sh` の `python` 呼び出しも `uv run python` に統一

## Changes

| 項目 | 旧 | 新 |
| ---- | -- | -- |
| Python セットアップ | `actions/setup-python@v5` | `astral-sh/setup-uv@v5` |
| 依存関係インストール | `py-actions/py-dependency-install@v4` (requirements.txt) | `uv sync` |
| matrix 戦略 | `python-version: [3.12]` | 削除 (固定値で matrix 不要) |
| ジョブ名 | `build` | `update-csv` |
| schedule 引数 | `github.event.schedule` (リテラル) | `${{ github.event.schedule }}` (正しい展開) |
| git add 対象 | `git add .` | `git add docs/csv/` (CSVのみに限定) |
| スクリプト内コマンド | `python src/...` | `uv run python src/...` |

## Test plan

- [ ] ワークフローの YAML 構文が正しいこと (GitHub Actions で parse error が出ないこと)
- [ ] `astral-sh/setup-uv@v5` + `uv sync` で依存関係がインストールされること
- [ ] `call_update_csv.sh` が `uv run` で正常にスクリプトを実行すること
- [ ] 次回の cron 実行 or `workflow_dispatch` で CSV 更新が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)