### PR TITLE
Relocate status_msg and data_timestamp before graph container

### DIFF
--- a/frontend/src/j_points.html
+++ b/frontend/src/j_points.html
@@ -50,7 +50,7 @@
       <option value="last_bottom">最終節が下</option>
     </select>
   </label>
-  <span style="color:#999; font-size:0.85em;">データ取得時刻: <span id="data_timestamp"></span></span>
+
 </section>
 
 <!-- Date slider -->
@@ -82,13 +82,17 @@
   <button id="reset_prefs">設定をリセット</button>
 </section>
 
+<!-- Status message and data timestamp -->
+<div style="margin:0.5em 1em; font-size:0.9em; color:#666;">
+  <span id="status_msg"></span>
+  <span style="color:#999; margin-left:1em;">データ取得時刻: <span id="data_timestamp"></span></span>
+</div>
+
 <!-- Bar graph container -->
 <div id="box_container"></div>
 
 <!-- Hidden .short div for HEIGHT_UNIT calculation -->
 <div class="short" style="display:none;"></div>
-
-<div id="status_msg" style="color:#666; font-size:0.9em; margin:0.5em 1em;"></div>
 
 <hr/>
 データ参照元: <a href="https://www.jleague.jp/match/">Jリーグ公式サイト: 日程結果</a><br/>


### PR DESCRIPTION
## Summary

PR #68 では `#status_msg` をグラフ下に配置したが、`transform: scale()` の overflow により グラフのビジュアルと重なる問題が発生。

グラフ前（`#appearance_controls` 直下）に移動することで根本的に解決。同時に `データ取得時刻` (`#data_timestamp`) もコントロール行から同じ場所に移動し、コントロール行の折り返しを完全に防ぐ。

## Changes

- `#status_msg` と `#data_timestamp` を `#box_container` の直前に配置
- コントロール行（`#controls`）から `data_timestamp` を削除

## Test plan

- [x] `npm run build` — ビルド成功
- [x] ブラウザ確認: コントロール行が折り返さないこと、status + timestamp がグラフ前に表示されること

Fixes #67