### PR TITLE
Fix minor view issues: rank table, date span, appearance init, status_msg placement

### DIFF
--- a/docs/j_points.css
+++ b/docs/j_points.css
@@ -152,6 +152,9 @@ table.ranktable td {
   border-bottom: solid 2px #777;
   text-align: right;
 }
+table.ranktable td div {
+  text-align: center;
+}
 table.ranktable th {
   border-bottom: solid 2px #222;
 }

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -18,7 +18,7 @@ import { getSortedTeamList } from './core/sorter';
 import { calculateTeamStats } from './ranking/stats-calculator';
 import type { MatchSortKey } from './ranking/stats-calculator';
 import { makeRankData, makeRankTable } from './ranking/rank-table';
-import { renderBarGraph, findSliderIndex, formatSliderDate } from './graph/renderer';
+import { renderBarGraph, findSliderIndex } from './graph/renderer';
 import { getHeightUnit, setFutureOpacity, setSpace, setScale } from './graph/css-utils';
 import { loadPrefs, savePrefs, clearPrefs } from './storage/local-storage';
 
@@ -158,8 +158,6 @@ function resetDateSlider(matchDates: string[], targetDate: string): void {
   const postEl = document.getElementById('post_date_slider');
   if (postEl) postEl.textContent = matchDates[matchDates.length - 1] ?? '';
 
-  const displayEl = document.getElementById('target_date_display');
-  if (displayEl) displayEl.textContent = formatSliderDate(matchDates[idx] ?? '1970/01/01', targetDate);
 }
 
 // ---- Cached TeamMap ----------------------------------------------------
@@ -212,7 +210,7 @@ function renderFromCache(
     );
     boxCon.innerHTML = html;
     const scaleSlider = document.getElementById('scale_slider') as HTMLInputElement | null;
-    setScale(boxCon, scaleSlider?.value ?? '1', false);
+    setScale(boxCon, scaleSlider?.value ?? '1');
     resetDateSlider(matchDates, targetDate);
   }
 
@@ -333,6 +331,11 @@ async function main(): Promise<void> {
   if (spaceColorEl    && prefs.spaceColor)    spaceColorEl.value    = prefs.spaceColor;
   if (scaleSliderEl   && prefs.scale)         scaleSliderEl.value   = prefs.scale;
 
+  // Apply restored values to CSS rules and update display spans.
+  // updateSlider=false because the inputs were already set above.
+  setFutureOpacity(futureOpacityEl?.value ?? '0.1', false);
+  if (prefs.spaceColor) setSpace(prefs.spaceColor, false);
+
   // Restore target date from prefs; fall back to today.
   const dateInput = document.getElementById('target_date') as HTMLInputElement;
   if (prefs.targetDate) {
@@ -368,10 +371,7 @@ async function main(): Promise<void> {
     const updateFromSlider = (): void => {
       const date = currentMatchDates[parseInt(dateSlider.value)];
       if (!date) return;
-      const isPreSeason = date === '1970/01/01';
       (document.getElementById('target_date') as HTMLInputElement).value = date.replace(/\//g, '-');
-      const displayEl = document.getElementById('target_date_display');
-      if (displayEl) displayEl.textContent = isPreSeason ? '開幕前' : date;
       loadAndRender(seasonMap);
     };
 

--- a/frontend/src/j_points.html
+++ b/frontend/src/j_points.html
@@ -61,7 +61,6 @@
   <input type="range" id="date_slider" min="0" max="0" step="1" value="0" style="width:300px;"/>
   <button id="date_slider_up">＞</button>
   <span id="post_date_slider"></span>
-  [<span id="target_date_display"></span>]
   <button id="reset_date_slider">最新にリセット</button>
 </section>
 

--- a/frontend/src/j_points.html
+++ b/frontend/src/j_points.html
@@ -50,7 +50,6 @@
       <option value="last_bottom">最終節が下</option>
     </select>
   </label>
-  <span id="status_msg" style="color:#666; font-size:0.9em;"></span>
   <span style="color:#999; font-size:0.85em;">データ取得時刻: <span id="data_timestamp"></span></span>
 </section>
 
@@ -88,6 +87,8 @@
 
 <!-- Hidden .short div for HEIGHT_UNIT calculation -->
 <div class="short" style="display:none;"></div>
+
+<div id="status_msg" style="color:#666; font-size:0.9em; margin:0.5em 1em;"></div>
 
 <hr/>
 データ参照元: <a href="https://www.jleague.jp/match/">Jリーグ公式サイト: 日程結果</a><br/>


### PR DESCRIPTION
## Summary

表示まわりのマイナー修正4件をまとめて対応。

- **順位表チーム名のセンタリング** — `table.ranktable td div { text-align: center }` を追加
- **スライダー右の日時 span 削除** — `#target_date_display` とその更新コード2箇所を削除（表示日 `input` と重複）
- **外観コントロールの初期表示修正** — ページ読み込み時に localStorage から復元した値を CSS と表示 span に反映 (`setFutureOpacity` 初期呼び出し、`setScale` の `current_scale` 更新を毎レンダリング後に実施)
- **`status_msg` をグラフ下に移動** — コントロール行での折り返し防止。グラフコンテナ直下・`<hr>` 前に配置

## Changes

- `docs/j_points.css`: ranktable チーム名セル div のセンタリングルール追加
- `frontend/src/j_points.html`: `#target_date_display` span 削除、`#status_msg` をグラフ下に移動
- `frontend/src/app.ts`: 不要な `target_date_display` 更新コード削除・未使用インポート削除、外観値の初期適用追加

## Test plan

- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx vitest run` — 204 tests passed
- [x] ブラウザで目視確認: 順位表チーム名センタリング、スライダー折り返し解消、透明度/倍率表示、status_msg 位置

Fixes #65, Fixes #66, Fixes #67