### PR TITLE
Add configurable tiebreak_order with H2H support

### DIFF
--- a/frontend/src/__tests__/config/season-map.test.ts
+++ b/frontend/src/__tests__/config/season-map.test.ts
@@ -190,4 +190,35 @@ describe('resolveSeasonInfo', () => {
 
     expect(info.leagueDisplay).toBe('Test Group');
   });
+
+  test('tiebreakOrder defaults to ["goal_diff", "goal_get"]', () => {
+    const entry: RawSeasonEntry = [20, 3, 3, []];
+    const info = resolveSeasonInfo(sampleGroup, sampleGroup.competitions.J1, entry);
+
+    expect(info.tiebreakOrder).toEqual(['goal_diff', 'goal_get']);
+  });
+
+  test('cascade: tiebreak_order from competition level', () => {
+    const comp: CompetitionEntry = {
+      league_display: 'ACL GS',
+      tiebreak_order: ['head_to_head', 'goal_diff', 'goal_get'],
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = [8, 0, 0, []];
+    const info = resolveSeasonInfo(sampleGroup, comp, entry);
+
+    expect(info.tiebreakOrder).toEqual(['head_to_head', 'goal_diff', 'goal_get']);
+  });
+
+  test('cascade: tiebreak_order from season overrides competition', () => {
+    const comp: CompetitionEntry = {
+      league_display: 'ACL GS',
+      tiebreak_order: ['head_to_head', 'goal_diff', 'goal_get'],
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = [8, 0, 0, [], { tiebreak_order: ['goal_diff', 'wins'] }];
+    const info = resolveSeasonInfo(sampleGroup, comp, entry);
+
+    expect(info.tiebreakOrder).toEqual(['goal_diff', 'wins']);
+  });
 });

--- a/frontend/src/__tests__/core/sorter.test.ts
+++ b/frontend/src/__tests__/core/sorter.test.ts
@@ -8,7 +8,8 @@ import {
   getPossibleLine,
   getSelfPossibleLine,
 } from '../../core/sorter';
-import { makeTeamData } from '../fixtures/match-data';
+import { makeTeamData, makeMatch } from '../fixtures/match-data';
+import type { TeamData, TeamMatch } from '../../types/match';
 
 // Helper: build TeamData with pre-filled stat fields (no matches needed for sorter tests).
 function makeStats(overrides: Record<string, number | Record<string, number>> = {}) {
@@ -22,9 +23,22 @@ function makeStats(overrides: Record<string, number | Record<string, number>> = 
     goal_get: 0,
     disp_goal_diff: 0,
     disp_goal_get: 0,
+    win: 0,
+    disp_win: 0,
     rest_games: {} as Record<string, number>,
     disp_rest_games: {} as Record<string, number>,
     ...overrides,
+  };
+}
+
+/** Build a TeamData with matches and pre-filled stats for H2H tests. */
+function makeTeamWithMatches(
+  matches: TeamMatch[],
+  stats: Record<string, number | Record<string, number>> = {},
+): TeamData {
+  return {
+    ...makeStats(stats),
+    df: matches,
   };
 }
 
@@ -206,5 +220,132 @@ describe('getSelfPossibleLine', () => {
       TeamA: makeStats({ avlbl_pt: 40, rest_games: {} }),
     };
     expect(getSelfPossibleLine(1, 'TeamA', false, teams)).toBe(0);
+  });
+});
+
+// ---- getSortedTeamList with tiebreakOrder ---------------------------------
+
+describe('getSortedTeamList tiebreakOrder', () => {
+  test('default tiebreakOrder ["goal_diff", "goal_get"] preserves existing behavior', () => {
+    const teams = {
+      TeamA: makeStats({ point: 20, goal_diff: 5, goal_get: 18 }),
+      TeamB: makeStats({ point: 20, goal_diff: 5, goal_get: 25 }),
+    };
+    const result = getSortedTeamList(teams, 'point');
+    expect(result[0]).toBe('TeamB');
+  });
+
+  test('tiebreakOrder ["goal_get"] skips goal_diff', () => {
+    const teams = {
+      TeamA: makeStats({ point: 20, goal_diff: 10, goal_get: 18 }),
+      TeamB: makeStats({ point: 20, goal_diff: 5, goal_get: 25 }),
+    };
+    // With only goal_get as tiebreaker, TeamB (25) beats TeamA (18)
+    // even though TeamA has a better goal_diff
+    const result = getSortedTeamList(teams, 'point', ['goal_get']);
+    expect(result[0]).toBe('TeamB');
+  });
+
+  test('tiebreakOrder ["wins", "goal_diff"] uses wins first', () => {
+    const teams = {
+      TeamA: makeStats({ point: 20, win: 6, goal_diff: 10, goal_get: 20 }),
+      TeamB: makeStats({ point: 20, win: 5, goal_diff: 15, goal_get: 25 }),
+    };
+    // wins: TeamA (6) > TeamB (5) → TeamA first
+    const result = getSortedTeamList(teams, 'point', ['wins', 'goal_diff']);
+    expect(result[0]).toBe('TeamA');
+  });
+
+  test('H2H 2 teams: direct result decides', () => {
+    // TeamA and TeamB tied on points, but TeamA beat TeamB 2-1
+    const teams = {
+      TeamA: makeTeamWithMatches(
+        [
+          makeMatch({ opponent: 'TeamB', goal_get: '2', goal_lose: '1', point: 3, is_home: true }),
+          makeMatch({ opponent: 'TeamC', goal_get: '0', goal_lose: '1', point: 0 }),
+        ],
+        { point: 3, goal_diff: 0, goal_get: 2, win: 1 },
+      ),
+      TeamB: makeTeamWithMatches(
+        [
+          makeMatch({ opponent: 'TeamA', goal_get: '1', goal_lose: '2', point: 0, is_home: false }),
+          makeMatch({ opponent: 'TeamC', goal_get: '3', goal_lose: '0', point: 3 }),
+        ],
+        { point: 3, goal_diff: 0, goal_get: 4, win: 1 },
+      ),
+      TeamC: makeTeamWithMatches([], { point: 0, goal_diff: -4, goal_get: 0 }),
+    };
+    // With default tiebreakers: goal_diff tied (0 = 0), goal_get TeamB > TeamA → TeamB first.
+    // With H2H: TeamA beat TeamB → TeamA first.
+    const result = getSortedTeamList(teams, 'point', ['head_to_head', 'goal_diff', 'goal_get']);
+    expect(result[0]).toBe('TeamA');
+    expect(result[1]).toBe('TeamB');
+  });
+
+  test('H2H 3 teams: mini-table decides', () => {
+    // Three-way tie: A beat B, B beat C, C beat A — all 3 pts each
+    // H2H mini-table: A(3pts,+1gd), B(3pts,+1gd), C(3pts,+1gd) → still tied
+    // But with different H2H goal differences we can distinguish:
+    // A beat B 2-0, B beat C 3-1, C beat A 1-0
+    // H2H: A: 3pts +2gd (from B) + 0pts -1gd (from C) = 3pts, +1gd
+    //       B: 0pts -2gd (from A) + 3pts +2gd (from C) = 3pts, 0gd
+    //       C: 3pts +1gd (from A) + 0pts -2gd (from B) = 3pts, -1gd
+    // All 3pts → sub-tie by H2H goal diff: A(+1) > B(0) > C(-1)
+    const teams = {
+      TeamA: makeTeamWithMatches(
+        [
+          makeMatch({ opponent: 'TeamB', goal_get: '2', goal_lose: '0', point: 3 }),
+          makeMatch({ opponent: 'TeamC', goal_get: '0', goal_lose: '1', point: 0 }),
+        ],
+        { point: 6, goal_diff: 5, goal_get: 10 },
+      ),
+      TeamB: makeTeamWithMatches(
+        [
+          makeMatch({ opponent: 'TeamA', goal_get: '0', goal_lose: '2', point: 0 }),
+          makeMatch({ opponent: 'TeamC', goal_get: '3', goal_lose: '1', point: 3 }),
+        ],
+        { point: 6, goal_diff: 5, goal_get: 10 },
+      ),
+      TeamC: makeTeamWithMatches(
+        [
+          makeMatch({ opponent: 'TeamA', goal_get: '1', goal_lose: '0', point: 3 }),
+          makeMatch({ opponent: 'TeamB', goal_get: '1', goal_lose: '3', point: 0 }),
+        ],
+        { point: 6, goal_diff: 5, goal_get: 10 },
+      ),
+    };
+    const result = getSortedTeamList(teams, 'point', ['head_to_head', 'goal_diff', 'goal_get']);
+    expect(result[0]).toBe('TeamA');
+    expect(result[1]).toBe('TeamB');
+    expect(result[2]).toBe('TeamC');
+  });
+
+  test('H2H fallthrough when no direct matches exist', () => {
+    // TeamA and TeamB tied on points but have not played each other
+    const teams = {
+      TeamA: makeTeamWithMatches(
+        [makeMatch({ opponent: 'TeamC', goal_get: '1', goal_lose: '0', point: 3 })],
+        { point: 3, goal_diff: 1, goal_get: 1 },
+      ),
+      TeamB: makeTeamWithMatches(
+        [makeMatch({ opponent: 'TeamC', goal_get: '3', goal_lose: '0', point: 3 })],
+        { point: 3, goal_diff: 3, goal_get: 3 },
+      ),
+      TeamC: makeTeamWithMatches([], { point: 0, goal_diff: -4, goal_get: 0 }),
+    };
+    // H2H returns null (no A vs B match) → falls through to goal_diff → TeamB first
+    const result = getSortedTeamList(teams, 'point', ['head_to_head', 'goal_diff', 'goal_get']);
+    expect(result[0]).toBe('TeamB');
+    expect(result[1]).toBe('TeamA');
+  });
+
+  test('unknown tiebreaker key is skipped (treated as no-op)', () => {
+    const teams = {
+      TeamA: makeStats({ point: 20, goal_diff: 5, goal_get: 20 }),
+      TeamB: makeStats({ point: 20, goal_diff: 10, goal_get: 25 }),
+    };
+    // 'unknown_key' is ignored, then goal_diff resolves
+    const result = getSortedTeamList(teams, 'point', ['unknown_key', 'goal_diff']);
+    expect(result[0]).toBe('TeamB');
   });
 });

--- a/frontend/src/__tests__/fixtures/match-data.ts
+++ b/frontend/src/__tests__/fixtures/match-data.ts
@@ -41,6 +41,7 @@ export function makeSeasonInfo(overrides: Partial<SeasonInfo> = {}): SeasonInfo 
     pointSystem: 'standard',
     cssFiles: [],
     teamRenameMap: {},
+    tiebreakOrder: ['goal_diff', 'goal_get'],
     ...overrides,
   };
 }

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -200,7 +200,7 @@ function renderFromCache(
     calculateTeamStats(teamData, targetDate, matchSortKey);
   }
 
-  const sortedTeams = getSortedTeamList(groupData, sortKey);
+  const sortedTeams = getSortedTeamList(groupData, sortKey, seasonInfo.tiebreakOrder);
 
   const { hasPk } = cache;
 

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -89,6 +89,11 @@ export function resolveSeasonInfo(
     ?? comp.point_system
     ?? 'standard';
 
+  // tiebreak_order: scalar cascade (lowest defined level wins)
+  const tiebreakOrder: string[] = opts.tiebreak_order
+    ?? comp.tiebreak_order
+    ?? ['goal_diff', 'goal_get'];
+
   return {
     teamCount: entry[0],
     promotionCount: entry[1],
@@ -101,5 +106,6 @@ export function resolveSeasonInfo(
     pointSystem,
     cssFiles,
     teamRenameMap,
+    tiebreakOrder,
   };
 }

--- a/frontend/src/core/sorter.ts
+++ b/frontend/src/core/sorter.ts
@@ -59,42 +59,196 @@ export function getPointSortedTeamList(
   });
 }
 
+// Known tiebreaker keys that can appear in tiebreak_order.
+const KNOWN_TIEBREAKERS = new Set(['head_to_head', 'goal_diff', 'goal_get', 'wins']);
+
 /**
- * Returns team names sorted by the given sort key, with goal_diff and goal_get as tiebreakers.
- * @param teams   - Single-group team map (team name → TeamData)
- * @param sortKey - Field name to sort by (e.g. 'point', 'disp_avlbl_pt')
+ * Groups team names by equal value of `keyFn`. Preserves order of the first
+ * occurrence of each distinct value.
+ */
+function groupByEqual(teamNames: string[], keyFn: (t: string) => number): string[][] {
+  const groups: string[][] = [];
+  const map = new Map<number, string[]>();
+  for (const t of teamNames) {
+    const v = keyFn(t);
+    let arr = map.get(v);
+    if (!arr) {
+      arr = [];
+      map.set(v, arr);
+      groups.push(arr);
+    }
+    arr.push(t);
+  }
+  return groups;
+}
+
+/**
+ * Computes head-to-head (H2H) mini-table points and goal difference
+ * among the given tied teams, using match data from the full team map.
+ *
+ * Returns a map of team name → { h2hPoints, h2hGoalDiff } or null
+ * if any pair has zero completed head-to-head matches (insufficient data).
+ */
+function computeH2H(
+  tiedTeams: string[],
+  allTeams: Record<string, TeamData>,
+  disp: boolean,
+): Map<string, { h2hPoints: number; h2hGoalDiff: number }> | null {
+  const tiedSet = new Set(tiedTeams);
+  const result = new Map<string, { h2hPoints: number; h2hGoalDiff: number }>();
+  for (const t of tiedTeams) {
+    result.set(t, { h2hPoints: 0, h2hGoalDiff: 0 });
+  }
+
+  // Track which pairs have at least one completed match
+  const pairHasMatch = new Set<string>();
+
+  for (const teamName of tiedTeams) {
+    const td = allTeams[teamName];
+    if (!td) continue;
+    for (const m of td.df) {
+      if (!tiedSet.has(m.opponent)) continue;
+      if (!m.has_result) continue;
+      // In disp mode, only count matches within the display window
+      // (matches after targetDate have has_result=true but we rely on
+      // the caller having already computed stats with the correct targetDate)
+      if (disp && m.match_date > (td as unknown as Record<string, string>)['_targetDate']) continue;
+
+      const pairKey = [teamName, m.opponent].sort().join('|');
+      pairHasMatch.add(pairKey);
+
+      const entry = result.get(teamName)!;
+      entry.h2hPoints += m.point;
+      const gGet = parseInt(m.goal_get) || 0;
+      const gLose = parseInt(m.goal_lose) || 0;
+      entry.h2hGoalDiff += gGet - gLose;
+    }
+  }
+
+  // Check that every pair of tied teams has at least one H2H match
+  for (let i = 0; i < tiedTeams.length; i++) {
+    for (let j = i + 1; j < tiedTeams.length; j++) {
+      const pairKey = [tiedTeams[i], tiedTeams[j]].sort().join('|');
+      if (!pairHasMatch.has(pairKey)) return null; // insufficient data
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Resolves a single tiebreaker for a group of tied teams, splitting them
+ * into sub-groups. Returns the list of sub-groups (each sorted internally).
+ */
+function applyTiebreaker(
+  tiedTeams: string[],
+  key: string,
+  allTeams: Record<string, TeamData>,
+  disp: boolean,
+): string[][] {
+  if (tiedTeams.length <= 1) return [tiedTeams];
+
+  if (key === 'head_to_head') {
+    const h2h = computeH2H(tiedTeams, allTeams, disp);
+    if (!h2h) return [tiedTeams]; // fallthrough: treat as still-tied
+
+    // First sort by H2H points, then by H2H goal difference
+    const sorted = [...tiedTeams].sort((a, b) => {
+      const diff = h2h.get(b)!.h2hPoints - h2h.get(a)!.h2hPoints;
+      if (diff !== 0) return diff;
+      return h2h.get(b)!.h2hGoalDiff - h2h.get(a)!.h2hGoalDiff;
+    });
+
+    return groupByEqual(sorted, (t) => {
+      const e = h2h.get(t)!;
+      // Combine points and goal diff into a single comparable value.
+      // Points have much higher weight to ensure they are compared first.
+      return e.h2hPoints * 10000 + e.h2hGoalDiff;
+    });
+  }
+
+  // Stat-based tiebreakers
+  const attrMap: Record<string, string> = {
+    goal_diff: 'goal_diff',
+    goal_get: 'goal_get',
+    wins: 'win',
+  };
+  const attr = attrMap[key];
+  if (!attr) {
+    console.warn(`Unknown tiebreaker key: "${key}" — skipping`);
+    return [tiedTeams];
+  }
+
+  const sorted = [...tiedTeams].sort((a, b) =>
+    calcCompare(getTeamAttr(allTeams[a], attr, disp), getTeamAttr(allTeams[b], attr, disp)),
+  );
+  return groupByEqual(sorted, (t) => getTeamAttr(allTeams[t], attr, disp));
+}
+
+/**
+ * Returns team names sorted by the given sort key, with configurable tiebreakers.
+ * @param teams         - Single-group team map (team name → TeamData)
+ * @param sortKey       - Field name to sort by (e.g. 'point', 'disp_avlbl_pt')
+ * @param tiebreakOrder - Ordered list of tiebreaker keys (default: ['goal_diff', 'goal_get'])
  * @returns Sorted list of team names, highest first
  */
 export function getSortedTeamList(
   teams: Record<string, TeamData>,
   sortKey: string,
+  tiebreakOrder: string[] = ['goal_diff', 'goal_get'],
 ): string[] {
   const disp = sortKey.startsWith('disp_');
-  return Object.keys(teams).sort((a, b) => {
+
+  // Warn about unknown tiebreaker keys (once per call)
+  for (const key of tiebreakOrder) {
+    if (!KNOWN_TIEBREAKERS.has(key)) {
+      console.warn(`Unknown tiebreaker key in tiebreak_order: "${key}"`);
+    }
+  }
+
+  // 1. Initial sort by primary key
+  const primarySorted = Object.keys(teams).sort((a, b) => {
     const getVal = (t: string) =>
       (teams[t] as unknown as Record<string, number | undefined>)[sortKey] ?? 0;
     let compare = calcCompare(getVal(a), getVal(b));
     if (compare !== 0) return compare;
 
+    // For avlbl_pt sort, use point as implicit secondary before tiebreakers
     if (sortKey.endsWith('avlbl_pt')) {
       const subKey = sortKey.replace('avlbl_pt', 'point');
       const getSubVal = (t: string) =>
         (teams[t] as unknown as Record<string, number | undefined>)[subKey] ?? 0;
       compare = calcCompare(getSubVal(a), getSubVal(b));
-      if (compare !== 0) return compare;
     }
-
-    compare = calcCompare(
-      getTeamAttr(teams[a], 'goal_diff', disp),
-      getTeamAttr(teams[b], 'goal_diff', disp),
-    );
-    if (compare !== 0) return compare;
-
-    return calcCompare(
-      getTeamAttr(teams[a], 'goal_get', disp),
-      getTeamAttr(teams[b], 'goal_get', disp),
-    );
+    return compare;
   });
+
+  // 2. Group by equal primary key value
+  let groups = groupByEqual(primarySorted, (t) => {
+    let val = (teams[t] as unknown as Record<string, number | undefined>)[sortKey] ?? 0;
+    if (sortKey.endsWith('avlbl_pt')) {
+      const subKey = sortKey.replace('avlbl_pt', 'point');
+      const subVal = (teams[t] as unknown as Record<string, number | undefined>)[subKey] ?? 0;
+      val = val * 100000 + subVal;
+    }
+    return val;
+  });
+
+  // 3. Apply tiebreakers to each group of tied teams
+  for (const key of tiebreakOrder) {
+    const newGroups: string[][] = [];
+    for (const group of groups) {
+      if (group.length <= 1) {
+        newGroups.push(group);
+      } else {
+        newGroups.push(...applyTiebreaker(group, key, teams, disp));
+      }
+    }
+    groups = newGroups;
+  }
+
+  // 4. Flatten
+  return groups.flat();
 }
 
 /**

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -32,6 +32,7 @@ export interface SeasonEntryOptions {
   point_system?: PointSystem;
   css_files?: string[];
   team_rename_map?: Record<string, string>;
+  tiebreak_order?: string[];
 }
 
 // Raw array format as loaded from season_map.json (tuple type).
@@ -79,6 +80,7 @@ export interface SeasonInfo {
   pointSystem: PointSystem;
   cssFiles: string[];
   teamRenameMap: Record<string, string>;
+  tiebreakOrder: string[];
 }
 
 // Converts a RawSeasonEntry tuple into a basic SeasonInfo object.
@@ -97,5 +99,6 @@ export function parseSeasonEntry(entry: RawSeasonEntry): SeasonInfo {
     pointSystem: opts.point_system ?? 'standard',
     cssFiles: opts.css_files ?? [],
     teamRenameMap: opts.team_rename_map ?? {},
+    tiebreakOrder: opts.tiebreak_order ?? ['goal_diff', 'goal_get'],
   };
 }


### PR DESCRIPTION
## Summary
- `tiebreak_order` カスケード (competition → season) を追加。デフォルト `["goal_diff", "goal_get"]` で既存動作を維持
- `getSortedTeamList()` をグループベースの段階的解決に改修し、`head_to_head` タイブレーカーを実装
- H2H は 2チーム直接対決・3+チームのミニテーブル両方に対応。データ不足時は次のタイブレーカーへフォールスルー
- サポートするタイブレーカー: `head_to_head`, `goal_diff`, `goal_get`, `wins`

## Changes
- `types/season.ts`: `SeasonEntryOptions.tiebreak_order` / `SeasonInfo.tiebreakOrder` 追加
- `config/season-map.ts`: `resolveSeasonInfo()` にスカラーカスケード追加
- `core/sorter.ts`: `getSortedTeamList()` 改修 + `computeH2H()` / `applyTiebreaker()` / `groupByEqual()` 追加
- `app.ts`: `seasonInfo.tiebreakOrder` を `getSortedTeamList` に伝播
- テスト 7件新規追加 (season-map 3件 + sorter 4件)

## Test plan
- [x] `npx vitest run` — 232 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] season_map.json に `tiebreak_order` を追加した competition での動作確認

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)