### PR TITLE
P5-1 + P5-2: Consolidate app state and extract prepareRenderData()

### DIFF
--- a/frontend/src/__tests__/core/prepare-render.test.ts
+++ b/frontend/src/__tests__/core/prepare-render.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from 'vitest';
+import { prepareRenderData } from '../../core/prepare-render';
+import type { PrepareRenderInput } from '../../core/prepare-render';
+import { makeMatch, makeTeamData, makeSeasonInfo } from '../fixtures/match-data';
+
+function makeTestInput(overrides: Partial<PrepareRenderInput> = {}): PrepareRenderInput {
+  return {
+    groupData: {
+      TeamA: makeTeamData([
+        makeMatch({ opponent: 'TeamB', point: 3, match_date: '2025/03/01', section_no: '1', goal_get: '2', goal_lose: '0' }),
+        makeMatch({ opponent: 'TeamC', point: 0, match_date: '2025/03/08', section_no: '2', goal_get: '0', goal_lose: '1' }),
+      ]),
+      TeamB: makeTeamData([
+        makeMatch({ opponent: 'TeamA', point: 0, match_date: '2025/03/01', section_no: '1', goal_get: '0', goal_lose: '2', is_home: false }),
+        makeMatch({ opponent: 'TeamC', point: 1, match_date: '2025/03/08', section_no: '2', goal_get: '1', goal_lose: '1' }),
+      ]),
+      TeamC: makeTeamData([
+        makeMatch({ opponent: 'TeamA', point: 3, match_date: '2025/03/08', section_no: '2', goal_get: '1', goal_lose: '0', is_home: false }),
+        makeMatch({ opponent: 'TeamB', point: 1, match_date: '2025/03/08', section_no: '2', goal_get: '1', goal_lose: '1', is_home: false }),
+      ]),
+    },
+    seasonInfo: makeSeasonInfo({ teamCount: 3, teams: ['TeamA', 'TeamB', 'TeamC'] }),
+    targetDate: '2025/12/31',
+    sortKey: 'point',
+    matchSortKey: 'section_no',
+    ...overrides,
+  };
+}
+
+describe('prepareRenderData', () => {
+  test('returns groupData with stats calculated', () => {
+    const result = prepareRenderData(makeTestInput());
+    // TeamA: 3 + 0 = 3pt, TeamB: 0 + 1 = 1pt, TeamC: 3 + 1 = 4pt
+    expect(result.groupData.TeamA.point).toBe(3);
+    expect(result.groupData.TeamA.win).toBe(1);
+    expect(result.groupData.TeamA.lose).toBe(1);
+    expect(result.groupData.TeamB.point).toBe(1);
+    expect(result.groupData.TeamB.draw).toBe(1);
+    expect(result.groupData.TeamC.point).toBe(4);
+  });
+
+  test('sortedTeams is sorted by requested sort key', () => {
+    const result = prepareRenderData(makeTestInput());
+    // TeamC: 4pt, TeamA: 3pt, TeamB: 1pt
+    expect(result.sortedTeams).toEqual(['TeamC', 'TeamA', 'TeamB']);
+  });
+
+  test('does not mutate the input groupData', () => {
+    const input = makeTestInput();
+    const originalPointA = input.groupData.TeamA.point; // undefined before stats
+    const originalDfLenA = input.groupData.TeamA.df.length;
+    prepareRenderData(input);
+    expect(input.groupData.TeamA.point).toBe(originalPointA);
+    expect(input.groupData.TeamA.df.length).toBe(originalDfLenA);
+  });
+
+  test('disp sort key uses disp_point for sorting', () => {
+    // targetDate between section 1 and section 2
+    const input = makeTestInput({
+      targetDate: '2025/03/05',
+      sortKey: 'disp_point',
+    });
+    const result = prepareRenderData(input);
+    // At 2025/03/05: TeamA disp_point=3 (section 1 only), TeamB disp_point=0, TeamC disp_point=0
+    expect(result.groupData.TeamA.disp_point).toBe(3);
+    expect(result.groupData.TeamB.disp_point).toBe(0);
+    expect(result.groupData.TeamC.disp_point).toBe(0);
+    expect(result.sortedTeams[0]).toBe('TeamA');
+  });
+
+  test('respects matchSortKey parameter', () => {
+    const bySection = prepareRenderData(makeTestInput({ matchSortKey: 'section_no' }));
+    const byDate = prepareRenderData(makeTestInput({ matchSortKey: 'match_date' }));
+    // Both should produce the same stats for this data (dates align with sections)
+    expect(bySection.groupData.TeamA.point).toBe(byDate.groupData.TeamA.point);
+    expect(bySection.sortedTeams).toEqual(byDate.sortedTeams);
+  });
+
+  test('works with empty team list', () => {
+    const input = makeTestInput({
+      groupData: {},
+      seasonInfo: makeSeasonInfo({ teamCount: 0, teams: [] }),
+    });
+    const result = prepareRenderData(input);
+    expect(result.groupData).toEqual({});
+    expect(result.sortedTeams).toEqual([]);
+  });
+});

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -23,6 +23,30 @@ import { renderBarGraph, findSliderIndex } from './graph/renderer';
 import { getHeightUnit, setFutureOpacity, setSpace, setScale } from './graph/css-utils';
 import { loadPrefs, savePrefs, clearPrefs } from './storage/local-storage';
 
+// ---- Application state ------------------------------------------------
+
+interface TeamMapCache {
+  key: string;
+  groupData: Record<string, TeamData>;
+  teamCount: number;
+  hasPk: boolean;
+}
+
+/** Mutable application state collected in one place. */
+interface AppState {
+  timestampMap: Record<string, string> | null;
+  teamMapCache: TeamMapCache | null;
+  currentMatchDates: string[];
+  heightUnit: number;
+}
+
+const state: AppState = {
+  timestampMap: null,
+  teamMapCache: null,
+  currentMatchDates: [],
+  heightUnit: 20,
+};
+
 const DEFAULT_COMPETITION = 'J1';
 
 // ---- DOM helpers -------------------------------------------------------
@@ -38,13 +62,11 @@ function setStatus(msg: string): void {
 
 // ---- Timestamp management ----------------------------------------------
 
-let timestampMap: Record<string, string> | null = null;
-
 async function loadTimestampMap(): Promise<Record<string, string>> {
-  if (timestampMap !== null) return timestampMap;
+  if (state.timestampMap !== null) return state.timestampMap;
   try {
     const res = await fetch('./csv/csv_timestamp.csv');
-    if (!res.ok) return (timestampMap = {});
+    if (!res.ok) return (state.timestampMap = {});
     const text = await res.text();
     const result = Papa.parse<{ file: string; date: string }>(text, {
       header: true,
@@ -56,9 +78,9 @@ async function loadTimestampMap(): Promise<Record<string, string>> {
       const d = new Date(row.date.replace(' ', 'T'));
       map[key] = isNaN(d.getTime()) ? row.date : formatTimestamp(d);
     }
-    return (timestampMap = map);
+    return (state.timestampMap = map);
   } catch {
-    return (timestampMap = {});
+    return (state.timestampMap = {});
   }
 }
 
@@ -70,8 +92,8 @@ function formatTimestamp(d: Date): string {
 
 function showTimestamp(csvFilename: string): void {
   const el = document.getElementById('data_timestamp');
-  if (!el || !timestampMap) return;
-  el.textContent = timestampMap[csvFilename] ?? '';
+  if (!el || !state.timestampMap) return;
+  el.textContent = state.timestampMap[csvFilename] ?? '';
 }
 
 // ---- URL parameter management ------------------------------------------
@@ -144,10 +166,8 @@ function populateSeasonPulldown(seasonMap: SeasonMap, competition: string): void
 
 // ---- Date slider management --------------------------------------------
 
-let currentMatchDates: string[] = [];
-
 function resetDateSlider(matchDates: string[], targetDate: string): void {
-  currentMatchDates = matchDates;
+  state.currentMatchDates = matchDates;
   const slider = document.getElementById('date_slider') as HTMLInputElement | null;
   if (!slider || matchDates.length === 0) return;
 
@@ -159,18 +179,6 @@ function resetDateSlider(matchDates: string[], targetDate: string): void {
   const postEl = document.getElementById('post_date_slider');
   if (postEl) postEl.textContent = matchDates[matchDates.length - 1] ?? '';
 }
-
-// ---- Cached TeamMap ----------------------------------------------------
-
-interface TeamMapCache {
-  key: string;
-  groupData: Record<string, TeamData>;
-  teamCount: number;
-  hasPk: boolean;
-}
-let teamMapCache: TeamMapCache | null = null;
-
-let heightUnit = 20;
 
 // ---- Core render pipeline ----------------------------------------------
 
@@ -208,7 +216,7 @@ function renderFromCache(
   if (boxCon) {
     const { html, matchDates } = renderBarGraph(
       groupData, sortedTeams, seasonInfo,
-      targetDate, disp, matchSortKey, bottomFirst, heightUnit, hasPk,
+      targetDate, disp, matchSortKey, bottomFirst, state.heightUnit, hasPk,
     );
     boxCon.innerHTML = html;
     const scaleSlider = document.getElementById('scale_slider') as HTMLInputElement | null;
@@ -248,8 +256,8 @@ function loadAndRender(seasonMap: SeasonMap): void {
 
   const filename = getCsvFilename(competition, season);
 
-  if (teamMapCache?.key === csvKey) {
-    renderFromCache(teamMapCache!, seasonMap, competition, season, targetDate, sortKey, matchSortKey, bottomFirst, disp);
+  if (state.teamMapCache?.key === csvKey) {
+    renderFromCache(state.teamMapCache, seasonMap, competition, season, targetDate, sortKey, matchSortKey, bottomFirst, disp);
     showTimestamp(filename);
     setStatus(`${leagueDisplay} ${season} (cached)`);
     return;
@@ -277,7 +285,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
       const hasPk = fields.includes('home_pk_score') || fields.includes('home_pk');
 
       const newCache = { key: csvKey, groupData, teamCount: seasonInfo.teamCount, hasPk };
-      teamMapCache = newCache;
+      state.teamMapCache = newCache;
 
       renderFromCache(newCache, seasonMap, competition, season, targetDate, sortKey, matchSortKey, bottomFirst, disp);
       showTimestamp(filename);
@@ -293,10 +301,18 @@ function loadAndRender(seasonMap: SeasonMap): void {
 
 async function main(): Promise<void> {
   void loadTimestampMap();
-  const seasonMap = await loadSeasonMap();
+
+  let seasonMap: SeasonMap;
+  try {
+    seasonMap = await loadSeasonMap();
+  } catch (err) {
+    setStatus('season_map.json の読み込みに失敗しました');
+    console.error('Failed to load season map:', err);
+    return;
+  }
 
   const unit = getHeightUnit();
-  if (unit > 0) heightUnit = unit;
+  if (unit > 0) state.heightUnit = unit;
 
   populateCompetitionPulldown(seasonMap);
 
@@ -349,16 +365,16 @@ async function main(): Promise<void> {
     dateInput.value = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
   }
 
-  // ---- Event listeners ----
+  // ---- Data-selection events ----
 
   competitionSel.addEventListener('change', () => {
-    teamMapCache = null;
+    state.teamMapCache = null;
     populateSeasonPulldown(seasonMap, competitionSel.value);
     loadAndRender(seasonMap);
   });
 
   document.getElementById('season_key')?.addEventListener('change', () => {
-    teamMapCache = null;
+    state.teamMapCache = null;
     loadAndRender(seasonMap);
   });
 
@@ -368,11 +384,12 @@ async function main(): Promise<void> {
     });
   }
 
-  // Date slider
+  // ---- Date slider events ----
+
   const dateSlider = document.getElementById('date_slider') as HTMLInputElement | null;
   if (dateSlider) {
     const updateFromSlider = (): void => {
-      const date = currentMatchDates[parseInt(dateSlider.value)];
+      const date = state.currentMatchDates[parseInt(dateSlider.value)];
       if (!date) return;
       (document.getElementById('target_date') as HTMLInputElement).value = date.replace(/\//g, '-');
       loadAndRender(seasonMap);
@@ -396,7 +413,8 @@ async function main(): Promise<void> {
     });
   }
 
-  // Appearance sliders
+  // ---- Appearance events ----
+
   const boxCon = document.getElementById('box_container') as HTMLElement;
 
   document.getElementById('scale_slider')?.addEventListener('input', (e) => {
@@ -417,7 +435,8 @@ async function main(): Promise<void> {
     savePrefs({ spaceColor: v });
   });
 
-  // Reset preferences
+  // ---- Reset ----
+
   document.getElementById('reset_prefs')?.addEventListener('click', () => {
     clearPrefs();
     location.assign(location.pathname);

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -15,8 +15,7 @@ import {
   loadSeasonMap, getCsvFilename, findCompetition, resolveSeasonInfo,
 } from './config/season-map';
 import { parseCsvResults } from './core/csv-parser';
-import { getSortedTeamList } from './core/sorter';
-import { calculateTeamStats } from './ranking/stats-calculator';
+import { prepareRenderData } from './core/prepare-render';
 import type { MatchSortKey } from './ranking/stats-calculator';
 import { makeRankData, makeRankTable } from './ranking/rank-table';
 import { renderBarGraph, findSliderIndex } from './graph/renderer';
@@ -199,16 +198,9 @@ function renderFromCache(
   if (!entry) return;
   const seasonInfo = resolveSeasonInfo(found.group, found.competition, entry);
 
-  const groupData: Record<string, TeamData> = {};
-  for (const [name, td] of Object.entries(cache.groupData)) {
-    groupData[name] = { ...td, df: [...td.df] };
-  }
-
-  for (const teamData of Object.values(groupData)) {
-    calculateTeamStats(teamData, targetDate, matchSortKey, seasonInfo.pointSystem);
-  }
-
-  const sortedTeams = getSortedTeamList(groupData, sortKey, seasonInfo.tiebreakOrder);
+  const { groupData, sortedTeams } = prepareRenderData({
+    groupData: cache.groupData, seasonInfo, targetDate, sortKey, matchSortKey,
+  });
 
   const { hasPk } = cache;
 

--- a/frontend/src/core/prepare-render.ts
+++ b/frontend/src/core/prepare-render.ts
@@ -1,0 +1,59 @@
+// Pure data preparation for the render pipeline.
+//
+// Extracts the data-transformation portion of renderFromCache(),
+// making it testable without any DOM dependency.
+
+import type { TeamData } from '../types/match';
+import type { SeasonInfo } from '../types/season';
+import { calculateTeamStats } from '../ranking/stats-calculator';
+import type { MatchSortKey } from '../ranking/stats-calculator';
+import { getSortedTeamList } from './sorter';
+
+/** Input parameters for prepareRenderData. */
+export interface PrepareRenderInput {
+  /** Raw group data from the CSV cache (will be deep-copied, not mutated). */
+  groupData: Record<string, TeamData>;
+  /** Fully resolved season info (from resolveSeasonInfo). */
+  seasonInfo: SeasonInfo;
+  /** Display cutoff date in 'YYYY/MM/DD' format. */
+  targetDate: string;
+  /** Team sort key (e.g. 'point', 'disp_avlbl_pt'). */
+  sortKey: string;
+  /** Match sort axis: 'section_no' or 'match_date'. */
+  matchSortKey: MatchSortKey;
+}
+
+/** Output of prepareRenderData, consumed by the rendering layer. */
+export interface PrepareRenderResult {
+  /** Deep-copied group data with stats calculated (mutated copy, not the original). */
+  groupData: Record<string, TeamData>;
+  /** Team names sorted by the requested sort key. */
+  sortedTeams: string[];
+}
+
+/**
+ * Prepares render-ready data from cached CSV data and season configuration.
+ *
+ * This is a pure function (no DOM access). It:
+ * 1. Deep-copies groupData so the original cache is not mutated.
+ * 2. Calculates team statistics (points, goals, etc.) for the given target date.
+ * 3. Sorts teams by the requested sort key with configured tiebreakers.
+ */
+export function prepareRenderData(input: PrepareRenderInput): PrepareRenderResult {
+  const { groupData: rawGroupData, seasonInfo, targetDate, sortKey, matchSortKey } = input;
+
+  // Deep copy: clone each TeamData and its df array so stats calculation
+  // does not mutate the cached original.
+  const groupData: Record<string, TeamData> = {};
+  for (const [name, td] of Object.entries(rawGroupData)) {
+    groupData[name] = { ...td, df: [...td.df] };
+  }
+
+  for (const teamData of Object.values(groupData)) {
+    calculateTeamStats(teamData, targetDate, matchSortKey, seasonInfo.pointSystem);
+  }
+
+  const sortedTeams = getSortedTeamList(groupData, sortKey, seasonInfo.tiebreakOrder);
+
+  return { groupData, sortedTeams };
+}


### PR DESCRIPTION
## Summary

Fixes #83

- **P5-1**: 散在していた4つのモジュール変数 (`timestampMap`, `teamMapCache`, `currentMatchDates`, `heightUnit`) を `AppState` / `state` オブジェクトに集約。`loadSeasonMap()` 失敗時のエラーハンドリング追加。イベントハンドラーをセクション分類
- **P5-2**: `renderFromCache()` のデータ準備ロジック (deep copy → stats計算 → ソート) を `core/prepare-render.ts` の純粋関数 `prepareRenderData()` に抽出。テスト6件追加

## Changes

### Commit 1 (P5-1): State consolidation
- `app.ts`: `AppState` interface + `state` object に集約、`loadSeasonMap()` try/catch 追加、イベントハンドラー分類コメント

### Commit 2 (P5-2): Extract prepareRenderData()
- New `core/prepare-render.ts`: `PrepareRenderInput`, `PrepareRenderResult`, `prepareRenderData()`
- New `__tests__/core/prepare-render.test.ts`: 6 test cases
- `app.ts`: `renderFromCache()` 簡素化、不要 import 削除

### 設計判断
- `prepareRenderData()` は解決済み `SeasonInfo` を直接受け取る (テスタビリティ重視)
- `seasonMap` は AppState に含めない (immutable な設定情報)
- イベントハンドラーはコメント分類のみ (移動は M3 まで先送り)

## Test plan

- [x] `npx vitest run` — 274 tests / 12 files all pass
- [x] `npm run typecheck` — clean
- [x] `npm run build` — success
- [x] ブラウザ UI テスト: 初期表示、大会/シーズン切替、日時スライダー、ソート4種、外観スライダー、localStorage 復元、URL パラメータ — デグレなし確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)