### PR TITLE
Post-TS cleanup: HTML, CSS, TypeScript, Python

### DIFF
--- a/docs/j_points.css
+++ b/docs/j_points.css
@@ -61,13 +61,6 @@ p {
 .live {
   border: 5px dashed red;
 }
-/*
-.live_border {
-  background-color: white;
-  border-top: 5px dashed red;
-}
-*/
-
 .promoted {
   background-color: #CFF3C0;
 }
@@ -82,15 +75,8 @@ p {
 }
 
 #box_container {
-  display:-webkit-box;
-  display:-ms-flexbox;
-  display:flex;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-  -ms-flex-direction: row;
+  display: flex;
   flex-direction: row;
-  -webkit-box-align: end;
-  -ms-flex-align: end;
   align-items: flex-end;
   transform-origin: left bottom;
   margin-bottom: 25px;

--- a/docs/j_points.css
+++ b/docs/j_points.css
@@ -110,8 +110,42 @@ p {
   font-weight: bold;
 }
 
+/* --- Controls layout (TS template) --- */
+#controls {
+  margin: 1em;
+  display: flex;
+  gap: 1.5em;
+  flex-wrap: wrap;
+  align-items: center;
+}
+#date_slider_section {
+  margin: 0.5em 1em;
+  display: flex;
+  gap: 0.5em;
+  flex-wrap: wrap;
+  align-items: center;
+}
 #date_slider {
   width: 60%;
+}
+#appearance_controls {
+  margin: 0.5em 1em;
+  display: flex;
+  gap: 1.5em;
+  flex-wrap: wrap;
+  align-items: center;
+}
+#status_bar {
+  margin: 0.5em 1em;
+  font-size: 0.9em;
+  color: #666;
+}
+#status_bar .timestamp-label {
+  color: #999;
+  margin-left: 1em;
+}
+#ranktable_section {
+  margin: 1em;
 }
 #date_slider_up, #date_slider_down {
   background-color: black;

--- a/frontend/src/__tests__/core/date-utils.test.ts
+++ b/frontend/src/__tests__/core/date-utils.test.ts
@@ -1,27 +1,8 @@
 import { describe, test, expect } from 'vitest';
-import { dgt, dateFormat, timeFormat, dateOnly } from '../../core/date-utils';
-
-describe('dgt', () => {
-  test('pads single digit to 2 places', () => {
-    expect(dgt(5, 2)).toBe('05');
-    expect(dgt(0, 2)).toBe('00');
-    expect(dgt(9, 2)).toBe('09');
-  });
-
-  test('no padding needed', () => {
-    expect(dgt(12, 2)).toBe('12');
-    expect(dgt(31, 2)).toBe('31');
-  });
-
-  test('pads to 4 places', () => {
-    expect(dgt(25, 4)).toBe('0025');
-    expect(dgt(2025, 4)).toBe('2025');
-  });
-});
+import { dateFormat, timeFormat, dateOnly } from '../../core/date-utils';
 
 describe('dateFormat', () => {
-  test('formats a Date object as YYYY/MM/DD', () => {
-    // Use UTC offset-safe construction: new Date(year, month-1, day)
+  test('formats a Date object as YYYY/MM/DD by default', () => {
     const d = new Date(2025, 2, 15); // March 15, 2025
     expect(dateFormat(d)).toBe('2025/03/15');
   });
@@ -31,9 +12,14 @@ describe('dateFormat', () => {
     expect(dateFormat(d)).toBe('2025/01/05');
   });
 
-  test('passes a string through unchanged', () => {
+  test('formats with hyphen separator for HTML date input', () => {
+    const d = new Date(2025, 2, 15);
+    expect(dateFormat(d, '-')).toBe('2025-03-15');
+  });
+
+  test('passes a string through unchanged regardless of separator', () => {
     expect(dateFormat('2025/03/15')).toBe('2025/03/15');
-    expect(dateFormat('already-formatted')).toBe('already-formatted');
+    expect(dateFormat('already-formatted', '-')).toBe('already-formatted');
   });
 });
 

--- a/frontend/src/__tests__/graph/renderer.test.ts
+++ b/frontend/src/__tests__/graph/renderer.test.ts
@@ -177,7 +177,7 @@ describe('renderBarGraph', () => {
   test('matchDates always starts with sentinel 1970/01/01 for "開幕前" slider position', () => {
     const groupData = buildGroupData();
     const { matchDates } = renderBarGraph(
-      groupData, ['TeamA', 'TeamB', 'TeamC'], info, TARGET, false, 'section_no', false, 20,
+      groupData, ['TeamA', 'TeamB', 'TeamC'], info, TARGET, false, false, 20,
     );
     expect(matchDates[0]).toBe('1970/01/01');
   });
@@ -185,7 +185,7 @@ describe('renderBarGraph', () => {
   test('matchDates contains sentinel + actual match dates in sorted order', () => {
     const groupData = buildGroupData();
     const { matchDates } = renderBarGraph(
-      groupData, ['TeamA', 'TeamB', 'TeamC'], info, TARGET, false, 'section_no', false, 20,
+      groupData, ['TeamA', 'TeamB', 'TeamC'], info, TARGET, false, false, 20,
     );
     expect(matchDates).toEqual(['1970/01/01', '2025/03/01', '2025/04/01']);
   });
@@ -199,7 +199,7 @@ describe('renderBarGraph', () => {
       calculateTeamStats(td, TARGET, 'section_no');
     }
     const { matchDates } = renderBarGraph(
-      groupData, ['TeamA', 'TeamB'], info, TARGET, false, 'section_no', false, 20,
+      groupData, ['TeamA', 'TeamB'], info, TARGET, false, false, 20,
     );
     expect(matchDates).toEqual(['1970/01/01']);
   });
@@ -208,7 +208,7 @@ describe('renderBarGraph', () => {
     const groupData = buildGroupData();
     const sortedTeams = ['TeamA', 'TeamB', 'TeamC'];
     const { html } = renderBarGraph(
-      groupData, sortedTeams, info, TARGET, false, 'section_no', false, 20,
+      groupData, sortedTeams, info, TARGET, false, false, 20,
     );
     expect(html).toContain('id="TeamA_column"');
     expect(html).toContain('id="TeamB_column"');
@@ -218,7 +218,7 @@ describe('renderBarGraph', () => {
   test('html starts and ends with point_column', () => {
     const groupData = buildGroupData();
     const { html } = renderBarGraph(
-      groupData, ['TeamA', 'TeamB', 'TeamC'], info, TARGET, false, 'section_no', false, 20,
+      groupData, ['TeamA', 'TeamB', 'TeamC'], info, TARGET, false, false, 20,
     );
     const firstPt = html.indexOf('point_column');
     const lastPt = html.lastIndexOf('point_column');
@@ -231,7 +231,7 @@ describe('renderBarGraph', () => {
     // indices 1 and 2 get extra point columns
     const groupData = buildGroupData();
     const { html } = renderBarGraph(
-      groupData, ['TeamA', 'TeamB', 'TeamC'], info, TARGET, false, 'section_no', false, 20,
+      groupData, ['TeamA', 'TeamB', 'TeamC'], info, TARGET, false, false, 20,
     );
     // Count point_column occurrences: start + insertions + end ≥ 3
     const count = (html.match(/point_column/g) ?? []).length;

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -208,7 +208,7 @@ function renderFromCache(
   if (boxCon) {
     const { html, matchDates } = renderBarGraph(
       groupData, sortedTeams, seasonInfo,
-      targetDate, disp, matchSortKey, bottomFirst, state.heightUnit, hasPk,
+      targetDate, disp, bottomFirst, state.heightUnit, hasPk,
     );
     boxCon.innerHTML = html;
     const scaleSlider = document.getElementById('scale_slider') as HTMLInputElement | null;

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -15,7 +15,7 @@ import {
   loadSeasonMap, getCsvFilename, findCompetition, resolveSeasonInfo,
 } from './config/season-map';
 import { parseCsvResults } from './core/csv-parser';
-import { dateInputFormat } from './core/date-utils';
+import { dateFormat } from './core/date-utils';
 import { prepareRenderData } from './core/prepare-render';
 import type { MatchSortKey } from './ranking/stats-calculator';
 import { makeRankData, makeRankTable } from './ranking/rank-table';
@@ -354,7 +354,7 @@ async function main(): Promise<void> {
 
   // Restore target date from prefs; fall back to today.
   const dateInput = document.getElementById('target_date') as HTMLInputElement;
-  dateInput.value = prefs.targetDate ?? dateInputFormat(new Date());
+  dateInput.value = prefs.targetDate ?? dateFormat(new Date(), '-');
 
   // ---- Data-selection events ----
 
@@ -397,7 +397,7 @@ async function main(): Promise<void> {
       updateFromSlider();
     });
     document.getElementById('reset_date_slider')?.addEventListener('click', () => {
-      (document.getElementById('target_date') as HTMLInputElement).value = dateInputFormat(new Date());
+      (document.getElementById('target_date') as HTMLInputElement).value = dateFormat(new Date(), '-');
       loadAndRender(seasonMap);
     });
   }

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -381,7 +381,7 @@ async function main(): Promise<void> {
   const dateSlider = document.getElementById('date_slider') as HTMLInputElement | null;
   if (dateSlider) {
     const updateFromSlider = (): void => {
-      const date = state.currentMatchDates[parseInt(dateSlider.value)];
+      const date = state.currentMatchDates[parseInt(dateSlider.value, 10)];
       if (!date) return;
       (document.getElementById('target_date') as HTMLInputElement).value = date.replace(/\//g, '-');
       loadAndRender(seasonMap);
@@ -390,11 +390,11 @@ async function main(): Promise<void> {
     dateSlider.addEventListener('change', updateFromSlider);
 
     document.getElementById('date_slider_down')?.addEventListener('click', () => {
-      dateSlider.value = String(Math.max(0, parseInt(dateSlider.value) - 1));
+      dateSlider.value = String(Math.max(0, parseInt(dateSlider.value, 10) - 1));
       updateFromSlider();
     });
     document.getElementById('date_slider_up')?.addEventListener('click', () => {
-      dateSlider.value = String(Math.min(parseInt(dateSlider.max), parseInt(dateSlider.value) + 1));
+      dateSlider.value = String(Math.min(parseInt(dateSlider.max, 10), parseInt(dateSlider.value, 10) + 1));
       updateFromSlider();
     });
     document.getElementById('reset_date_slider')?.addEventListener('click', () => {

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -11,7 +11,7 @@ import type {
  * @param season      - Season name (e.g. '2025', '2026East')
  */
 export function getCsvFilename(competition: string, season: string): string {
-  return 'csv/' + season + '_allmatch_result-' + competition + '.csv';
+  return `csv/${season}_allmatch_result-${competition}.csv`;
 }
 
 /**

--- a/frontend/src/core/csv-parser.ts
+++ b/frontend/src/core/csv-parser.ts
@@ -87,10 +87,10 @@ export function parseCsvResults(
     const matchDate = new Date(match.match_date);
     if (!isNaN(matchDate.getTime())) matchDateStr = dateFormat(matchDate);
 
-    const homePk = match.home_pk_score ? parseInt(match.home_pk_score) : null;
-    const awayPk = match.away_pk_score ? parseInt(match.away_pk_score) : null;
-    const homeScoreEx = match.home_score_ex ? parseInt(match.home_score_ex) : null;
-    const awayScoreEx = match.away_score_ex ? parseInt(match.away_score_ex) : null;
+    const homePk = match.home_pk_score ? parseInt(match.home_pk_score, 10) : null;
+    const awayPk = match.away_pk_score ? parseInt(match.away_pk_score, 10) : null;
+    const homeScoreEx = match.home_score_ex ? parseInt(match.home_score_ex, 10) : null;
+    const awayScoreEx = match.away_score_ex ? parseInt(match.away_score_ex, 10) : null;
     const hasResult = Boolean(match.home_goal && match.away_goal);
     const status = makeStatusAttr(match);
     const live = makeLiveAttr(match);

--- a/frontend/src/core/date-utils.ts
+++ b/frontend/src/core/date-utils.ts
@@ -1,18 +1,17 @@
 // Utility functions for date and time formatting.
 
-/** Zero-pads number `m` to `n` digits. */
-export function dgt(m: number, n: number): string {
-  const longstr = '0000' + m;
-  return longstr.substring(longstr.length - n);
+/** Zero-pads a number to 2 digits. */
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
 }
 
 /**
- * Formats a Date object as "YYYY/MM/DD".
+ * Formats a Date as "YYYY/MM/DD" (default) or "YYYY-MM-DD" (sep='-').
  * If a string is given, returns it as-is (already formatted).
  */
-export function dateFormat(date: Date | string): string {
+export function dateFormat(date: Date | string, sep = '/'): string {
   if (typeof date === 'string') return date;
-  return [date.getFullYear(), dgt(date.getMonth() + 1, 2), dgt(date.getDate(), 2)].join('/');
+  return `${date.getFullYear()}${sep}${pad2(date.getMonth() + 1)}${sep}${pad2(date.getDate())}`;
 }
 
 /**
@@ -20,7 +19,7 @@ export function dateFormat(date: Date | string): string {
  */
 export function timeFormat(date: Date | string): string {
   if (typeof date === 'string') return date.replace(/(\d\d:\d\d):\d\d/, '$1');
-  return [dgt(date.getHours(), 2), dgt(date.getMinutes(), 2)].join(':');
+  return `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
 }
 
 /**
@@ -29,11 +28,4 @@ export function timeFormat(date: Date | string): string {
  */
 export function dateOnly(dateStr: string): string {
   return dateStr.replace(/^\d{4}\//, '');
-}
-
-/**
- * Formats a Date as "YYYY-MM-DD" for HTML <input type="date"> elements.
- */
-export function dateInputFormat(d: Date): string {
-  return [d.getFullYear(), dgt(d.getMonth() + 1, 2), dgt(d.getDate(), 2)].join('-');
 }

--- a/frontend/src/core/date-utils.ts
+++ b/frontend/src/core/date-utils.ts
@@ -30,3 +30,10 @@ export function timeFormat(date: Date | string): string {
 export function dateOnly(dateStr: string): string {
   return dateStr.replace(/^\d{4}\//, '');
 }
+
+/**
+ * Formats a Date as "YYYY-MM-DD" for HTML <input type="date"> elements.
+ */
+export function dateInputFormat(d: Date): string {
+  return [d.getFullYear(), dgt(d.getMonth() + 1, 2), dgt(d.getDate(), 2)].join('-');
+}

--- a/frontend/src/core/sorter.ts
+++ b/frontend/src/core/sorter.ts
@@ -121,8 +121,8 @@ function computeH2H(
 
       const entry = result.get(teamName)!;
       entry.h2hPoints += m.point;
-      const gGet = parseInt(m.goal_get) || 0;
-      const gLose = parseInt(m.goal_lose) || 0;
+      const gGet = parseInt(m.goal_get, 10) || 0;
+      const gLose = parseInt(m.goal_lose, 10) || 0;
       entry.h2hGoalDiff += gGet - gLose;
     }
   }

--- a/frontend/src/graph/bar-column.ts
+++ b/frontend/src/graph/bar-column.ts
@@ -81,47 +81,48 @@ export function makeHtmlColumn(
     const matchDate = row.match_date === '' ? '未定' : row.match_date;
     if (matchDate !== '未定') matchDateSet.add(matchDate);
 
+    const statusSuffix = row.status ? `<br/>${row.status}` : '';
+
     if (!row.has_result || matchDate > targetDate) {
       // Unplayed or completed-after-cutoff: future (ghost) styling
       graph.push(
-        '<div class="' + futureClass + ' box"><div class="future bg ' + teamName + '"></div><p class="tooltip">'
+        `<div class="${futureClass} box"><div class="future bg ${teamName}"></div><p class="tooltip">`
         + makeWinContent(row, matchDate)
-        + '<span class="tooltiptext ' + teamName + '">(' + row.section_no + ') ' + timeFormat(row.start_time)
-        + (row.status ? '<br/>' + row.status : '') + '</span></p></div>\n',
+        + `<span class="tooltiptext ${teamName}">(${row.section_no}) ${timeFormat(row.start_time)}`
+        + `${statusSuffix}</span></p></div>\n`,
       );
     } else {
       const cls = classifyResult(row.point, row.pk_get, pointSystem);
+      const liveCls = row.live ? ' live' : '';
       if (cls === 'win') {
         const heightCls = boxHeightClass(winPt);
+        const stadiumLine = heightCls !== 'tall' ? `<br/>${row.stadium}` : '';
         graph.push(
-          '<div class="' + heightCls + ' box' + (row.live ? ' live' : '') + '"><p class="tooltip '
-          + teamName + '">' + makeWinContent(row, matchDate)
-          + '<span class="tooltiptext halfW ' + teamName + '">(' + row.section_no + ') ' + timeFormat(row.start_time)
-          + (heightCls !== 'tall' ? '<br/>' + row.stadium : '')
-          + (row.status ? '<br/>' + row.status : '') + '</span></p></div>\n',
+          `<div class="${heightCls} box${liveCls}"><p class="tooltip ${teamName}">`
+          + makeWinContent(row, matchDate)
+          + `<span class="tooltiptext halfW ${teamName}">(${row.section_no}) ${timeFormat(row.start_time)}`
+          + `${stadiumLine}${statusSuffix}</span></p></div>\n`,
         );
       } else if (cls === 'pk_win') {
         graph.push(
-          '<div class="medium box' + (row.live ? ' live' : '') + '"><p class="tooltip '
-          + teamName + '">' + makePkWinContent(row, matchDate)
-          + '<span class="tooltiptext halfW ' + teamName + '">(' + row.section_no + ') ' + timeFormat(row.start_time)
-          + '<br/>' + row.stadium
-          + (row.status ? '<br/>' + row.status : '') + '</span></p></div>\n',
+          `<div class="medium box${liveCls}"><p class="tooltip ${teamName}">`
+          + makePkWinContent(row, matchDate)
+          + `<span class="tooltiptext halfW ${teamName}">(${row.section_no}) ${timeFormat(row.start_time)}`
+          + `<br/>${row.stadium}${statusSuffix}</span></p></div>\n`,
         );
       } else if (cls === 'draw' || cls === 'pk_loss') {
         graph.push(
-          '<div class="short box' + (row.live ? ' live' : '') + '"><p class="tooltip ' + teamName + '">'
+          `<div class="short box${liveCls}"><p class="tooltip ${teamName}">`
           + makeDrawContent(row, matchDate)
-          + '<span class="tooltiptext fullW ' + teamName + '">'
+          + `<span class="tooltiptext fullW ${teamName}">`
           + makeFullContent(row, matchDate)
-          + (row.status ? '<br/>' + row.status : '') + '</span></p></div>',
+          + `${statusSuffix}</span></p></div>`,
         );
       } else {
         // Loss (point === 0): no box; goes to loseBox for the stats tooltip
         let loseContent = makeFullContent(row, matchDate);
         if (row.live) {
-          loseContent = '<div class="live">' + loseContent
-            + (row.status ? '<br/>' + row.status : '') + '</div>';
+          loseContent = `<div class="live">${loseContent}${statusSuffix}</div>`;
         }
         loseBox.push(loseContent);
       }

--- a/frontend/src/graph/css-utils.ts
+++ b/frontend/src/graph/css-utils.ts
@@ -82,10 +82,10 @@ export function setSpace(value: string, updateColorPicker = true): void {
  * No localStorage writes (Phase 3b).
  */
 export function setScale(boxCon: HTMLElement, value: string, updateSlider = true): void {
-  boxCon.style.transform = 'scale(' + value + ')';
+  boxCon.style.transform = `scale(${value})`;
   const pointCol = boxCon.querySelector('.point_column');
   if (pointCol) {
-    boxCon.style.height = String((pointCol as HTMLElement).clientHeight * parseFloat(value)) + 'px';
+    boxCon.style.height = `${(pointCol as HTMLElement).clientHeight * parseFloat(value)}px`;
   }
   if (updateSlider) {
     const slider = document.getElementById('scale_slider') as HTMLInputElement | null;

--- a/frontend/src/graph/css-utils.ts
+++ b/frontend/src/graph/css-utils.ts
@@ -37,7 +37,7 @@ export function getCssRule(selector: string): CSSStyleRule | undefined {
 export function getHeightUnit(): number {
   const rule = getCssRule('.short');
   if (!rule) return 0;
-  return parseInt(rule.style.height) || 0;
+  return parseInt(rule.style.height, 10) || 0;
 }
 
 /**

--- a/frontend/src/graph/renderer.ts
+++ b/frontend/src/graph/renderer.ts
@@ -5,7 +5,6 @@
 
 import type { TeamData } from '../types/match';
 import type { SeasonInfo } from '../types/season';
-import type { MatchSortKey } from '../ranking/stats-calculator';
 import { makeHtmlColumn } from './bar-column';
 import type { ColumnResult } from './bar-column';
 import { getRankClass, joinLoseBox } from './tooltip';
@@ -106,7 +105,6 @@ export function appendSpaceCols(
  * @param seasonInfo   Season configuration.
  * @param targetDate   Display cutoff date 'YYYY/MM/DD'.
  * @param disp         true → use disp_avlbl_pt for column heights.
- * @param matchSortKey 'section_no' or 'match_date' (used by makeHtmlColumn internally).
  * @param bottomFirst  true → reverse graph order so older/earlier matches appear at bottom.
  * @param heightUnit   CSS height in px for one point box (from getHeightUnit()).
  */
@@ -116,7 +114,6 @@ export function renderBarGraph(
   seasonInfo: SeasonInfo,
   targetDate: string,
   disp: boolean,
-  _matchSortKey: MatchSortKey,
   bottomFirst: boolean,
   heightUnit: number,
   hasPk = false,

--- a/frontend/src/graph/renderer.ts
+++ b/frontend/src/graph/renderer.ts
@@ -42,11 +42,11 @@ export function makeInsertColumns(seasonInfo: SeasonInfo): number[] {
  */
 export function makePointColumn(maxAvblPt: number, bottomFirst: boolean): string {
   const boxList = Array.from({ length: maxAvblPt }, (_, i) => i + 1)
-    .map(i => '<div class="point box">' + i + '</div>');
+    .map(i => `<div class="point box">${i}</div>`);
   if (bottomFirst) boxList.reverse();
-  return '<div class="point_column"><div class="point box">順位</div><div class="point box">勝点</div>'
+  return `<div class="point_column"><div class="point box">順位</div><div class="point box">勝点</div>`
     + boxList.join('')
-    + '<div class="point box">勝点</div><div class="point box">順位</div></div>\n\n';
+    + `<div class="point box">勝点</div><div class="point box">順位</div></div>\n\n`;
 }
 
 /**
@@ -73,10 +73,7 @@ export function appendSpaceCols(
 
   const spaceCols = maxAvblPt - col.avlbl_pt;
   if (spaceCols > 0) {
-    graph.push(
-      '<div class="space box" style="height:' + heightUnit * spaceCols + 'px">('
-      + spaceCols + ')</div>',
-    );
+    graph.push(`<div class="space box" style="height:${heightUnit * spaceCols}px">(${spaceCols})</div>`);
   }
 
   if (bottomFirst) {
@@ -85,16 +82,12 @@ export function appendSpaceCols(
   }
 
   const rankClass = getRankClass(rank, seasonInfo);
-  const rankCell = '<div class="short box ' + rankClass + '">' + rank + '</div>';
-  const teamName = '<div class="short box tooltip ' + col.teamName + '">' + col.teamName
-    + '<span class=" tooltiptext fullW ' + col.teamName + '">'
-    + '成績情報:<hr/>' + col.stats
-    + '<hr/>敗戦記録:<hr/>'
-    + joinLoseBox(loseBox) + '</span></div>\n';
+  const rankCell = `<div class="short box ${rankClass}">${rank}</div>`;
+  const teamName = `<div class="short box tooltip ${col.teamName}">${col.teamName}`
+    + `<span class=" tooltiptext fullW ${col.teamName}">`
+    + `成績情報:<hr/>${col.stats}<hr/>敗戦記録:<hr/>${joinLoseBox(loseBox)}</span></div>\n`;
 
-  return '<div id="' + col.teamName + '_column">'
-    + rankCell + teamName + graph.join('') + teamName + rankCell
-    + '</div>\n\n';
+  return `<div id="${col.teamName}_column">${rankCell}${teamName}${graph.join('')}${teamName}${rankCell}</div>\n\n`;
 }
 
 /**

--- a/frontend/src/graph/tooltip.ts
+++ b/frontend/src/graph/tooltip.ts
@@ -7,28 +7,22 @@ import { dateOnly, timeFormat } from '../core/date-utils';
 
 /** Tooltip body for a 3-pt win: MM/DD + opponent + score + stadium. */
 export function makeWinContent(row: TeamMatch, matchDate: string): string {
-  return dateOnly(matchDate) + ' ' + row.opponent + '<br/>'
-    + row.goal_get + '-' + row.goal_lose
-    + '<br/>' + row.stadium;
+  return `${dateOnly(matchDate)} ${row.opponent}<br/>${row.goal_get}-${row.goal_lose}<br/>${row.stadium}`;
 }
 
 /** Tooltip body for a 2-pt PK win: same as win but includes PK scores in parentheses. */
 export function makePkWinContent(row: TeamMatch, matchDate: string): string {
-  return dateOnly(matchDate) + ' ' + row.opponent + '<br/>'
-    + row.goal_get + '-' + row.goal_lose + ' (' + row.pk_get + '-' + row.pk_lose + ')'
-    + '<br/>' + row.stadium;
+  return `${dateOnly(matchDate)} ${row.opponent}<br/>${row.goal_get}-${row.goal_lose} (${row.pk_get}-${row.pk_lose})<br/>${row.stadium}`;
 }
 
 /** Tooltip body for a 1-pt draw or PK loss: minimal—MM/DD and opponent only. */
 export function makeDrawContent(row: TeamMatch, matchDate: string): string {
-  return dateOnly(matchDate) + ' ' + row.opponent;
+  return `${dateOnly(matchDate)} ${row.opponent}`;
 }
 
 /** Full match details for draw/loss tooltips: section number, time, date, opponent, score, stadium. */
 export function makeFullContent(row: TeamMatch, matchDate: string): string {
-  return '(' + row.section_no + ') ' + timeFormat(row.start_time) + '<br/>'
-    + dateOnly(matchDate) + ' ' + row.opponent + '<br/>'
-    + row.goal_get + '-' + row.goal_lose + ' ' + row.stadium;
+  return `(${row.section_no}) ${timeFormat(row.start_time)}<br/>${dateOnly(matchDate)} ${row.opponent}<br/>${row.goal_get}-${row.goal_lose} ${row.stadium}`;
 }
 
 /**
@@ -41,13 +35,11 @@ export function makeTeamStats(teamData: TeamData, disp: boolean, hasPk = false):
   const label = disp ? '表示時の状態' : '最新の状態';
   const p = (key: string): number =>
     (teamData as unknown as Record<string, number>)[pre + key] ?? 0;
-  const pkLine = hasPk ? p('pk_win') + 'PK勝 ' + p('pk_loss') + 'PK負 ' : '';
-  return label + '<br/>'
-    + p('win') + '勝 ' + pkLine + p('draw') + '分 '
-    + p('lose') + '敗<br/>'
-    + '勝点' + p('point') + ', 最大' + p('avlbl_pt') + '<br/>'
-    + p('goal_get') + '得点, ' + (p('goal_get') - p('goal_diff')) + '失点<br/>'
-    + '得失点差: ' + p('goal_diff');
+  const pkLine = hasPk ? `${p('pk_win')}PK勝 ${p('pk_loss')}PK負 ` : '';
+  return `${label}<br/>${p('win')}勝 ${pkLine}${p('draw')}分 ${p('lose')}敗<br/>`
+    + `勝点${p('point')}, 最大${p('avlbl_pt')}<br/>`
+    + `${p('goal_get')}得点, ${p('goal_get') - p('goal_diff')}失点<br/>`
+    + `得失点差: ${p('goal_diff')}`;
 }
 
 /** Joins loss-match content strings with <hr/> dividers. */

--- a/frontend/src/j_points.html
+++ b/frontend/src/j_points.html
@@ -2,23 +2,27 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>J League Matches Bar Graph</title>
   <meta property="og:title" content="JLeague_Matches-Bar_Graph" />
   <meta property="og:description" content="Jリーグの勝ち点 (取得済み & 今後取り得る) を各チームの試合情報と共に積み上げたグラフを自動生成" />
   <meta property="og:image" content="https://mokekuma-git.github.io/JLeague_Matches-Bar_Graph/android-chrome-256x256.png" />
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@Moke_kuma" />
-  <link rel="shortcut icon" href="favicon.ico">
+  <link rel="icon" href="favicon.ico">
   <link rel="apple-touch-icon" href="apple-touch-icon.png">
   <link rel="icon" type="image/png" href="android-chrome-192x192.png">
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@riversun/sortable-table/lib/sortable-table.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@riversun/sortable-table@1.1.2/lib/sortable-table.js"
+          integrity="sha384-LWX4/EsjUytgODwrauhUKkKTx/K3AFLgbEh/Mhr4YZABcgO0N9yZeK7uBWuLWYPn"
+          crossorigin="anonymous"></script>
   <link rel="stylesheet" href="j_points.css">
   <link rel="stylesheet" href="team_style.css">
   <link rel="stylesheet" href="national_team_style.css">
 </head>
 <body>
+<main>
 
-<section id="controls" style="margin:1em; display:flex; gap:1.5em; flex-wrap:wrap; align-items:center;">
+<section id="controls">
   <label>
     大会:
     <select id="competition_key">
@@ -51,10 +55,10 @@
 </section>
 
 <!-- Date slider -->
-<section id="date_slider_section" style="margin:0.5em 1em; display:flex; gap:0.5em; align-items:center; flex-wrap:wrap;">
+<section id="date_slider_section">
   <span id="pre_date_slider">開幕前</span>
   <button id="date_slider_down">＜</button>
-  <input type="range" id="date_slider" min="0" max="0" step="1" value="0" style="width:300px;"/>
+  <input type="range" id="date_slider" min="0" max="0" step="1" value="0"/>
   <button id="date_slider_up">＞</button>
   <span id="post_date_slider"></span>
   <button id="reset_date_slider">最新にリセット</button>
@@ -65,7 +69,7 @@
 </section>
 
 <!-- Appearance controls -->
-<section id="appearance_controls" style="margin:0.5em 1em; display:flex; gap:1.5em; align-items:center; flex-wrap:wrap;">
+<section id="appearance_controls">
   <label>
     グラフ縮小:
     <input type="range" id="scale_slider" min="0.1" max="1" step="0.1" value="1"/>
@@ -84,16 +88,13 @@
 </section>
 
 <!-- Status message and data timestamp -->
-<div style="margin:0.5em 1em; font-size:0.9em; color:#666;">
+<div id="status_bar">
   <span id="status_msg"></span>
-  <span style="color:#999; margin-left:1em;">データ取得時刻: <span id="data_timestamp"></span></span>
+  <span class="timestamp-label">データ取得時刻: <span id="data_timestamp"></span></span>
 </div>
 
 <!-- Bar graph container -->
 <div id="box_container"></div>
-
-<!-- Hidden .short div for HEIGHT_UNIT calculation -->
-<div class="short" style="display:none;"></div>
 
 <hr/>
 データ参照元: <a href="https://www.jleague.jp/match/">Jリーグ公式サイト: 日程結果</a><br/>
@@ -101,7 +102,7 @@
 <a href="https://github.com/mokekuma-git/JLeague_Matches-Bar_Graph">Github公開場所</a>
 <hr/>
 
-<section id="ranktable_section" style="margin:1em;">
+<section id="ranktable_section">
   <div class="sortable-table">
     <table id="ranktable" class="ranktable">
       <thead></thead>
@@ -115,6 +116,7 @@
     <li>ACL: 天皇杯優勝チームがACL参加時の繰り上がり権利獲得は含まない (「なし」と表示)</li>
   </ul>
 </section>
+</main>
 
 <script type="module" src="./app.ts"></script>
 </body>

--- a/frontend/src/ranking/stats-calculator.ts
+++ b/frontend/src/ranking/stats-calculator.ts
@@ -29,7 +29,7 @@ export function sortTeamMatches(
     if (prioA !== prioB) return prioA - prioB;
     const vA = a[matchSortKey];
     const vB = b[matchSortKey];
-    if (matchSortKey === 'section_no') return parseInt(vA) - parseInt(vB);
+    if (matchSortKey === 'section_no') return parseInt(vA, 10) - parseInt(vB, 10);
     if (!/\d\d\/\d\d$/.test(vA)) {
       if (!/\d\d\/\d\d$/.test(vB)) return 0;
       return 1;
@@ -107,8 +107,8 @@ export function calculateTeamStats(
       teamData.all_game += 1;
       const cls = classifyResult(row.point, row.pk_get, pointSystem);
       (teamData[cls] as number) += 1;
-      teamData.goal_diff += parseInt(row.goal_get) - parseInt(row.goal_lose);
-      teamData.goal_get += parseInt(row.goal_get);
+      teamData.goal_diff += parseInt(row.goal_get, 10) - parseInt(row.goal_lose, 10);
+      teamData.goal_get += parseInt(row.goal_get, 10);
 
       if (row.match_date <= targetDate) {
         // Within display window: also counts toward disp_ stats
@@ -117,8 +117,8 @@ export function calculateTeamStats(
         teamData.disp_all_game += 1;
         teamData.disp_point += row.point;
         teamData.disp_avlbl_pt += row.point;
-        teamData.disp_goal_diff += parseInt(row.goal_get) - parseInt(row.goal_lose);
-        teamData.disp_goal_get += parseInt(row.goal_get);
+        teamData.disp_goal_diff += parseInt(row.goal_get, 10) - parseInt(row.goal_lose, 10);
+        teamData.disp_goal_get += parseInt(row.goal_get, 10);
       } else {
         // After display cutoff: treat as future for display purposes
         teamData.disp_avlbl_pt += maxPt;

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -66,8 +66,7 @@ export interface GroupEntry {
 export type SeasonMap = Record<string, GroupEntry>;
 
 // Object form of a fully resolved season entry.
-// Use parseSeasonEntry() for basic tuple→object conversion,
-// or resolveSeasonInfo() (in season-map.ts) for full cascade resolution.
+// Use resolveSeasonInfo() (in season-map.ts) for cascade resolution.
 export interface SeasonInfo {
   teamCount: number;
   promotionCount: number;
@@ -81,24 +80,4 @@ export interface SeasonInfo {
   cssFiles: string[];
   teamRenameMap: Record<string, string>;
   tiebreakOrder: string[];
-}
-
-// Converts a RawSeasonEntry tuple into a basic SeasonInfo object.
-// For full cascade-resolved properties, use resolveSeasonInfo() instead.
-export function parseSeasonEntry(entry: RawSeasonEntry): SeasonInfo {
-  const opts = entry[4] ?? {};
-  return {
-    teamCount: entry[0],
-    promotionCount: entry[1],
-    relegationCount: entry[2],
-    teams: entry[3],
-    rankClass: opts.rank_properties ?? {},
-    groupDisplay: opts.group_display,
-    urlCategory: opts.url_category,
-    leagueDisplay: opts.league_display ?? '',
-    pointSystem: opts.point_system ?? 'standard',
-    cssFiles: opts.css_files ?? [],
-    teamRenameMap: opts.team_rename_map ?? {},
-    tiebreakOrder: opts.tiebreak_order ?? ['goal_diff', 'goal_get'],
-  };
 }

--- a/src/get_endtime_list.py
+++ b/src/get_endtime_list.py
@@ -45,7 +45,7 @@ def _is_current_or_future_season(season_name: str) -> bool:
     return False
 
 
-def read_match_csv(file_path):
+def read_match_csv(file_path: Path) -> pd.DataFrame:
     """Read a match CSV file and return a DataFrame."""
     df = pd.read_csv(file_path, index_col=0)
     # Convert match_date to datetime if it's not already
@@ -119,7 +119,7 @@ def read_match_times_from_file(file: Path) -> list[datetime]:
     return list(match_times)
 
 
-def datetime_to_cron(dt, offset_minutes=0):
+def datetime_to_cron(dt: datetime, offset_minutes: int = 0) -> str:
     """Convert a datetime to a cron expression with an offset.
 
     Adjusts the time from JST to GitHub server time (UTC) by subtracting 15 hours.
@@ -135,7 +135,7 @@ def datetime_to_cron(dt, offset_minutes=0):
     return f"{dt.minute} {dt.hour} {dt.day} {dt.month} *"
 
 
-def update_workflow_file(match_times):
+def update_workflow_file(match_times: list[datetime]) -> bool:
     """Update the GitHub workflow file with cron schedules."""
     with open(WORKFLOW_FILE, 'r', encoding='utf-8') as f:
         workflow_content = f.read()

--- a/src/get_endtime_list.py
+++ b/src/get_endtime_list.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
 import re
-from typing import List
 
 import pandas as pd
 
@@ -55,7 +54,7 @@ def read_match_csv(file_path):
     return df
 
 
-def read_all_match_times(year: int = None, competition: str = "*") -> List[datetime]:
+def read_all_match_times(year: int = None, competition: str = "*") -> list[datetime]:
     """Get all match times from all J-League CSV files.
 
     Args:
@@ -89,7 +88,7 @@ def read_all_match_times(year: int = None, competition: str = "*") -> List[datet
     return all_times
 
 
-def read_match_times_from_file(file: Path) -> List[datetime]:
+def read_match_times_from_file(file: Path) -> list[datetime]:
     """Read match times from a specific CSV file.
 
     Args:

--- a/src/make_old_matches_csv.py
+++ b/src/make_old_matches_csv.py
@@ -52,8 +52,6 @@ def make_each_csv(filename: str, comp_index: int) -> dict[str, pd.DataFrame]:
     _df = pd.read_csv(filename, index_col=0)
     matches = _df[_df['大会'].isin(config.league_name[comp_index])].reset_index(drop=True)
     if matches.empty:
-        # print tournament counts for debugging
-        # print(matches['大会'].value_counts())
         return []
 
     year = matches['年度'].value_counts().keys()[0]
@@ -103,7 +101,6 @@ def init_season_dict(matches: pd.DataFrame, year: int) -> dict[str, str]:
     season_dict = {}
     season_names = matches['大会'].value_counts().keys()
     if len(season_names) > 1:
-        # print(f"Multiple tournaments in {year}: {season_names}")
         # ex) 1993: ['Ｊ１ サントリー', 'Ｊ１ ＮＩＣＯＳ']
         season_start = {}
         for _name in season_names:

--- a/src/make_old_matches_csv.py
+++ b/src/make_old_matches_csv.py
@@ -10,7 +10,7 @@ from set_config import load_config
 config = load_config(Path(__file__).parent / '../config/old_matches.yaml')
 
 
-def make_old_matches_csv(competition: str, years: int = None) -> None:
+def make_old_matches_csv(competition: str, years: list[int] | None = None) -> None:
     """Convert match results of the specified years for the given competition into CSV format
 
     Args:

--- a/src/make_old_matches_csv.py
+++ b/src/make_old_matches_csv.py
@@ -71,9 +71,9 @@ def make_each_csv(filename: str, comp_index: int) -> dict[str, pd.DataFrame]:
     if year <= 1998:  # Until 1998, there was a penalty kick rule
         matches['away_goal'] = matches['away_goal'].str.replace(r'\(PK.*', '', regex=True)
         matches['home_pk'] = matches['スコア'].str.extract(r'\(PK(\d+)\-', expand=False)
-        matches['home_pk'].fillna('')
+        matches['home_pk'] = matches['home_pk'].fillna('')
         matches['away_pk'] = matches['スコア'].str.extract(r'\(PK\d+\-(\d+)\)', expand=False)
-        matches['away_pk'].fillna('')
+        matches['away_pk'] = matches['away_pk'].fillna('')
         columns_list.extend(['home_pk', 'away_pk'])
     matches['attendance'] = matches['attendance'].astype('int')
 

--- a/src/read_aclgl_matches.py
+++ b/src/read_aclgl_matches.py
@@ -75,7 +75,6 @@ def read_match_from_web(soup: BeautifulSoup) -> list[dict[str, Any]]:
     for _section in match_groups:
         group = _section.find('header').text.strip()
         group = group.replace('グループ', '')
-        # print('Group: ', group)
 
         match_table = _section.find('tbody')
         _index = 0

--- a/src/read_jfamatch.py
+++ b/src/read_jfamatch.py
@@ -55,7 +55,7 @@ def _prepare_config() -> Config:
     """
     new_conf = load_config(Path(__file__).parent / '../config/jfamatch.yaml')
 
-    def is_string_list(obj):
+    def is_string_list(obj: Any) -> bool:
         if not isinstance(obj, list):
             return False
         return all(isinstance(item, str) for item in obj)

--- a/src/read_jfamatch.py
+++ b/src/read_jfamatch.py
@@ -98,7 +98,7 @@ def read_match_json(_url: str) -> Dict[str, Any]:
     """
     result = None
     counter = 0
-    while result is None or counter > 10:
+    while result is None and counter < 10:
         try:
             print(f'access {_url} ...')
             result = json.loads(requests.get(_url, timeout=config.http_timeout).text)

--- a/src/read_jfamatch.py
+++ b/src/read_jfamatch.py
@@ -188,10 +188,10 @@ def read_jfa_match(_url: str, matches_in_section: int = None) -> pd.DataFrame:
         if '【中止】' in _match_data['venueFullName']:
             _row['status'] = '試合中止'
             if config.debug:
-                print('Cancel Game## ' + _match_data['venueFullName'])
+                print(f'Cancel Game## {_match_data["venueFullName"]}')
         else:
             if config.debug:
-                print('No Cancel## ' + _match_data['venueFullName'])
+                print(f'No Cancel## {_match_data["venueFullName"]}')
 
         _row['extraTime'] = str(_row['extraTime'])  # Stringify for comparison with old style CSV
         _row['match_date'] = to_datetime_aspossible(_row['match_date'])

--- a/src/read_jfamatch.py
+++ b/src/read_jfamatch.py
@@ -36,7 +36,6 @@ import os
 from pathlib import Path
 import re
 from typing import Any
-from typing import Dict
 
 import pandas as pd
 import requests
@@ -86,7 +85,7 @@ def _prepare_config() -> Config:
 config = _prepare_config()
 
 
-def read_match_json(_url: str) -> Dict[str, Any]:
+def read_match_json(_url: str) -> dict[str, Any]:
     """Read the match JSON data from the given URL
 
     Args:
@@ -221,7 +220,7 @@ def read_group(competition: str) -> None:
     update_if_diff(match_df, comp_conf.csv_path)
 
 
-def read_all_group(comp_conf: Dict[str, Any]) -> pd.DataFrame:
+def read_all_group(comp_conf: dict[str, Any]) -> pd.DataFrame:
     """Read the match data for all groups in the specified competition.
 
     Args:

--- a/src/read_jfamatch.py
+++ b/src/read_jfamatch.py
@@ -162,7 +162,6 @@ def read_jfa_match(_url: str, matches_in_section: int = None) -> pd.DataFrame:
         pd.DataFrame: DataFrame containing the match data
     """
     match_list = read_match_json(_url)[config.schedule_container][config.schedule_list]
-    # print(match_list)
     result_list = []
     match_index_dict = {}
     for (_count, _match_data) in enumerate(match_list):

--- a/src/read_jleague_matches.py
+++ b/src/read_jleague_matches.py
@@ -307,7 +307,6 @@ def read_match_from_web(soup: BeautifulSoup) -> list[dict[str, Any]]:
             print(f'Warning: No match data in section "{section_no_text}", skipping')
             continue
         section_no = section_no_match[1]
-        # print((match_date, section_no))
         group = None  # Track current group from groupHead headers (e.g., EAST, WEST)
         for _tr in _section.find_all('tr'):
             # Track group headers
@@ -333,7 +332,6 @@ def read_match_from_web(soup: BeautifulSoup) -> list[dict[str, Any]]:
             match_dict['home_goal'] = _tr.find('td', class_='point leftside').text.strip()
             match_dict['away_goal'] = _tr.find('td', class_='point rightside').text.strip()
             match_dict['away_team'] = _tr.find('td', class_='clubName rightside').text.strip()
-            # str_match_date = (match_date.strftime("%Y/%m/%d") if match_date else '未定')
 
             _status = _tr.find('td', class_='status')
             match_dict['status'] = \

--- a/src/read_older2020_matches.py
+++ b/src/read_older2020_matches.py
@@ -5,8 +5,6 @@ import os
 from pathlib import Path
 import re
 import sys
-from typing import List
-from typing import Optional
 
 from bs4 import BeautifulSoup
 import pandas as pd
@@ -19,7 +17,7 @@ config = load_config(Path(__file__).parent / '../config/old_matches.yaml')
 MATCH_CARD_ID = re.compile(config.match_data.card_id_pattern)
 
 
-def read_href(td_tag) -> Optional[str]:
+def read_href(td_tag) -> str | None:
     """Get href of a tag in given td tag
 
     Args:
@@ -62,7 +60,7 @@ def store_year_data(year: int) -> None:
     print(f"Stored: {csv_file}")
 
 
-def process_years(years: List[int]) -> None:
+def process_years(years: list[int]) -> None:
     """Specified years of J-League match data are processed and stored.
 
     Args:
@@ -88,7 +86,7 @@ def parse_arguments() -> argparse.Namespace:
     return args
 
 
-def parse_years() -> List[int]:
+def parse_years() -> list[int]:
     """Parse years from command-line arguments.
 
     If no arguments are provided, default to all years from 1993 to the current year.

--- a/src/read_older2020_matches.py
+++ b/src/read_older2020_matches.py
@@ -29,9 +29,7 @@ def read_href(td_tag: bs4.element.Tag) -> str | None:
     """
     a_tag = td_tag.find('a')
     if a_tag:
-        # print(a_tag['href'])
         return MATCH_CARD_ID.search(a_tag['href'])[1]
-    # print(_td)
     return None
 
 

--- a/src/read_older2020_matches.py
+++ b/src/read_older2020_matches.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import re
 import sys
 
+import bs4
 from bs4 import BeautifulSoup
 import pandas as pd
 import requests
@@ -17,7 +18,7 @@ config = load_config(Path(__file__).parent / '../config/old_matches.yaml')
 MATCH_CARD_ID = re.compile(config.match_data.card_id_pattern)
 
 
-def read_href(td_tag) -> str | None:
+def read_href(td_tag: bs4.element.Tag) -> str | None:
     """Get href of a tag in given td tag
 
     Args:

--- a/src/read_we_league.py
+++ b/src/read_we_league.py
@@ -41,7 +41,6 @@ def parse_match_date_data(match: bs4.element.Tag) -> dict[str, str]:
         match: 日時データを示すTag要素
         フォーマットは、match_date, start_timeをキーとしたDict形式
     """
-    # display(match.contents[0].strip(), match.contents[2].strip())
     match_date = match.contents[0].strip()
     if datetime.strptime(match_date, DATE_FORMAT).date().month <= SEASON_THRESHOLD_MONTH:
         match_date = f'{SEASON + 1}/' + match_date
@@ -66,7 +65,6 @@ def read_match_from_web(soup: bs4.BeautifulSoup) -> list[dict[str, Any]]:
         section = MATCH_WEEK_REGEXP.match(match_box.get('id'))[1]
         for match_data in match_box.find_all('li', class_='matchContainer'):
             # 1試合分のmatchContainer内
-            # display(match_data)
             match_dict = {'section_no': section, 'match_index_in_section': _index}
 
             # 日時 (<span class="time">[空白類]9/12<span>(SUN)</span>10:01[空白類]</span>)

--- a/src/read_we_league.py
+++ b/src/read_we_league.py
@@ -2,6 +2,7 @@
 import argparse
 from datetime import datetime
 import os
+from pathlib import Path
 import re
 from typing import Any
 
@@ -107,7 +108,7 @@ def make_args() -> argparse.Namespace:
 
 
 if __name__ == '__main__':
-    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    os.chdir(Path(__file__).parent)
 
     ARGS = make_args()
     if ARGS.debug:

--- a/src/set_config.py
+++ b/src/set_config.py
@@ -46,7 +46,6 @@ config.timezone = pytz.timezone(config.timezone)
 from os import PathLike
 from pathlib import Path
 from typing import Any
-from typing import Union
 
 import yaml
 
@@ -208,7 +207,7 @@ class Config:
             return format_str.format(**kwargs)
         return format_str
 
-    def get_from_keypath(self, key: str) -> Union[str, ConfigSection, Any]:
+    def get_from_keypath(self, key: str) -> str | ConfigSection | Any:
         """指定されたキーのパスを辿って値、またはConfigSectionを取得する
 
         キーはドット区切りでセクション名と共に指定する


### PR DESCRIPTION
## Summary

Fixes #85

TS移行後に残った冗長・古い・非標準な記述を4領域 (HTML/CSS/TypeScript/Python) にわたって整理。

- **HTML**: viewport meta, favicon rel 正規化, SortableTable CDN 固定+SRI, 未使用要素削除, セマンティック改善, インラインスタイル→CSS移動
- **Python**: バグ修正2件 (fillna 未代入, リトライ条件), typing モダナイズ, 型ヒント追加, デバッグ文削除, pathlib/f-string 統一
- **TypeScript**: テンプレートリテラル統一, 未使用パラメータ/エクスポート削除, parseInt radix 明示, dateFormat 重複解消, cachebuster 定数化
- **CSS**: ベンダープレフィクス削除, コメントアウト済みルール削除

## Changes

23 files changed, 157 insertions, 205 deletions (net -48 lines)

### Bug fixes (Python)
- `make_old_matches_csv.py`: `fillna('')` の戻り値が未代入だった
- `read_jfamatch.py`: リトライループの条件が `or` → `and` で間違っていた

### Cleanup
- 12 commits covering HTML/CSS (1), Python (5), TypeScript (6)
- Details in Issue #85 comment

## Test plan

- [x] `uv run pytest` passed
- [x] `npx vitest run` passed (frontend/)
- [x] `npm run build` succeeded (frontend/)
- [x] CI: test-python, test-typescript workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)