### PR TITLE
TypeScript frontend code review and cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,41 +3,7 @@
 Jリーグ・各種サッカー大会の勝ち点積み上げグラフを可視化するWebアプリケーション。
 GitHub Pages で公開: <https://mokekuma-git.github.io/JLeague_Matches-Bar_Graph/>
 
-## ビューアが提供する体験
-
-このプロジェクトの核心は「リーグ戦の勝ち点推移を、チーム固有カラーで一望できる積み上げバーグラフ」にある。
-
-### 積み上げバーグラフ
-
-- 各チームを1本の縦棒で表現し、試合ごとの勝ち点 (勝ち=3pt / 引き分け=1pt / 負け=0ptなど) を色分けして積み上げる
-- 未実施の試合も半透明で勝ち点上限まで描画し、「今後取り得る最大勝ち点」を視覚化する
-- チームカラーは CSS で定義 (`team_style.css` / `national_team_style.css`)。マウスオーバーで試合詳細のツールチップを表示
-
-### 日時スライダーによる時間遡行
-
-- スライダーまたは日付指定で任意の日付時点の状態を再現する
-- 指定日以降の試合は未実施扱いとなり、その時点での順位・勝ち点がグラフと順位表に反映される
-
-### ソート
-
-- **チームソート**: 勝ち点 (表示日時点 / 最新)、最大勝ち点 (表示日時点 / 最新) の4軸
-- **試合ソート**: 積み上げ方向を「古い試合が下 / 新しい試合が下 / 第1節が下 / 最終節が下」から選択
-
-### 順位表
-
-- SortableTable (CDN) でソート可能な順位表を自動生成
-- 優勝確定・昇格圏・降格圏・プレーオフ圏をライン表示で示す
-- 勝ち点・得失点差・得点・勝敗数などの統計値を集計
-
-### カテゴリ・シーズン切り替え
-
-- ドロップダウンで J1/J2/J3 とシーズン (1993年〜) を切り替え
-- URL パラメータ (`?competition=J1&season=2026East`) で状態を共有可能
-- ユーザー設定 (カテゴリ・シーズン・ソート・表示日・外観) は localStorage に保存し、再訪時に復元
-
-### 外観カスタマイズ
-
-- グラフ縮小率・未実施試合の透明度・余白色を調整可能
+チーム固有カラーの積み上げバーグラフで勝ち点推移を一望でき、日時スライダーで任意時点の順位を再現する。
 
 ## ディレクトリ構造
 
@@ -45,103 +11,41 @@ GitHub Pages で公開: <https://mokekuma-git.github.io/JLeague_Matches-Bar_Grap
 JLeague_Matches-Bar_Graph/
 ├── frontend/                        # TypeScript フロントエンド (Vite)
 │   ├── src/
-│   │   ├── app.ts                  #   統合ビューア エントリポイント
+│   │   ├── app.ts                  #   エントリポイント
 │   │   ├── j_points.html           #   HTMLテンプレート (Vite input)
-│   │   ├── config/
-│   │   │   └── season-map.ts       #   season_map.json 読み込み・ユーティリティ
-│   │   ├── core/
-│   │   │   ├── csv-parser.ts       #   CSV→TeamMap 変換
-│   │   │   ├── point-calculator.ts #   勝ち点計算ロジック
-│   │   │   ├── prepare-render.ts   #   レンダ前データ準備 (純粋関数)
-│   │   │   ├── sorter.ts           #   チーム・試合ソート
-│   │   │   └── date-utils.ts       #   日付ユーティリティ
-│   │   ├── graph/
-│   │   │   ├── renderer.ts         #   バーグラフ描画
-│   │   │   ├── bar-column.ts       #   各チームの棒グラフ生成
-│   │   │   ├── tooltip.ts          #   ツールチップ生成
-│   │   │   └── css-utils.ts        #   CSS変数操作 (スケール等)
-│   │   ├── ranking/
-│   │   │   ├── rank-table.ts       #   順位表HTML生成
-│   │   │   └── stats-calculator.ts #   チーム統計集計
-│   │   ├── storage/
-│   │   │   └── local-storage.ts    #   ユーザー設定の永続化
-│   │   ├── types/
-│   │   │   ├── match.ts            #   試合データ型定義
-│   │   │   ├── season.ts           #   シーズン設定型定義
-│   │   │   └── config.ts           #   カテゴリ設定型定義
+│   │   ├── config/season-map.ts    #   season_map.json 読み込み・ユーティリティ
+│   │   ├── core/                   #   CSV解析, 勝ち点計算, ソート, 日付ユーティリティ
+│   │   ├── graph/                  #   バーグラフ描画, ツールチップ, CSS操作
+│   │   ├── ranking/                #   順位表HTML生成, 統計集計
+│   │   ├── storage/                #   localStorage 永続化
+│   │   ├── types/                  #   型定義 (match, season, config)
 │   │   └── __tests__/              #   Vitest テスト
-│   ├── package.json
-│   ├── tsconfig.json
 │   ├── vite.config.ts              #   ビルド → docs/ に出力
 │   └── vitest.config.ts
-├── config/                          # YAML設定ファイル (Python用)
-│   ├── jfamatch.yaml               #   JFA系大会設定
-│   ├── jleague.yaml                #   Jリーグ設定
-│   └── old_matches.yaml            #   過去データ設定
-├── src/                             # Pythonスクリプト (データ取得・変換)
-│   ├── set_config.py               #   設定管理モジュール (YAML読み込み)
-│   ├── match_utils.py              #   共有ユーティリティ (CSV I/O, season_map読み込み, 日付計算)
-│   ├── read_jleague_matches.py     #   Jリーグ公式サイトからスクレイピング (BS4)
-│   ├── read_jfamatch.py            #   JFA JSON APIからデータ取得
-│   ├── read_older2020_matches.py   #   2020年以前の過去データ取得
-│   ├── read_aclgl_matches.py       #   ACLデータ取得
-│   ├── read_we_league.py           #   WEリーグデータ取得
-│   ├── get_endtime_list.py         #   cron自動生成 (試合日程→GitHub Actions)
-│   └── make_old_matches_csv.py     #   過去データCSV変換
-├── tests/                           # テストコード (pytest)
-│   ├── test_read_jleague_matches.py
-│   ├── test_get_endtime_list.py
-│   ├── test_2026_special_season.py #   2026特別シーズン対応テスト
-│   ├── check_j_scores_homeaway.py
-│   └── test_data/                  #   テスト用HTMLファイル
-├── docs/                            # GitHub Pages公開ディレクトリ
-│   ├── index.html                  #   → j_points.html へリダイレクト
-│   ├── j_points.html               #   ★ ビルド生成物 (gitignore対象)
-│   ├── assets/                     #   ★ ビルド生成物 (gitignore対象)
-│   ├── j_points.css                #   Jリーグ用スタイル (手動管理)
-│   ├── j_points_legacy.{html,js}  #   旧JS版 Jリーグページ (レガシー)
-│   ├── olympic_points.{html,js,css}#  オリンピック用 (旧JS)
-│   ├── wc2022_points.{html,js}    #   W杯用 (旧JS)
-│   ├── wcafc_fq_points.{html,js}  #   W杯予選用 (旧JS)
-│   ├── prince_points.{html,js}    #   プリンスリーグ用 (旧JS)
-│   ├── aclgl_points.{html,js}     #   ACL用 (旧JS)
-│   ├── team_style.css              #   チームカラー定義 (国内)
-│   ├── national_team_style.css     #   チームカラー定義 (代表)
+├── src/                             # Python スクリプト (データ取得・変換)
+│   ├── match_utils.py              #   共有ライブラリ (CSV I/O, season_map, 日付計算)
+│   ├── set_config.py               #   設定管理 (YAML読み込み)
+│   ├── read_jleague_matches.py     #   Jリーグスクレイピング (BS4)
+│   ├── read_jfamatch.py            #   JFA JSON API データ取得
+│   └── ...                         #   ACL, WEリーグ, 過去データ, cron生成等
+├── config/                          #   YAML設定 (jleague.yaml, jfamatch.yaml等)
+├── tests/                           #   pytest テストコード + test_data/
+├── docs/                            # GitHub Pages 公開ディレクトリ
+│   ├── j_points.html, assets/      #   ★ ビルド生成物 (gitignore対象)
+│   ├── *_points.{html,js}          #   旧JS版ページ (ACL, W杯, 五輪等。未TS化)
+│   ├── *.css                       #   スタイル (チームカラー定義含む)
 │   ├── csv/                        #   処理済みCSV
-│   └── json/                       #   メタデータ
-│       ├── season_map.json         #     シーズン設定 (全カテゴリ共通)
-│       └── aclgl_points.json       #     ACL試合データ (独自JSON構造)
-├── csv/                             # 年次アーカイブCSV (元データ保管)
-├── scripts/
-│   ├── call_update_csv.sh          #   CI/CD実行スクリプト
-│   └── format_season_map.py        #   season_map.json カスタムフォーマッタ
-├── image/                           # favicon等の画像素材
-├── .github/workflows/
-│   ├── deploy-pages.yaml           #   GitHub Pages デプロイ (TS build + upload)
-│   ├── upadate-match-csv.yaml     #   CSV定期更新 (試合時刻連動cron)
-│   ├── test-python.yaml            #   Python テスト (PR/push)
-│   ├── test-typescript.yaml        #   TypeScript typecheck + vitest (PR/push)
-│   ├── build-typescript.yaml       #   TypeScript ビルド (手動実行)
-│   └── check-build-artifacts.yaml  #   ビルド生成物の誤コミット検出 (PR)
-├── pyproject.toml                   # Python依存関係 (uv管理)
-├── uv.lock                          # uvロックファイル
-├── setup.cfg                        # flake8等の設定
-├── pytest.ini                       # pytest設定
-└── .pylintrc                        # pylint設定
+│   └── json/                       #   season_map.json, aclgl_points.json
+├── scripts/                         #   CI/CDスクリプト, season_map.jsonフォーマッタ
+├── .github/workflows/               #   Pages デプロイ, CSV更新, テスト, ビルドチェック
+└── pyproject.toml                   #   Python依存 (uv管理)
 ```
 
 ## 技術スタック
 
-- **バックエンド (データ取得):** Python 3.12+ / BeautifulSoup4, requests, pandas, PyYAML, pytz, lxml
-- **パッケージ管理 (Python):** uv (`pyproject.toml` + `uv.lock`)
-- **フロントエンド (TypeScript版):** TypeScript + Vite / PapaParse (CSV解析), SortableTable (CDN)
-- **フロントエンド (旧JS版):** Vanilla JavaScript (ACL, W杯, オリンピック, プリンスリーグ等。未TS化)
-- **パッケージ管理 (Frontend):** npm (`frontend/package.json` + `package-lock.json`)
-- **Node.js:** 22 (CI/CD・ローカル開発共通)
-- **ホスティング:** GitHub Pages (GitHub Actions でビルド&デプロイ)
-- **CI/CD:** GitHub Actions (CSV定期更新 + TSビルド&デプロイ + テスト)
-- **テスト (Python):** pytest
-- **テスト (TypeScript):** vitest (環境: node, DOM テストは happy-dom)
+- **Python 3.12+**: BeautifulSoup4, requests, pandas, PyYAML / パッケージ管理: uv / テスト: pytest
+- **TypeScript + Vite**: PapaParse (CSV), SortableTable (CDN) / パッケージ管理: npm / テスト: vitest (DOM: happy-dom) / Node.js 22
+- **CI/CD**: GitHub Actions (CSV定期更新 + TSビルド&デプロイ + テスト) → GitHub Pages
 
 ## 主要コマンド
 
@@ -166,18 +70,6 @@ npm run dev               # Vite開発サーバー起動
 - `docs/` 内の CSV, JSON, CSS, 旧JS ページ等はそのまま git 管理 (Python 側が直接更新)
 - `check-build-artifacts.yaml` が PR 時にビルド生成物の誤コミットを検出
 
-## TypeScript 移行状況
-
-| ページ | 状態 | 備考 |
-| ------ | ---- | ---- |
-| Jリーグ (`j_points`) | TS版稼働中 | `frontend/src/app.ts` → `docs/j_points.html` (ビルド生成) |
-| Jリーグ (レガシー) | 旧JS維持 | `docs/j_points_legacy.{html,js}` |
-| ACL | 旧JS | `docs/aclgl_points.{html,js}` — 独自JSON (`aclgl_points.json`) |
-| W杯2022 | 旧JS | `docs/wc2022_points.{html,js}` — 固定データ |
-| W杯AFC予選 | 旧JS | `docs/wcafc_fq_points.{html,js}` |
-| オリンピック | 旧JS | `docs/olympic_points.{html,js,css}` |
-| プリンスリーグ | 旧JS | `docs/prince_points.{html,js}` — JFA JSON API |
-
 ## CSV形式
 
 `docs/csv/*.csv` のカラム:
@@ -185,12 +77,12 @@ npm run dev               # Vite開発サーバー起動
 
 - `status`: "試合終了" (完了) / "ＶＳ" (未実施)
 - `home_goal`/`away_goal`: 空 = 未実施
-- `group`: グループ名 (2026特別シーズン等、グループ分けがある場合のみ)
-- `home_pk_score`/`away_pk_score`: PK得点 (省略可能。PK戦あり試合のみ値あり、それ以外は空。JFA JSONの命名に倣った)
+- `group`: グループ名 (グループ分けがある場合のみ)
+- `home_pk_score`/`away_pk_score`: PK得点 (省略可能。JFA JSONの命名に倣った)
 
 ## season_map.json 構造
 
-`docs/json/season_map.json` は4階層構造: **Group → Competition → Seasons → Entry**。
+4階層構造: **Group → Competition → Seasons → Entry**。
 
 ```json
 {
@@ -214,88 +106,50 @@ npm run dev               # Vite開発サーバー起動
 }
 ```
 
-### 階層別のプロパティ
+### 階層別プロパティ
 
-**Group 階層** (`jleague` 等): `display_name`, `css_files?`, `season_start_month?`
+- **Group** (`jleague` 等): `display_name`, `css_files?`, `season_start_month?`
+- **Competition** (`J1` 等): `league_display?`, `css_files?`, `point_system?`, `team_rename_map?`, `tiebreak_order?`, `season_start_month?`, `seasons`
 
-**Competition 階層** (`J1` 等): `league_display?`, `css_files?`, `point_system?`, `team_rename_map?`, `tiebreak_order?`, `season_start_month?`, `seasons`
-
-**Season Entry** (配列): シーズンごとのチーム構成
+### Season Entry (配列)
 
 | Index | 内容 | 必須 | 例 |
 | ----- | ---- | ---- | -- |
 | 0 | チーム数 | 必須 | `10` |
 | 1 | 昇格枠数 | 必須 | `1` |
 | 2 | 降格枠数 | 必須 | `0` |
-| 3 | チームリスト (前年度成績順) | 必須 | `["鹿島", "柏", ...]` |
-| 4 | SeasonEntryOptions | 省略可 | `{"group_display": "EAST", "rank_properties": {"3": "promoted_playoff"}}` |
+| 3 | チームリスト (前年度成績順 = 同順位時の優先順位) | 必須 | `["鹿島", "柏", ...]` |
+| 4 | SeasonEntryOptions | 省略可 | `{"group_display": "EAST"}` |
 
 ### プロパティカスケード
 
-TS 版 `resolveSeasonInfo()` が Group → Competition → Season Entry の3階層をマージして `SeasonInfo` を生成する。スカラ値は下位が上書き、配列 (`css_files`) は和集合、オブジェクト (`team_rename_map`) はマージ。
-
-### チームリスト (index 3) の存在理由
-
-順位ソートのための情報がすべて一致している同順位のチームを並べる際のベース優先順位とする。
-仮にここに出てこないチームが取得されてCSVなどに書き込まれた場合は、Warningを出しつつ、CSVでの登場順にこのリストに追加するものと考えて仮に動作させる。
+`resolveSeasonInfo()` が Group → Competition → Season Entry の3階層をマージ。スカラ値は下位が上書き、配列 (`css_files`) は和集合、オブジェクト (`team_rename_map`) はマージ。
 
 ### SeasonEntryOptions の主要キー
 
-| キー | 説明 | 例 |
-| ---- | --- | -- |
-| `group_display` | HTML上の表示グループ名 (groupHeadテキスト)。スクレイピング結果の `group` 列でフィルタしてCSVに振り分ける | `"EAST"`, `"EAST-A"` |
-| `url_category` | スクレイピングURL `{category}/{sec}/` のカテゴリ部分を上書き (デフォルト: competition key を小文字化。例: `J1` → `j1`) | `"j2j3"` → URL `j2j3/{sec}/` |
-| `rank_properties` | 順位→CSSクラスのマッピング | `{"3": "promoted_playoff"}` |
-| `season_start_month` | シーズン開始月 (1-12)。Group→Competition→SeasonEntry でカスケード。コードデフォルト: `7` (秋春制) | `1` (暦年), `7` (秋春制) |
+- `group_display`: HTML上の表示グループ名。スクレイピング結果の `group` 列でCSVに振り分ける
+- `url_category`: スクレイピングURL のカテゴリ部分を上書き (デフォルト: competition key の小文字化)
+- `rank_properties`: 順位→CSSクラスのマッピング (例: `{"3": "promoted_playoff"}`)
+- `season_start_month`: シーズン開始月。カスケード対象。コードデフォルト: `7` (秋春制)
 
 ### シーズン命名規則
 
-- **カテゴリ番号 (1, 2, 3) は不変** — 東西・グループの区別はシーズン名の追番で行う (カテゴリを増やさない)
-- シーズン名 = 年号 + 任意の追番
-  - 年号: 4桁数値 (`2026` 等) または `26-27` のような2桁年ハイフン形式 (秋春制)
-  - 追番: `A`/`B` (前後期)、`East`/`West` (地域)、`EastA`/`WestB` (地域+組) 等
-  - 追番なし (素の年号) = 該当シーズンの全サブシーズンを結合した仮想結果
-- `get_season_from_date(season_start_month=N)` がシーズン文字列を自動算出。`season_start_month=1` → `"YYYY"` (暦年)、それ以外 → `"YY-YY"` (跨年)。`resolve_season_start_month()` が season_map.json のカスケードから開始月を解決する
+- カテゴリ番号 (1, 2, 3) は不変。東西・グループはシーズン名の追番で区別
+- シーズン名 = 年号 (`2026` or `26-27`) + 追番 (`East`/`West`/`A`/`B`/`EastA` 等)。追番なし = 全サブシーズン結合の仮想結果
+- `get_season_from_date(season_start_month=N)`: `1` → `"YYYY"` (暦年)、それ以外 → `"YY-YY"` (跨年)
 - CSVファイル名: `{シーズン名}_allmatch_result-J{カテゴリ}.csv`
-- 順序は辞書順 (`East` < `West`, `EastA` < `EastB` < `WestA` < `WestB`)
-- CSVファイル検索の正規表現: `r"(\d{4}[A-Za-z]*|\d{2}-\d{2}[A-Za-z]*)_allmatch_result-J(\d+).csv"`
+- CSV検索正規表現: `r"(\d{4}[A-Za-z]*|\d{2}-\d{2}[A-Za-z]*)_allmatch_result-J(\d+).csv"`
 
 ## 開発プラクティス
 
-- **リファクタリング時のビルド確認**: テスト (`vitest`) 通過だけでなく `npm run build` (`vite build`) も各段階で確認する。CI の `test-typescript.yaml` は typecheck + vitest のみで、ビルド自体は PR 時に自動検証されないため、ローカルでの確認を習慣とする
-- **season_map.json 編集後のフォーマット**: `python scripts/format_season_map.py` でカスタム整形を実行する (標準 `json.dump` では1シーズンが縦に長くなりすぎるため)
+- **リファクタリング時のビルド確認**: テスト (`vitest`) だけでなく `npm run build` も確認する。CI は typecheck + vitest のみでビルドは PR 時に自動検証されない
+- **season_map.json 編集後**: `python scripts/format_season_map.py` でカスタム整形を実行
 
 ## 設計上の決定事項
 
-- **JFA JSON APIはCSVカラム設計の重要な参考情報源** — 新カラムを追加する際はJFA JSON構造を参照して名称を決める
-- **スクレイピング時のシーズン文字列は `config.season` (YAML) が正** — HTMLから読み取ったシーズン情報で上書きしない。不一致時は警告のみ (別途シーズン検証ロジックを設けることはあり得る)
-- **`get_sub_seasons(category)` の戻り値で更新動作が決まる**
-  - `None`: そのカテゴリに `config.season` のエントリが season_map にない → スキップ (何もしない)
-  - `[]`: 通常の単一シーズン → `update_all_matches()` で従来通り更新
-  - `[...]`: マルチグループシーズン → `update_sub_season_matches()` で各サブシーズン CSV に振り分け
-  - season_map に新しい年のエントリを追加しない限り、そのカテゴリ・年は自動的にスキップされる
-- **`match_utils.py` が共通ライブラリ** — CSV I/O (`update_if_diff`, `read_allmatches_csv`), season_map 読み込み (`load_season_map`, `get_sub_seasons`, `get_csv_path`), 日付計算 (`get_season_from_date`, `to_datetime_aspossible`) などの共通関数を提供。他スクリプト (`read_jfamatch`, `read_aclgl`, `read_we_league`) がインポートして使う。`read_jleague_matches.py` は J-League 固有のスクレイピングと URL 構築 (`competition.lower()` で URL セグメント生成) のみを担当
-- **勝ち点システム (PointSystem)** — `'standard'` (勝3/PK勝2/PK負1/分1/負0) と `'old-two-points'` (勝2/分1/負0) の2種類。season_map.json の Competition 階層で `point_system` として指定可能 (デフォルト: `'standard'`)
-- **SeasonEntry のバリデーション方針** — season_map.json は手動編集ファイルのため、読み込み時にバリデーションを行う。必須フィールド (配列 index 0〜3) の型不正・欠落はエラーで即停止。SeasonEntryOptions (index 4) の未知キーは Warning を出して無視する (新しい reader 向けオプションの試行錯誤を妨げない)
-
-## aclgl_points.json 構造
-
-`docs/json/aclgl_points.json` は ACL 専用の試合データ JSON。`season_map.json` とは異なる構造を持つ。
-
-```json
-{
-  "グループ名": {
-    "チーム名": {
-      "df": [
-        { "match_date": "04/16", "section_no": "1", "opponent": "...",
-          "goal_get": "2", "goal_lose": "2", "point": 1,
-          "has_result": true, "is_home": false, "group": "A",
-          "match_status": "試合終了", "stadium": "...", "start_time": "04:00:00" }
-      ]
-    }
-  }
-}
-```
-
-旧JS版 (`aclgl_points.js`) が直接このJSONを読み込んで表示する。
-CSV 経由ではなく、Python 側で JSON を直接生成している点が他の大会と異なる。
+- **JFA JSON APIはCSVカラム名の参考情報源** — 新カラム追加時はJFA JSON構造を参照
+- **スクレイピング時のシーズン文字列は `config.season` (YAML) が正** — HTML読み取り値で上書きしない
+- **`get_sub_seasons(category)` の戻り値で更新動作が決まる**: `None` → スキップ / `[]` → 単一シーズン更新 / `[...]` → マルチグループ振り分け
+- **`match_utils.py` が共通ライブラリ** — CSV I/O, season_map 読み込み, 日付計算を提供。各 reader がインポートして使う
+- **勝ち点システム**: `'standard'` (勝3/PK勝2/PK負1/分1/負0) と `'old-two-points'` (勝2/分1/負0)。Competition 階層の `point_system` で指定 (デフォルト: `'standard'`)
+- **SeasonEntry バリデーション**: index 0〜3 の型不正は即エラー。index 4 の未知キーは Warning で無視

--- a/frontend/src/__tests__/config/season-map.test.ts
+++ b/frontend/src/__tests__/config/season-map.test.ts
@@ -192,6 +192,15 @@ describe('resolveSeasonInfo', () => {
     expect(info.leagueDisplay).toBe('Test Group');
   });
 
+  test('fallback to groupKey when no display_name and no league_display', () => {
+    const comp: CompetitionEntry = { seasons: {} };
+    const group: GroupEntry = { competitions: {} };
+    const entry: RawSeasonEntry = [10, 0, 0, []];
+    const info = resolveSeasonInfo(group, comp, entry, 'my_group');
+
+    expect(info.leagueDisplay).toBe('my_group');
+  });
+
   test('tiebreakOrder defaults to ["goal_diff", "goal_get"]', () => {
     const entry: RawSeasonEntry = [20, 3, 3, []];
     const info = resolveSeasonInfo(sampleGroup, sampleGroup.competitions.J1, entry);

--- a/frontend/src/__tests__/core/csv-parser.test.ts
+++ b/frontend/src/__tests__/core/csv-parser.test.ts
@@ -283,7 +283,7 @@ describe('parseCsvResults', () => {
       const td = result['DefaultGroup']['TeamB'];
       calculateTeamStats(td, TARGET, 'section_no');
       expect(td.point).toBe(0);
-      expect(td.lose).toBe(2);
+      expect(td.loss).toBe(2);
       expect(td.goal_get).toBe(1);
       expect(td.goal_diff).toBe(-2);
     });

--- a/frontend/src/__tests__/core/prepare-render.test.ts
+++ b/frontend/src/__tests__/core/prepare-render.test.ts
@@ -33,7 +33,7 @@ describe('prepareRenderData', () => {
     // TeamA: 3 + 0 = 3pt, TeamB: 0 + 1 = 1pt, TeamC: 3 + 1 = 4pt
     expect(result.groupData.TeamA.point).toBe(3);
     expect(result.groupData.TeamA.win).toBe(1);
-    expect(result.groupData.TeamA.lose).toBe(1);
+    expect(result.groupData.TeamA.loss).toBe(1);
     expect(result.groupData.TeamB.point).toBe(1);
     expect(result.groupData.TeamB.draw).toBe(1);
     expect(result.groupData.TeamC.point).toBe(4);
@@ -177,7 +177,7 @@ describe('prepareRenderData with pointSystem', () => {
 
     // old-two-points uses the point values from matches (which the caller
     // would have set to the old-two-points scale). Here we verify the system
-    // correctly uses the pointSystem for classification (win/draw/lose).
+    // correctly uses the pointSystem for classification (win/draw/loss).
     const oldResult = prepareRenderData({
       groupData: {
         TeamA: makeTeamData([
@@ -199,7 +199,7 @@ describe('prepareRenderData with pointSystem', () => {
     expect(oldResult.groupData.TeamA.win).toBe(1);
     expect(oldResult.groupData.TeamA.draw).toBe(1);
     expect(oldResult.groupData.TeamB.win).toBe(1);
-    expect(oldResult.groupData.TeamB.lose).toBe(1);
+    expect(oldResult.groupData.TeamB.loss).toBe(1);
   });
 });
 

--- a/frontend/src/__tests__/graph/bar-column.test.ts
+++ b/frontend/src/__tests__/graph/bar-column.test.ts
@@ -26,7 +26,7 @@ describe('makeHtmlColumn – box class per result type', () => {
     ]);
     expect(result.graph).toHaveLength(1);
     expect(result.graph[0]).toContain('"tall box"');
-    expect(result.loseBox).toHaveLength(0);
+    expect(result.lossBox).toHaveLength(0);
   });
 
   test('win box contains team CSS class', () => {
@@ -59,12 +59,12 @@ describe('makeHtmlColumn – box class per result type', () => {
     expect(result.graph[0]).toContain('"short box"');
   });
 
-  test('loss (0 pt) → no graph entry, one loseBox entry', () => {
+  test('loss (0 pt) → no graph entry, one lossBox entry', () => {
     const { result } = buildColumn([
       makeMatch({ goal_get: '0', goal_lose: '2', point: 0, match_date: '2025/03/15' }),
     ]);
     expect(result.graph).toHaveLength(0);
-    expect(result.loseBox).toHaveLength(1);
+    expect(result.lossBox).toHaveLength(1);
   });
 });
 
@@ -111,11 +111,11 @@ describe('makeHtmlColumn – live match styling', () => {
     expect(result.graph[0]).toContain('"short box live"');
   });
 
-  test('live loss → loseBox entry wrapped in <div class="live">', () => {
+  test('live loss → lossBox entry wrapped in <div class="live">', () => {
     const { result } = buildColumn([
       makeMatch({ goal_get: '0', goal_lose: '1', point: 0, match_date: '2025/03/15', live: true }),
     ]);
-    expect(result.loseBox[0]).toContain('<div class="live">');
+    expect(result.lossBox[0]).toContain('<div class="live">');
   });
 });
 
@@ -182,27 +182,27 @@ describe('makeHtmlColumn – matchDates', () => {
   });
 });
 
-// ─── loseBox content ───────────────────────────────────────────────────────────
+// ─── lossBox content ───────────────────────────────────────────────────────────
 
-describe('makeHtmlColumn – loseBox content', () => {
-  test('loseBox entry contains match details from makeFullContent', () => {
+describe('makeHtmlColumn – lossBox content', () => {
+  test('lossBox entry contains match details from makeFullContent', () => {
     const { result } = buildColumn([
       makeMatch({
         goal_get: '0', goal_lose: '2', point: 0, match_date: '2025/03/15',
         opponent: 'TeamB', stadium: 'LossStadium', section_no: '4',
       }),
     ]);
-    expect(result.loseBox[0]).toContain('TeamB');
-    expect(result.loseBox[0]).toContain('LossStadium');
-    expect(result.loseBox[0]).toContain('(4)');
+    expect(result.lossBox[0]).toContain('TeamB');
+    expect(result.lossBox[0]).toContain('LossStadium');
+    expect(result.lossBox[0]).toContain('(4)');
   });
 
-  test('multiple losses accumulate in loseBox order', () => {
+  test('multiple losses accumulate in lossBox order', () => {
     const { result } = buildColumn([
       makeMatch({ goal_get: '0', goal_lose: '1', point: 0, match_date: '2025/03/01', section_no: '1' }),
       makeMatch({ goal_get: '0', goal_lose: '2', point: 0, match_date: '2025/03/08', section_no: '2' }),
     ]);
-    expect(result.loseBox).toHaveLength(2);
+    expect(result.lossBox).toHaveLength(2);
   });
 });
 
@@ -246,11 +246,11 @@ describe('makeHtmlColumn – old-two-points system', () => {
     expect(result.graph[0]).toContain('"medium box"');
   });
 
-  test('loss (0 pt) → goes to loseBox', () => {
+  test('loss (0 pt) → goes to lossBox', () => {
     const { result } = buildOldColumn([
       makeMatch({ goal_get: '0', goal_lose: '2', point: 0, match_date: '2025/03/15' }),
     ]);
     expect(result.graph).toHaveLength(0);
-    expect(result.loseBox).toHaveLength(1);
+    expect(result.lossBox).toHaveLength(1);
   });
 });

--- a/frontend/src/__tests__/graph/bar-column.test.ts
+++ b/frontend/src/__tests__/graph/bar-column.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { makeHtmlColumn } from '../../graph/bar-column';
+import { buildTeamColumn } from '../../graph/bar-column';
 import { calculateTeamStats } from '../../ranking/stats-calculator';
 import { makeMatch, makeTeamData } from '../fixtures/match-data';
 
@@ -14,12 +14,12 @@ function buildColumn(
 ) {
   const td = makeTeamData(matches);
   calculateTeamStats(td, target, 'section_no');
-  return { result: makeHtmlColumn(TEAM, td, target, disp), td };
+  return { result: buildTeamColumn(TEAM, td, target, disp), td };
 }
 
 // ─── box class per result type ─────────────────────────────────────────────────
 
-describe('makeHtmlColumn – box class per result type', () => {
+describe('buildTeamColumn – box class per result type', () => {
   test('win (3 pt, within cutoff) → tall box in graph', () => {
     const { result } = buildColumn([
       makeMatch({ goal_get: '2', goal_lose: '0', point: 3, match_date: '2025/03/15' }),
@@ -70,7 +70,7 @@ describe('makeHtmlColumn – box class per result type', () => {
 
 // ─── future / display-future matches ──────────────────────────────────────────
 
-describe('makeHtmlColumn – future and display-future boxes', () => {
+describe('buildTeamColumn – future and display-future boxes', () => {
   test('unplayed match → tall box with "future bg" class', () => {
     const { result } = buildColumn([
       makeMatch({ has_result: false, goal_get: '', goal_lose: '', point: 0, match_date: '2025/05/01' }),
@@ -96,7 +96,7 @@ describe('makeHtmlColumn – future and display-future boxes', () => {
 
 // ─── live match flag ───────────────────────────────────────────────────────────
 
-describe('makeHtmlColumn – live match styling', () => {
+describe('buildTeamColumn – live match styling', () => {
   test('live win → "tall box live" CSS class', () => {
     const { result } = buildColumn([
       makeMatch({ goal_get: '1', goal_lose: '0', point: 3, match_date: '2025/03/15', live: true, status: '前半' }),
@@ -121,7 +121,7 @@ describe('makeHtmlColumn – live match styling', () => {
 
 // ─── avlbl_pt always equals disp_avlbl_pt ──────────────────────────────────────
 
-describe('makeHtmlColumn – avlbl_pt is always disp_avlbl_pt', () => {
+describe('buildTeamColumn – avlbl_pt is always disp_avlbl_pt', () => {
   // Win in March (within cutoff) + loss in April (after cutoff):
   //   avlbl_pt     = 3   (win only; April loss contributes 0 to latest)
   //   disp_avlbl_pt = 6  (3 win + 3 potential for April gray box)
@@ -147,15 +147,15 @@ describe('makeHtmlColumn – avlbl_pt is always disp_avlbl_pt', () => {
   test('disp flag does not change avlbl_pt (both use disp_avlbl_pt)', () => {
     const td = makeTeamData(MATCHES);
     calculateTeamStats(td, TARGET, 'section_no');
-    const latestAP = makeHtmlColumn(TEAM, td, TARGET, false).avlbl_pt;
-    const dispAP   = makeHtmlColumn(TEAM, td, TARGET, true).avlbl_pt;
+    const latestAP = buildTeamColumn(TEAM, td, TARGET, false).avlbl_pt;
+    const dispAP   = buildTeamColumn(TEAM, td, TARGET, true).avlbl_pt;
     expect(latestAP).toBe(dispAP); // both = disp_avlbl_pt = 6
   });
 });
 
 // ─── matchDates collection ─────────────────────────────────────────────────────
 
-describe('makeHtmlColumn – matchDates', () => {
+describe('buildTeamColumn – matchDates', () => {
   test('collects YYYY/MM/DD dates from played matches', () => {
     const { result } = buildColumn([
       makeMatch({ goal_get: '1', goal_lose: '0', point: 3, match_date: '2025/03/01' }),
@@ -184,7 +184,7 @@ describe('makeHtmlColumn – matchDates', () => {
 
 // ─── lossBox content ───────────────────────────────────────────────────────────
 
-describe('makeHtmlColumn – lossBox content', () => {
+describe('buildTeamColumn – lossBox content', () => {
   test('lossBox entry contains match details from makeFullContent', () => {
     const { result } = buildColumn([
       makeMatch({
@@ -208,11 +208,11 @@ describe('makeHtmlColumn – lossBox content', () => {
 
 // ─── old-two-points system ─────────────────────────────────────────────────────
 
-describe('makeHtmlColumn – old-two-points system', () => {
+describe('buildTeamColumn – old-two-points system', () => {
   function buildOldColumn(matches: ReturnType<typeof makeMatch>[]) {
     const td = makeTeamData(matches);
     calculateTeamStats(td, TARGET, 'section_no', 'old-two-points');
-    return { result: makeHtmlColumn(TEAM, td, TARGET, false, false, 'old-two-points'), td };
+    return { result: buildTeamColumn(TEAM, td, TARGET, false, false, 'old-two-points'), td };
   }
 
   test('win (2 pt) → medium box', () => {

--- a/frontend/src/__tests__/graph/tooltip.test.ts
+++ b/frontend/src/__tests__/graph/tooltip.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect } from 'vitest';
 import {
   makeWinContent, makePkWinContent, makeDrawContent, makeFullContent,
-  makeTeamStats, joinLossBox, getRankClass, getBright,
+  makeTeamStats, joinLossBox, getRankClass,
 } from '../../graph/tooltip';
+import { getBright } from '../../graph/css-utils';
 import { calculateTeamStats } from '../../ranking/stats-calculator';
 import { makeMatch, makeTeamData, makeSeasonInfo } from '../fixtures/match-data';
 

--- a/frontend/src/__tests__/graph/tooltip.test.ts
+++ b/frontend/src/__tests__/graph/tooltip.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import {
   makeWinContent, makePkWinContent, makeDrawContent, makeFullContent,
-  makeTeamStats, joinLoseBox, getRankClass, getBright,
+  makeTeamStats, joinLossBox, getRankClass, getBright,
 } from '../../graph/tooltip';
 import { calculateTeamStats } from '../../ranking/stats-calculator';
 import { makeMatch, makeTeamData, makeSeasonInfo } from '../fixtures/match-data';
@@ -122,19 +122,19 @@ describe('makeTeamStats', () => {
   });
 });
 
-// ─── joinLoseBox ───────────────────────────────────────────────────────────────
+// ─── joinLossBox ───────────────────────────────────────────────────────────────
 
-describe('joinLoseBox', () => {
+describe('joinLossBox', () => {
   test('joins entries with <hr/>', () => {
-    expect(joinLoseBox(['loss1', 'loss2', 'loss3'])).toBe('loss1<hr/>loss2<hr/>loss3');
+    expect(joinLossBox(['loss1', 'loss2', 'loss3'])).toBe('loss1<hr/>loss2<hr/>loss3');
   });
 
   test('single entry: no <hr/>', () => {
-    expect(joinLoseBox(['only'])).toBe('only');
+    expect(joinLossBox(['only'])).toBe('only');
   });
 
   test('empty array: empty string', () => {
-    expect(joinLoseBox([])).toBe('');
+    expect(joinLossBox([])).toBe('');
   });
 });
 

--- a/frontend/src/__tests__/ranking/rank-table.test.ts
+++ b/frontend/src/__tests__/ranking/rank-table.test.ts
@@ -22,7 +22,7 @@ function makeStatsTeam(opts: {
   goal_get?: number;
   win?: number;
   draw?: number;
-  lose?: number;
+  loss?: number;
   pk_win?: number;
   pk_loss?: number;
   avrg_pt?: number;
@@ -34,7 +34,7 @@ function makeStatsTeam(opts: {
   disp_goal_get?: number;
   disp_win?: number;
   disp_draw?: number;
-  disp_lose?: number;
+  disp_loss?: number;
   disp_pk_win?: number;
   disp_pk_loss?: number;
   disp_avrg_pt?: number;
@@ -62,7 +62,7 @@ function makeStatsTeam(opts: {
     pk_win: opts.pk_win ?? 0,
     pk_loss: opts.pk_loss ?? 0,
     draw: opts.draw ?? 0,
-    lose: opts.lose ?? 0,
+    loss: opts.loss ?? 0,
     avrg_pt: opts.avrg_pt ?? (all_game > 0 ? opts.point / all_game : 0),
     rest_games,
     disp_point: opts.disp_point ?? opts.point,
@@ -74,7 +74,7 @@ function makeStatsTeam(opts: {
     disp_pk_win: opts.disp_pk_win ?? opts.pk_win ?? 0,
     disp_pk_loss: opts.disp_pk_loss ?? opts.pk_loss ?? 0,
     disp_draw: opts.disp_draw ?? opts.draw ?? 0,
-    disp_lose: opts.disp_lose ?? opts.lose ?? 0,
+    disp_loss: opts.disp_loss ?? opts.loss ?? 0,
     disp_avrg_pt: opts.disp_avrg_pt ?? (opts.disp_all_game ?? all_game) > 0
       ? (opts.disp_point ?? opts.point) / (opts.disp_all_game ?? all_game)
       : 0,
@@ -90,9 +90,9 @@ describe('makeRankData – season finished', () => {
 
   const groupData: Record<string, TeamData> = {
     TeamA: makeStatsTeam({ point: 9, avlbl_pt: 9, all_game: 3, win: 3, rest_games: {} }),
-    TeamB: makeStatsTeam({ point: 6, avlbl_pt: 6, all_game: 3, win: 2, lose: 1, rest_games: {} }),
-    TeamC: makeStatsTeam({ point: 3, avlbl_pt: 3, all_game: 3, win: 1, lose: 2, rest_games: {} }),
-    TeamD: makeStatsTeam({ point: 0, avlbl_pt: 0, all_game: 3, lose: 3, rest_games: {} }),
+    TeamB: makeStatsTeam({ point: 6, avlbl_pt: 6, all_game: 3, win: 2, loss: 1, rest_games: {} }),
+    TeamC: makeStatsTeam({ point: 3, avlbl_pt: 3, all_game: 3, win: 1, loss: 2, rest_games: {} }),
+    TeamD: makeStatsTeam({ point: 0, avlbl_pt: 0, all_game: 3, loss: 3, rest_games: {} }),
   };
   const teamList = ['TeamA', 'TeamB', 'TeamC', 'TeamD'];
 
@@ -509,7 +509,7 @@ describe('makeRankData – row shape', () => {
       goal_diff: 3, avrg_pt: 3.0, rest_games: {}, dfLength: 2,
     }),
     TeamB: makeStatsTeam({
-      point: 0, avlbl_pt: 0, all_game: 2, lose: 2, goal_get: 1,
+      point: 0, avlbl_pt: 0, all_game: 2, loss: 2, goal_get: 1,
       goal_diff: -3, avrg_pt: 0.0, rest_games: {}, dfLength: 2,
     }),
   };
@@ -566,7 +566,7 @@ describe('makeRankTable – thead hasPk=false', () => {
     expect(ids).not.toContain('pk_loss');
   });
 
-  test('includes standard columns: rank, name, win, draw, lose, point', () => {
+  test('includes standard columns: rank, name, win, draw, loss, point', () => {
     const table = makeTableEl();
     makeRankTable(table, [], false);
     const ids = getHeaderIds(table);
@@ -574,7 +574,7 @@ describe('makeRankTable – thead hasPk=false', () => {
     expect(ids).toContain('name');
     expect(ids).toContain('win');
     expect(ids).toContain('draw');
-    expect(ids).toContain('lose');
+    expect(ids).toContain('loss');
     expect(ids).toContain('point');
   });
 });

--- a/frontend/src/__tests__/ranking/stats-calculator.test.ts
+++ b/frontend/src/__tests__/ranking/stats-calculator.test.ts
@@ -12,7 +12,7 @@ describe('calculateTeamStats', () => {
       expect(td.point).toBe(3);
       expect(td.win).toBe(1);
       expect(td.draw).toBe(0);
-      expect(td.lose).toBe(0);
+      expect(td.loss).toBe(0);
       expect(td.all_game).toBe(1);
       expect(td.goal_diff).toBe(2);
       expect(td.goal_get).toBe(2);
@@ -26,11 +26,11 @@ describe('calculateTeamStats', () => {
       expect(td.win).toBe(0);
     });
 
-    test('loss: point=0, lose=1', () => {
+    test('loss: point=0, loss=1', () => {
       const td = makeTeamData([makeMatch({ goal_get: '0', goal_lose: '2', point: 0 })]);
       calculateTeamStats(td, TARGET, 'section_no');
       expect(td.point).toBe(0);
-      expect(td.lose).toBe(1);
+      expect(td.loss).toBe(1);
       expect(td.win).toBe(0);
     });
 
@@ -129,16 +129,16 @@ describe('calculateTeamStats', () => {
       expect(td.rest_games).toEqual({}); // completed in latest view
     });
 
-    test('disp_win/disp_draw/disp_lose only count within cutoff', () => {
+    test('disp_win/disp_draw/disp_loss only count within cutoff', () => {
       const td = makeTeamData([
         makeMatch({ goal_get: '2', goal_lose: '0', point: 3, match_date: '2025/03/01', section_no: '1' }), // win, in range
         makeMatch({ goal_get: '0', goal_lose: '1', point: 0, match_date: '2025/04/01', section_no: '2' }), // loss, out of range
       ]);
       calculateTeamStats(td, '2025/03/31', 'section_no');
       expect(td.disp_win).toBe(1);
-      expect(td.disp_lose).toBe(0);
+      expect(td.disp_loss).toBe(0);
       expect(td.win).toBe(1);
-      expect(td.lose).toBe(1);
+      expect(td.loss).toBe(1);
     });
 
     test('disp_avrg_pt differs from avrg_pt when games span the cutoff date', () => {
@@ -246,7 +246,7 @@ describe('classifyResult', () => {
   });
 
   test('standard: 0pt → loss', () => {
-    expect(classifyResult(0, null, 'standard')).toBe('lose');
+    expect(classifyResult(0, null, 'standard')).toBe('loss');
   });
 
   test('old-two-points: 2pt → win', () => {
@@ -258,7 +258,7 @@ describe('classifyResult', () => {
   });
 
   test('old-two-points: 0pt → loss', () => {
-    expect(classifyResult(0, null, 'old-two-points')).toBe('lose');
+    expect(classifyResult(0, null, 'old-two-points')).toBe('loss');
   });
 });
 

--- a/frontend/src/__tests__/storage/local-storage.test.ts
+++ b/frontend/src/__tests__/storage/local-storage.test.ts
@@ -28,29 +28,6 @@ describe('loadPrefs', () => {
     expect(loadPrefs()).toMatchObject({ competition: 'J2', season: '2025' });
   });
 
-  it('migrates legacy category to competition', () => {
-    // Simulate old prefs with numeric category key
-    localStorage.setItem(
-      'jleague_viewer_prefs',
-      JSON.stringify({ category: '1', season: '2025' }),
-    );
-    const prefs = loadPrefs();
-    expect(prefs.competition).toBe('J1');
-    expect(prefs).not.toHaveProperty('category');
-    // Verify migration is persisted
-    const raw = JSON.parse(localStorage.getItem('jleague_viewer_prefs')!);
-    expect(raw.competition).toBe('J1');
-    expect(raw).not.toHaveProperty('category');
-  });
-
-  it('does not overwrite existing competition with legacy category', () => {
-    localStorage.setItem(
-      'jleague_viewer_prefs',
-      JSON.stringify({ category: '2', competition: 'J1' }),
-    );
-    const prefs = loadPrefs();
-    expect(prefs.competition).toBe('J1');
-  });
 });
 
 describe('savePrefs', () => {

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -171,12 +171,12 @@ function populateCompetitionPulldown(seasonMap: SeasonMap): void {
   sel.innerHTML = '';
   const groups = Object.entries(seasonMap);
   const multiGroup = groups.length > 1;
-  for (const [, group] of groups) {
+  for (const [groupKey, group] of groups) {
     if (multiGroup) {
       // Disabled separator showing group name (only when multiple groups exist)
       const sep = document.createElement('option');
       sep.disabled = true;
-      sep.textContent = `── ${group.display_name} `;
+      sep.textContent = `── ${group.display_name ?? groupKey} `;
       sel.appendChild(sep);
     }
 
@@ -238,7 +238,7 @@ function renderFromCache(
   if (!found) return;
   const entry = found.competition.seasons[season];
   if (!entry) return;
-  const seasonInfo = resolveSeasonInfo(found.group, found.competition, entry);
+  const seasonInfo = resolveSeasonInfo(found.group, found.competition, entry, found.groupKey);
 
   const { groupData, sortedTeams } = prepareRenderData({
     groupData: cache.groupData, seasonInfo, targetDate, sortKey, matchSortKey,
@@ -283,7 +283,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
     return;
   }
 
-  const leagueDisplay = resolveSeasonInfo(found.group, found.competition, found.competition.seasons[season]).leagueDisplay;
+  const leagueDisplay = resolveSeasonInfo(found.group, found.competition, found.competition.seasons[season], found.groupKey).leagueDisplay;
 
   writeUrlParams(competition, season);
   savePrefs({ competition, season, targetDate: targetDateRaw, teamSortKey: sortKey, matchSortKey: matchSortUiValue });
@@ -306,7 +306,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
     download: true,
     complete: (results) => {
       const entry = found.competition.seasons[season];
-      const seasonInfo = resolveSeasonInfo(found.group, found.competition, entry);
+      const seasonInfo = resolveSeasonInfo(found.group, found.competition, entry, found.groupKey);
       const teamMap = parseCsvResults(
         results.data,
         results.meta.fields ?? [],

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -20,7 +20,7 @@ import { prepareRenderData } from './core/prepare-render';
 import type { MatchSortKey } from './ranking/stats-calculator';
 import { makeRankData, makeRankTable } from './ranking/rank-table';
 import { renderBarGraph, findSliderIndex } from './graph/renderer';
-import { getHeightUnit, setFutureOpacity, setSpace, setScale } from './graph/css-utils';
+import { DEFAULT_HEIGHT_UNIT, getHeightUnit, setFutureOpacity, setSpace, setScale } from './graph/css-utils';
 import { loadPrefs, savePrefs, clearPrefs } from './storage/local-storage';
 
 // ---- Application state ------------------------------------------------
@@ -44,7 +44,7 @@ const state: AppState = {
   timestampMap: null,
   teamMapCache: null,
   currentMatchDates: [],
-  heightUnit: 20,
+  heightUnit: DEFAULT_HEIGHT_UNIT,
 };
 
 const DEFAULT_COMPETITION = 'J1';
@@ -345,8 +345,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const unit = getHeightUnit();
-  if (unit > 0) state.heightUnit = unit;
+  state.heightUnit = getHeightUnit();
 
   populateCompetitionPulldown(seasonMap);
   populateFixedSelect('team_sort_key', TEAM_SORT_OPTIONS);

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -258,7 +258,7 @@ function renderFromCache(
     resetDateSlider(matchDates, targetDate);
   }
 
-  const rankData = makeRankData(groupData, sortedTeams, seasonInfo, disp);
+  const rankData = makeRankData(groupData, sortedTeams, seasonInfo, disp, cache.hasPk);
   const tableEl = document.getElementById('ranktable');
   if (tableEl) makeRankTable(tableEl, rankData, hasPk);
 }

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -61,6 +61,7 @@ export function resolveSeasonInfo(
   group: GroupEntry,
   comp: CompetitionEntry,
   entry: RawSeasonEntry,
+  groupKey: string = '',
 ): SeasonInfo {
   const opts = entry[4] ?? {};
 
@@ -83,7 +84,8 @@ export function resolveSeasonInfo(
   // Scalars: lowest defined level wins
   const leagueDisplay = opts.league_display
     ?? comp.league_display
-    ?? group.display_name;
+    ?? group.display_name
+    ?? groupKey;
 
   const pointSystem: PointSystem = opts.point_system
     ?? comp.point_system

--- a/frontend/src/core/point-calculator.ts
+++ b/frontend/src/core/point-calculator.ts
@@ -3,14 +3,8 @@
 // Each PointSystem defines a mapping from MatchResult to points awarded.
 // New scoring systems can be added by extending POINT_MAPS.
 
+import { POINT_MAPS } from '../types/config';
 import type { PointSystem } from '../types/config';
-import type { MatchResult } from '../types/match';
-
-/** Points awarded for each match result under each scoring system. */
-const POINT_MAPS: Record<PointSystem, Record<MatchResult, number>> = {
-  'standard':       { win: 3, pk_win: 2, pk_loss: 1, draw: 1, loss: 0 },
-  'old-two-points': { win: 2, pk_win: 1, pk_loss: 1, draw: 1, loss: 0 },
-};
 
 /** Returns the maximum points earnable per game under the given point system. */
 export function getMaxPointsPerGame(ps: PointSystem = 'standard'): number {

--- a/frontend/src/core/point-calculator.ts
+++ b/frontend/src/core/point-calculator.ts
@@ -1,19 +1,25 @@
 // Point calculation logic from match results.
 //
-// Scoring rules vary by PointSystem:
-//   standard:       Win 3 / Draw 1 / Loss 0 / PK-win 2 / PK-loss 1
-//   old-two-points: Win 2 / Draw 1 / Loss 0  (no PK in this system)
+// Each PointSystem defines a mapping from MatchResult to points awarded.
+// New scoring systems can be added by extending POINT_MAPS.
 
 import type { PointSystem } from '../types/config';
+import type { MatchResult } from '../types/match';
+
+/** Points awarded for each match result under each scoring system. */
+const POINT_MAPS: Record<PointSystem, Record<MatchResult, number>> = {
+  'standard':       { win: 3, pk_win: 2, pk_loss: 1, draw: 1, loss: 0 },
+  'old-two-points': { win: 2, pk_win: 1, pk_loss: 1, draw: 1, loss: 0 },
+};
 
 /** Returns the maximum points earnable per game under the given point system. */
 export function getMaxPointsPerGame(ps: PointSystem = 'standard'): number {
-  return ps === 'old-two-points' ? 2 : 3;
+  return POINT_MAPS[ps].win;
 }
 
 /** Returns the points awarded for a win under the given point system. */
 export function getWinPoints(ps: PointSystem = 'standard'): number {
-  return ps === 'old-two-points' ? 2 : 3;
+  return POINT_MAPS[ps].win;
 }
 
 /**
@@ -35,12 +41,12 @@ export function getPointFromResult(
   pointSystem: PointSystem = 'standard',
 ): number {
   if (!(goalGet && goalLose)) return 0;
-  const winPts = getWinPoints(pointSystem);
-  if (goalGet > goalLose) return winPts;
-  if (goalGet < goalLose) return 0;
+  const map = POINT_MAPS[pointSystem];
+  if (goalGet > goalLose) return map.win;
+  if (goalGet < goalLose) return map.loss;
   // Draw after 90 min → determine by PK result
   if (pkGet !== null && pkLose !== null) {
-    return pkGet > pkLose ? winPts - 1 : 1;
+    return pkGet > pkLose ? map.pk_win : map.pk_loss;
   }
-  return 1;
+  return map.draw;
 }

--- a/frontend/src/core/sorter.ts
+++ b/frontend/src/core/sorter.ts
@@ -5,7 +5,7 @@ import type { TeamData } from '../types/match';
 import { getMaxPointsPerGame } from './point-calculator';
 
 // Numeric fields extracted from TeamData for point/relegation line calculations.
-// All fields are guaranteed to exist once makeHtmlColumn has run.
+// All fields are guaranteed to exist once buildTeamColumn has run.
 export interface PointCacheEntry {
   point: number;
   avlbl_pt: number;

--- a/frontend/src/graph/bar-column.ts
+++ b/frontend/src/graph/bar-column.ts
@@ -31,7 +31,7 @@ export interface ColumnResult {
   avlbl_pt: number;
   teamName: string;
   /** Full-match content strings for loss matches (shown in team stats tooltip). */
-  loseBox: string[];
+  lossBox: string[];
   /** Pre-rendered stats HTML for the team name tooltip. */
   stats: string;
   /** Sorted unique YYYY/MM/DD match dates encountered (for the date slider). */
@@ -45,7 +45,7 @@ export interface ColumnResult {
  *   tall (.tall)   – win (3 pt) or any display-future match
  *   medium (.medium) – PK win (2 pt)
  *   short (.short)   – draw / PK loss (1 pt)
- *   (none)           – loss (0 pt) → goes to loseBox only
+ *   (none)           – loss (0 pt) → goes to lossBox only
  *
  * Under old-two-points (2-1-0):
  *   medium (.medium) – win (2 pt) or display-future match
@@ -71,7 +71,7 @@ export function makeHtmlColumn(
   pointSystem: PointSystem = 'standard',
 ): ColumnResult {
   const graph: string[] = [];
-  const loseBox: string[] = [];
+  const lossBox: string[] = [];
   const matchDateSet = new Set<string>();
   const winPt = getWinPoints(pointSystem);
   const futureClass = boxHeightClass(winPt);
@@ -119,12 +119,12 @@ export function makeHtmlColumn(
           + `${statusSuffix}</span></p></div>`,
         );
       } else {
-        // Loss (point === 0): no box; goes to loseBox for the stats tooltip
-        let loseContent = makeFullContent(row, matchDate);
+        // Loss (point === 0): no box; goes to lossBox for the stats tooltip
+        let lossContent = makeFullContent(row, matchDate);
         if (row.live) {
-          loseContent = `<div class="live">${loseContent}${statusSuffix}</div>`;
+          lossContent = `<div class="live">${lossContent}${statusSuffix}</div>`;
         }
-        loseBox.push(loseContent);
+        lossBox.push(lossContent);
       }
     }
   }
@@ -136,7 +136,7 @@ export function makeHtmlColumn(
     graph,
     avlbl_pt,
     teamName,
-    loseBox,
+    lossBox,
     stats: makeTeamStats(teamData, disp, hasPk),
     matchDates: [...matchDateSet].sort(),
   };

--- a/frontend/src/graph/bar-column.ts
+++ b/frontend/src/graph/bar-column.ts
@@ -1,6 +1,6 @@
 // Bar graph column builder: generates box-graph HTML for a single team.
 //
-// Precondition: call calculateTeamStats(teamData, ...) before makeHtmlColumn.
+// Precondition: call calculateTeamStats(teamData, ...) before buildTeamColumn.
 // calculateTeamStats handles stat accumulation and sorts teamData.df in place.
 
 import type { PointSystem } from '../types/config';
@@ -17,13 +17,19 @@ import {
 } from './tooltip';
 
 /** CSS class name for box height based on point value. */
+const BOX_HEIGHT_CLASS: Record<number, string> = {
+  3: 'tall',
+  2: 'medium',
+  1: 'short',
+};
+
 function boxHeightClass(pointValue: number): string {
-  if (pointValue >= 3) return 'tall';
-  if (pointValue === 2) return 'medium';
-  return 'short';
+  const cls = BOX_HEIGHT_CLASS[pointValue];
+  if (!cls) throw new Error(`No CSS height class for point value ${pointValue}`);
+  return cls;
 }
 
-/** Result returned by makeHtmlColumn, consumed by appendSpaceCols (renderer). */
+/** Result returned by buildTeamColumn, consumed by assembleTeamColumn (renderer). */
 export interface ColumnResult {
   /** Box HTML strings in display order (before any reversal by the renderer). */
   graph: string[];
@@ -62,7 +68,7 @@ export interface ColumnResult {
  * @param hasPk      true → PK columns exist in the CSV.
  * @param pointSystem Scoring system.
  */
-export function makeHtmlColumn(
+export function buildTeamColumn(
   teamName: string,
   teamData: TeamData,
   targetDate: string,

--- a/frontend/src/graph/renderer.ts
+++ b/frontend/src/graph/renderer.ts
@@ -7,7 +7,7 @@ import type { TeamData } from '../types/match';
 import type { SeasonInfo } from '../types/season';
 import { makeHtmlColumn } from './bar-column';
 import type { ColumnResult } from './bar-column';
-import { getRankClass, joinLoseBox } from './tooltip';
+import { getRankClass, joinLossBox } from './tooltip';
 
 /** Return value of renderBarGraph, consumed by j_points.ts. */
 export interface RenderResult {
@@ -53,7 +53,7 @@ export function makePointColumn(maxAvblPt: number, bottomFirst: boolean): string
  *
  * Steps:
  *   1. Add a space box at the top (height = (maxAvblPt - col.avlbl_pt) × heightUnit px).
- *   2. If bottomFirst, reverse graph[] and loseBox[].
+ *   2. If bottomFirst, reverse graph[] and lossBox[].
  *   3. Wrap with rank_cell (top/bottom) and team_name tooltip boxes.
  *
  * Returns: <div id="TEAM_column">rank + name + boxes + name + rank</div>
@@ -68,7 +68,7 @@ export function appendSpaceCols(
 ): string {
   // Clone arrays so we don't mutate the original ColumnResult.
   const graph = [...col.graph];
-  const loseBox = [...col.loseBox];
+  const lossBox = [...col.lossBox];
 
   const spaceCols = maxAvblPt - col.avlbl_pt;
   if (spaceCols > 0) {
@@ -77,14 +77,14 @@ export function appendSpaceCols(
 
   if (bottomFirst) {
     graph.reverse();
-    loseBox.reverse();
+    lossBox.reverse();
   }
 
   const rankClass = getRankClass(rank, seasonInfo);
   const rankCell = `<div class="short box ${rankClass}">${rank}</div>`;
   const teamName = `<div class="short box tooltip ${col.teamName}">${col.teamName}`
     + `<span class=" tooltiptext fullW ${col.teamName}">`
-    + `成績情報:<hr/>${col.stats}<hr/>敗戦記録:<hr/>${joinLoseBox(loseBox)}</span></div>\n`;
+    + `成績情報:<hr/>${col.stats}<hr/>敗戦記録:<hr/>${joinLossBox(lossBox)}</span></div>\n`;
 
   return `<div id="${col.teamName}_column">${rankCell}${teamName}${graph.join('')}${teamName}${rankCell}</div>\n\n`;
 }

--- a/frontend/src/graph/tooltip.ts
+++ b/frontend/src/graph/tooltip.ts
@@ -1,4 +1,4 @@
-// Pure HTML-generation helpers: tooltip content, team stats, rank class, and CSS brightness.
+// Pure HTML-generation helpers: tooltip content, team stats, and rank class.
 // None of these functions access the DOM or global state.
 
 import type { TeamData, TeamMatch } from '../types/match';
@@ -59,21 +59,3 @@ export function getRankClass(rank: number, seasonInfo: SeasonInfo): string {
   return '';
 }
 
-/**
- * Calculates perceived brightness of a hex color code with per-channel modifiers.
- * Returns 0.0 (darkest) to 1.0 (brightest). Useful for auto-selecting text color
- * (white on dark, black on light backgrounds).
- */
-export function getBright(
-  colorcode: string,
-  rgbMod: { r?: number; g?: number; b?: number },
-): number {
-  const code = colorcode.startsWith('#') ? colorcode.slice(1) : colorcode;
-  const channelLen = Math.floor(code.length / 3);
-  if (channelLen < 1) return 0;
-  const rgb = [0, 1, 2].map(i => parseInt(code.slice(channelLen * i, channelLen * (i + 1)), 16));
-  const rmod = rgbMod.r ?? 1;
-  const gmod = rgbMod.g ?? 1;
-  const bmod = rgbMod.b ?? 1;
-  return Math.max(rgb[0] * rmod, rgb[1] * gmod, rgb[2] * bmod) / 255;
-}

--- a/frontend/src/graph/tooltip.ts
+++ b/frontend/src/graph/tooltip.ts
@@ -36,7 +36,7 @@ export function makeTeamStats(teamData: TeamData, disp: boolean, hasPk = false):
   const p = (key: string): number =>
     (teamData as unknown as Record<string, number>)[pre + key] ?? 0;
   const pkLine = hasPk ? `${p('pk_win')}PK勝 ${p('pk_loss')}PK負 ` : '';
-  return `${label}<br/>${p('win')}勝 ${pkLine}${p('draw')}分 ${p('lose')}敗<br/>`
+  return `${label}<br/>${p('win')}勝 ${pkLine}${p('draw')}分 ${p('loss')}敗<br/>`
     + `勝点${p('point')}, 最大${p('avlbl_pt')}<br/>`
     + `${p('goal_get')}得点, ${p('goal_get') - p('goal_diff')}失点<br/>`
     + `得失点差: ${p('goal_diff')}`;

--- a/frontend/src/graph/tooltip.ts
+++ b/frontend/src/graph/tooltip.ts
@@ -43,8 +43,8 @@ export function makeTeamStats(teamData: TeamData, disp: boolean, hasPk = false):
 }
 
 /** Joins loss-match content strings with <hr/> dividers. */
-export function joinLoseBox(loseBox: string[]): string {
-  return loseBox.join('<hr/>');
+export function joinLossBox(lossBox: string[]): string {
+  return lossBox.join('<hr/>');
 }
 
 /**

--- a/frontend/src/j_points.html
+++ b/frontend/src/j_points.html
@@ -36,19 +36,13 @@
   <label>
     チーム順:
     <select id="team_sort_key">
-      <option value="disp_point" selected>勝点(表示時)</option>
-      <option value="disp_avlbl_pt">最大勝点(表示時)</option>
-      <option value="point">勝点(最新)</option>
-      <option value="avlbl_pt">最大勝点(最新)</option>
+      <!-- populated by app.ts from TEAM_SORT_OPTIONS -->
     </select>
   </label>
   <label>
     試合順:
     <select id="match_sort_key">
-      <option value="old_bottom" selected>古い試合が下</option>
-      <option value="new_bottom">新しい試合が下</option>
-      <option value="first_bottom">第1節が下</option>
-      <option value="last_bottom">最終節が下</option>
+      <!-- populated by app.ts from MATCH_SORT_OPTIONS -->
     </select>
   </label>
 

--- a/frontend/src/ranking/rank-table.ts
+++ b/frontend/src/ranking/rank-table.ts
@@ -24,7 +24,7 @@ export interface RankRow {
   pk_win?: number;
   pk_loss?: number;
   draw: number;
-  lose: number;
+  loss: number;
   point: number;
   avlbl_pt: number;
   avrg_pt: string;   // toFixed(2) string for display
@@ -96,7 +96,7 @@ export function makeRankData(
         pk_loss:   getTeamAttr(td, 'pk_loss',  disp),
       } : {}),
       draw:        getTeamAttr(td, 'draw',     disp),
-      lose:        getTeamAttr(td, 'lose',     disp),
+      loss:        getTeamAttr(td, 'loss',     disp),
       point,
       avlbl_pt:    avlblPt,
       avrg_pt:     avrgPt.toFixed(2),
@@ -178,7 +178,7 @@ function buildRankTableHead(tableEl: HTMLElement, hasPk: boolean): void {
       { id: 'pk_loss', label: 'PK負', sortable: true as true },
     ] : []),
     { id: 'draw',        label: '分',        sortable: true },
-    { id: 'lose',        label: '負',        sortable: true },
+    { id: 'loss',        label: '負',        sortable: true },
     { id: 'goal_get',    label: '得点',      sortable: true },
     { id: 'goal_lose',   label: '失点',      sortable: true },
     { id: 'goal_diff',   label: '点差',      sortable: true },

--- a/frontend/src/ranking/rank-table.ts
+++ b/frontend/src/ranking/rank-table.ts
@@ -21,8 +21,8 @@ export interface RankRow {
   rank: number;
   name: string;      // HTML string: '<div class="TeamName">TeamName</div>'
   win: number;
-  pk_win: number;
-  pk_loss: number;
+  pk_win?: number;
+  pk_loss?: number;
   draw: number;
   lose: number;
   point: number;
@@ -55,6 +55,7 @@ export function makeRankData(
   teamList: string[],
   seasonInfo: SeasonInfo,
   disp: boolean,
+  hasPk: boolean = false,
 ): RankRow[] {
   const { teamCount, promotionCount, relegationCount } = seasonInfo;
   const relegationRank = teamCount - relegationCount;
@@ -90,8 +91,10 @@ export function makeRankData(
       rank,
       name: `<div class="${teamName}">${teamName}</div>`,
       win:         getTeamAttr(td, 'win',      disp),
-      pk_win:      getTeamAttr(td, 'pk_win',   disp),
-      pk_loss:     getTeamAttr(td, 'pk_loss',  disp),
+      ...(hasPk ? {
+        pk_win:    getTeamAttr(td, 'pk_win',   disp),
+        pk_loss:   getTeamAttr(td, 'pk_loss',  disp),
+      } : {}),
       draw:        getTeamAttr(td, 'draw',     disp),
       lose:        getTeamAttr(td, 'lose',     disp),
       point,

--- a/frontend/src/ranking/stats-calculator.ts
+++ b/frontend/src/ranking/stats-calculator.ts
@@ -2,7 +2,7 @@
 // Populates disp_* and latest fields on TeamData in place.
 
 import type { PointSystem } from '../types/config';
-import type { TeamData, TeamMatch } from '../types/match';
+import type { MatchResult, TeamData, TeamMatch } from '../types/match';
 import { getMaxPointsPerGame, getWinPoints } from '../core/point-calculator';
 
 // Priority for sorting postponed/future matches (lower = earlier in graph display).
@@ -40,18 +40,18 @@ export function sortTeamMatches(
 }
 
 /**
- * Classifies a match result into win/pk_win/pk_loss/draw/lose.
+ * Classifies a match result into win/pk_win/pk_loss/draw/loss.
  * Returns TeamData field names so the result can be used to index stat counters.
  */
 export function classifyResult(
   point: number, pkGet: number | null, pointSystem: PointSystem,
-): 'win' | 'pk_win' | 'pk_loss' | 'draw' | 'lose' {
+): MatchResult {
   const winPt = getWinPoints(pointSystem);
   if (point >= winPt) return 'win';
   if (point >= 2 && pkGet !== null) return 'pk_win';
   if (point === 1 && pkGet !== null) return 'pk_loss';
   if (point === 1) return 'draw';
-  return 'lose';
+  return 'loss';
 }
 
 // Initializes all stat fields on teamData and accumulates them from teamData.df.
@@ -73,7 +73,7 @@ export function calculateTeamStats(
   teamData.win = 0;
   teamData.pk_win = 0;
   teamData.pk_loss = 0;
-  teamData.lose = 0;
+  teamData.loss = 0;
   teamData.draw = 0;
   teamData.all_game = 0;
   teamData.rest_games = {};
@@ -86,7 +86,7 @@ export function calculateTeamStats(
   teamData.disp_win = 0;
   teamData.disp_pk_win = 0;
   teamData.disp_pk_loss = 0;
-  teamData.disp_lose = 0;
+  teamData.disp_loss = 0;
   teamData.disp_draw = 0;
   teamData.disp_all_game = 0;
   teamData.disp_rest_games = {};

--- a/frontend/src/storage/local-storage.ts
+++ b/frontend/src/storage/local-storage.ts
@@ -16,27 +16,11 @@ export interface ViewerPrefs {
   scale?: string;
 }
 
-// Legacy prefs stored `category` (numeric string like "1") instead of
-// `competition` (key like "J1").  Detect and migrate on first load.
-interface LegacyPrefs extends ViewerPrefs {
-  category?: string;
-}
-
-const CATEGORY_TO_COMPETITION: Record<string, string> = {
-  '1': 'J1', '2': 'J2', '3': 'J3',
-};
-
 export function loadPrefs(): ViewerPrefs {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return {};
-    const parsed = JSON.parse(raw) as LegacyPrefs;
-    if (parsed.category && !parsed.competition) {
-      parsed.competition = CATEGORY_TO_COMPETITION[parsed.category] ?? parsed.category;
-      delete parsed.category;
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed));
-    }
-    return parsed;
+    return JSON.parse(raw) as ViewerPrefs;
   } catch {
     return {};
   }

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -1,10 +1,12 @@
-// Types for competition configuration.
+// Types and constants for competition configuration.
 
-// Points calculation rule.
-// PK win/loss is detected automatically from the presence of
-// home_pk_score/away_pk_score columns in the CSV, so it is not included here.
-// Head-to-head tiebreaking is configured via tiebreak_order, not PointSystem.
-export type PointSystem =
-  | 'standard'        // win 3 / draw 1 / loss 0  (standard J.League rule)
-  | 'old-two-points'  // win 2 / draw 1 / loss 0  (pre-1995 world football)
-  ;
+import type { MatchResult } from './match';
+
+/** Points awarded for each match result under each scoring system. */
+export const POINT_MAPS = {
+  'standard':       { win: 3, pk_win: 2, pk_loss: 1, draw: 1, loss: 0 },
+  'old-two-points': { win: 2, pk_win: 1, pk_loss: 1, draw: 1, loss: 0 },
+} satisfies Record<string, Record<MatchResult, number>>;
+
+// Derived from POINT_MAPS keys. To add a new scoring system, add an entry above.
+export type PointSystem = keyof typeof POINT_MAPS;

--- a/frontend/src/types/match.ts
+++ b/frontend/src/types/match.ts
@@ -46,8 +46,12 @@ export interface TeamMatch {
   live: boolean;
 }
 
-// Aggregated statistics written onto TeamData by make_html_column.
-// All fields are optional because they do not exist until make_html_column runs.
+// Classification of a single match result.
+// Used as both classifyResult() return type and TeamStats counter field names.
+export type MatchResult = 'win' | 'pk_win' | 'pk_loss' | 'draw' | 'loss';
+
+// Aggregated statistics written onto TeamData by calculateTeamStats.
+// All fields are optional because they do not exist until calculateTeamStats runs.
 export interface TeamStats {
   point?: number;
   avlbl_pt?: number;
@@ -60,13 +64,13 @@ export interface TeamStats {
   win?: number;
   pk_win?: number;
   pk_loss?: number;
-  lose?: number;
+  loss?: number;
   draw?: number;
   all_game?: number;
   disp_win?: number;
   disp_pk_win?: number;
   disp_pk_loss?: number;
-  disp_lose?: number;
+  disp_loss?: number;
   disp_draw?: number;
   disp_all_game?: number;
   rest_games?: Record<string, number>;      // opponent → remaining matches

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -47,21 +47,15 @@ export type RawSeasonEntry = [
 ];
 
 // A single competition within a group (e.g., J1 within jleague).
-export interface CompetitionEntry {
-  league_display?: string;
-  css_files?: string[];
-  point_system?: PointSystem;
-  team_rename_map?: Record<string, string>;
-  tiebreak_order?: string[];
-  season_start_month?: number;
+// Extends SeasonEntryOptions because cascade allows any option at this level.
+export interface CompetitionEntry extends SeasonEntryOptions {
   seasons: Record<string, RawSeasonEntry>;
 }
 
 // A top-level group (e.g., jleague, international).
-export interface GroupEntry {
-  display_name: string;
-  css_files?: string[];
-  season_start_month?: number;
+// Extends SeasonEntryOptions because cascade allows any option at this level.
+export interface GroupEntry extends SeasonEntryOptions {
+  display_name?: string;  // defaults to group key when omitted
   competitions: Record<string, CompetitionEntry>;
 }
 


### PR DESCRIPTION
## Summary

Closes #91

Design-level review and cleanup of all TypeScript frontend files, following the same approach as the Python cleanup (#89/#90).

### Changes (11 commits)

- **Type safety**: Add `MatchResult` type, rename `lose` → `loss` across types/graph/ranking/tests, make `RankRow` `pk_win`/`pk_loss` optional
- **Declarative config**: Replace point calculation branching with `POINT_MAPS` lookup, consolidate into `config.ts` with `PointSystem` derived via `keyof typeof`
- **Type hierarchy**: `GroupEntry`/`CompetitionEntry` inherit `SeasonEntryOptions`, `display_name` optional with `groupKey` fallback
- **Graph refactoring**: Rename functions for clarity (`buildTeamColumn`, `getScaleColumnPositions`, `assembleTeamColumn`), replace permissive `boxHeightClass` with strict map + error
- **Code organization**: Move `getBright` to `css-utils`, extract `DEFAULT_HEIGHT_UNIT` constant, move fixed dropdown options from HTML to TS constants
- **Cleanup**: Remove legacy `category→competition` localStorage migration, trim CLAUDE.md

### Not changed (documented for future work)

- `cssFiles` dynamic loading (needed at M1-C / ACL GS integration)
- i18n of Japanese string literals (roadmap item 6)
- `csv-parser.ts` field type inconsistencies (tied to TeamStats class refactoring)
- `sorter.ts` `avlbl_pt` tiebreak order fix (requires spec design first)

## Test plan

- [x] `npx vitest run` — 290 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run build` — builds successfully
- [x] All TS + HTML files reviewed


🤖 Generated with [Claude Code](https://claude.com/claude-code)