### PR TITLE
Rename category to competition in old_matches pipeline

### DIFF
--- a/config/old_matches.yaml
+++ b/config/old_matches.yaml
@@ -44,5 +44,5 @@ match_data:
   card_id_pattern: "/SFMS02/\\?match_card_id=(\\d+)"
   url_format: "https://data.j-league.or.jp/SFMS01/search?competition_years={year}&tv_relay_station_name="
   csv_path_format: "../csv/{year}.csv"
-  league_csv_path: "../docs/csv/{season}_allmatch_result-J{category}.csv"
+  league_csv_path: "../docs/csv/{season}_allmatch_result-{competition}.csv"
   encoding: "utf-8"


### PR DESCRIPTION
## Summary

M1-A の残作業。`make_old_matches_csv.py` と `old_matches.yaml` で残っていた `category` → `competition` リネームを完了。

Refs #70

## Changes

- `config/old_matches.yaml`: `league_csv_path` のフォーマット文字列 `J{category}` → `{competition}`
- `src/make_old_matches_csv.py`: 関数シグネチャ `category: int` → `competition: str`、内部で `comp_index` に変換、main ループを `['J1', 'J2', 'J3']` に変更

## Test plan

- [x] `uv run pytest` — 58 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)