### PR TITLE
Integrate multi-group display and international competitions

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -31,6 +31,7 @@ Classify the change set into one of:
 | **Trivial** | CLAUDE.md / README update, CSS color addition, single test addition, config tweak | Commit directly to `main`, no Issue/PR needed |
 | **Single-commit fix** | One logical change, 1-3 files, self-contained | May go to `main` or a branch — ask if unclear |
 | **Multi-commit work** | 2+ logical steps, or part of an ongoing series | Needs a branch. If no Issue exists, suggest creating one |
+| **Sub-issue** | Part of a larger milestone; a parent feature branch exists | Sub-branch → PR to **parent branch** (not `main`). Parent branch's PR handles the merge to `main` |
 
 ## Step 3 — Branch Validation
 
@@ -41,6 +42,19 @@ Check whether the current branch is appropriate:
 - **On a feature/fix/refactor branch**: Verify the changes match the branch's purpose. Warn if they seem unrelated.
 
 If the user needs to switch branches, offer to do it (stashing if needed).
+
+### Parent Branch Detection
+
+When on a feature/fix/refactor branch, check whether it was branched from another feature branch (not `main`):
+
+1. `MAIN_BASE=$(git merge-base main HEAD)`
+2. For each local branch (excluding `main` and current): `BRANCH_BASE=$(git merge-base <branch> HEAD)`
+3. If `BRANCH_BASE` differs from `MAIN_BASE` (i.e., BRANCH_BASE is a descendant of MAIN_BASE), that branch is the **parent branch**
+
+If a parent branch is detected, confirm with the user:
+> "This branch appears to be based on `<parent-branch>` (not `main`). Should the PR target `<parent-branch>`?"
+
+Store the confirmed parent branch as the PR base for Step 7. If no parent branch is found, the PR base is `main`.
 
 ### Branch Naming
 
@@ -144,33 +158,63 @@ If a pre-commit hook fails: fix the issue, re-stage, and create a **new** commit
 After committing, if on a feature/fix/refactor branch and the work appears complete, suggest:
 
 1. **Push**: `git push -u origin {branch}`
-2. **Create PR** using the project's PR format:
-   ```
-   gh pr create --title "..." --body "$(cat <<'EOF'
-   Fixes #{N}
+2. **Determine PR base** (from Step 3 parent branch detection):
+   - Parent branch detected → `--base <parent-branch>`
+   - No parent branch → `--base main` (default, omit the flag)
+3. **Create PR** using the project's PR format:
 
-   ## Summary
-   [Japanese bullet points — what was done and why]
+**PR targeting `main`** (no parent branch):
+```
+gh pr create --title "..." --body "$(cat <<'EOF'
+Fixes #{N}
 
-   ## Changes
-   | Commit | Description |
-   |--------|-------------|
-   | `abc1234` | ... |
+## Summary
+[Japanese bullet points — what was done and why]
 
-   ## Test plan
-   - [ ] `uv run pytest` passed
-   - [ ] `npx vitest run` passed (frontend/)
-   - [ ] `npm run build` succeeded (frontend/)
+## Changes
+| Commit | Description |
+|--------|-------------|
+| `abc1234` | ... |
 
+## Test plan
+- [ ] `uv run pytest` passed
+- [ ] `npx vitest run` passed (frontend/)
+- [ ] `npm run build` succeeded (frontend/)
 
-   🤖 Generated with [Claude Code](https://claude.com/claude-code)
-   EOF
-   )"
-   ```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**PR targeting a parent branch** (sub-issue work):
+```
+gh pr create --title "..." --base <parent-branch> --body "$(cat <<'EOF'
+Refs #{sub-issue-N}
+
+> このPRは `<parent-branch>` への統合PRです。`main` への統合は親Issue #N の完了PRで行います。
+
+## Summary
+[Japanese bullet points — what was done and why]
+
+## Changes
+| Commit | Description |
+|--------|-------------|
+| `abc1234` | ... |
+
+## Test plan
+- [ ] `uv run pytest` passed
+- [ ] `npx vitest run` passed (frontend/)
+- [ ] `npm run build` succeeded (frontend/)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
 
 PR conventions:
 - **Title**: English, concise (< 70 chars)
-- **`Fixes #N`**: At the top of the body to auto-close the Issue
+- **`Fixes #N`**: Use only when the PR directly closes the Issue AND targets `main`. For sub-issue PRs targeting a parent branch, use `Refs #N` instead
+- **`--base`**: Always specify when not targeting `main`
 - **Summary**: Japanese bullet points (日本語)
 - **Changes**: Commit table or category breakdown
 - **Test plan**: Checklist with `- [x]` for passed, `- [ ]` for pending

--- a/docs/json/season_map.json
+++ b/docs/json/season_map.json
@@ -276,7 +276,7 @@
           "2026": [6, 0, 0,
             [],
             {"shown_groups": ["C"]}],
-          "2022": [12, 0, 0,
+          "2022": [6, 0, 0,
             [],
             {"shown_groups": ["A", "B"]}]
         }
@@ -284,6 +284,10 @@
       "Olympic_GS": {
         "league_display": "オリンピック GS",
         "shown_groups": ["A", "B"],
+        "cross_group_standing": {
+          "position": 3,
+          "advance_count": 2
+        },
         "team_rename_map": {
           "ホンジュラス": "ホンジュラ",
           "ニュージーランド": "ニュージー",
@@ -293,7 +297,46 @@
           "コートジボワール": "コートジボ"
         },
         "seasons": {
-          "2021": [16, 0, 0,
+          "2021": [4, 0, 0,
+            []]
+        }
+      }
+    }
+  },
+  "acl": {
+    "display_name": "ACL",
+    "css_files": ["team_style.css"],
+    "season_start_month": 1,
+    "competitions": {
+      "ACL_GS": {
+        "league_display": "ACL GS",
+        "tiebreak_order": ["head_to_head", "goal_diff", "goal_get"],
+        "shown_groups": ["F", "G", "H", "I", "J"],
+        "cross_group_standing": {
+          "position": 2,
+          "exclude_from_rank": 4,
+          "advance_count": 3
+        },
+        "team_rename_map": {
+          "ユナイテッドシティ": "UCFC",
+          "タンピネス": "タンピ",
+          "ポートFC": "ポート",
+          "チェンライU": "チェン",
+          "ラーチャブリー": "ラチャ",
+          "ベトテル": "Viettel",
+          "パトゥムユナイテッド": "パトゥ",
+          "全北現代": "全北",
+          "ホアンアインザライ": "ホアン",
+          "山東泰山": "山東",
+          "セーラーズ": "セーラ",
+          "メルボルンシティ": "メルボ",
+          "シドニーFC": "シドニ"
+        },
+        "seasons": {
+          "2022": [4, 0, 0,
+            [],
+            {"group_team_count": {"J": 3}}],
+          "2021": [4, 0, 0,
             []]
         }
       }

--- a/frontend/src/__tests__/ranking/cross-group.test.ts
+++ b/frontend/src/__tests__/ranking/cross-group.test.ts
@@ -1,0 +1,340 @@
+import { describe, test, expect } from 'vitest';
+import { buildCrossGroupRows } from '../../ranking/rank-table';
+import type { GroupRenderResult } from '../../ranking/rank-table';
+import type { CrossGroupStanding } from '../../types/season';
+import { TeamStats } from '../../types/match';
+import type { TeamData, TeamMatch } from '../../types/match';
+
+// ---- Test helpers --------------------------------------------------------
+
+function makeMatch(overrides: Partial<TeamMatch> = {}): TeamMatch {
+  return {
+    is_home: true, opponent: 'Opp', goal_get: 2, goal_lose: 1,
+    pk_get: null, pk_lose: null, score_ex_get: null, score_ex_lose: null,
+    has_result: true, point: 3, match_date: '2022/04/01', section_no: 1,
+    stadium: 'Stadium', start_time: '15:00', status: '試合終了', live: false,
+    ...overrides,
+  };
+}
+
+/** Build a TeamData with pre-populated latestStats (bypasses calculateTeamStats). */
+function buildTeamData(
+  stats: { point: number; avlbl_pt: number; all_game: number;
+    goal_diff?: number; goal_get?: number;
+    win?: number; draw?: number; loss?: number },
+  matches: TeamMatch[] = [],
+): TeamData {
+  const s = new TeamStats();
+  s.point = stats.point; s.avlbl_pt = stats.avlbl_pt; s.all_game = stats.all_game;
+  s.goal_diff = stats.goal_diff ?? 0; s.goal_get = stats.goal_get ?? 0;
+  s.resultCounts.win = stats.win ?? 0;
+  s.resultCounts.draw = stats.draw ?? 0;
+  s.resultCounts.loss = stats.loss ?? 0;
+  s.avrg_pt = stats.all_game > 0 ? stats.point / stats.all_game : 0;
+  // displayStats = latestStats copy for simplicity
+  const d = new TeamStats();
+  Object.assign(d, { ...s, resultCounts: { ...s.resultCounts } });
+  return { df: matches, latestStats: s, displayStats: d };
+}
+
+// ---- Tests ---------------------------------------------------------------
+
+describe('buildCrossGroupRows', () => {
+  // 3 groups × 4 teams, standard 3pt system.
+  // Sorted teams per group: [1st, 2nd, 3rd, 4th].
+  function makeThreeGroupResults(): Record<string, GroupRenderResult> {
+    return {
+      A: {
+        sortedTeams: ['A1', 'A2', 'A3', 'A4'],
+        groupData: {
+          A1: buildTeamData({ point: 9, avlbl_pt: 9, all_game: 3, win: 3, goal_diff: 5, goal_get: 7 }),
+          A2: buildTeamData({ point: 6, avlbl_pt: 6, all_game: 3, win: 2, loss: 1, goal_diff: 2, goal_get: 5 }),
+          A3: buildTeamData({ point: 3, avlbl_pt: 3, all_game: 3, win: 1, loss: 2, goal_diff: -1, goal_get: 3 }),
+          A4: buildTeamData({ point: 0, avlbl_pt: 0, all_game: 3, loss: 3, goal_diff: -6, goal_get: 1 }),
+        },
+      },
+      B: {
+        sortedTeams: ['B1', 'B2', 'B3', 'B4'],
+        groupData: {
+          B1: buildTeamData({ point: 7, avlbl_pt: 7, all_game: 3, win: 2, draw: 1, goal_diff: 4, goal_get: 6 }),
+          B2: buildTeamData({ point: 5, avlbl_pt: 5, all_game: 3, win: 1, draw: 2, goal_diff: 1, goal_get: 4 }),
+          B3: buildTeamData({ point: 4, avlbl_pt: 4, all_game: 3, win: 1, draw: 1, loss: 1, goal_diff: 0, goal_get: 3 }),
+          B4: buildTeamData({ point: 0, avlbl_pt: 0, all_game: 3, loss: 3, goal_diff: -5, goal_get: 2 }),
+        },
+      },
+      C: {
+        sortedTeams: ['C1', 'C2', 'C3', 'C4'],
+        groupData: {
+          C1: buildTeamData({ point: 9, avlbl_pt: 9, all_game: 3, win: 3, goal_diff: 6, goal_get: 8 }),
+          C2: buildTeamData({ point: 4, avlbl_pt: 4, all_game: 3, win: 1, draw: 1, loss: 1, goal_diff: 0, goal_get: 3 }),
+          C3: buildTeamData({ point: 3, avlbl_pt: 3, all_game: 3, win: 1, loss: 2, goal_diff: -2, goal_get: 2 }),
+          C4: buildTeamData({ point: 1, avlbl_pt: 1, all_game: 3, draw: 1, loss: 2, goal_diff: -4, goal_get: 1 }),
+        },
+      },
+    };
+  }
+
+  test('extracts 2nd-place teams and sorts by points desc', () => {
+    const results = makeThreeGroupResults();
+    const config: CrossGroupStanding = { position: 2 };
+    const rows = buildCrossGroupRows(results, config, false, '9999/12/31', 3);
+
+    expect(rows).toHaveLength(3);
+    // A2: 6pt, B2: 5pt, C2: 4pt
+    expect(rows[0].rank).toBe('A');
+    expect(rows[0].point).toBe(6);
+    expect(rows[1].rank).toBe('B');
+    expect(rows[1].point).toBe(5);
+    expect(rows[2].rank).toBe('C');
+    expect(rows[2].point).toBe(4);
+  });
+
+  test('sorts by goal_diff then goal_get when points tied', () => {
+    const results = makeThreeGroupResults();
+    // Make B2 and C2 same points, different goal_diff
+    results.B.groupData.B2 = buildTeamData({
+      point: 4, avlbl_pt: 4, all_game: 3, win: 1, draw: 1, loss: 1,
+      goal_diff: -1, goal_get: 2,
+    });
+    // C2 already has point=4, goal_diff=0, goal_get=3
+    const config: CrossGroupStanding = { position: 2 };
+    const rows = buildCrossGroupRows(results, config, false, '9999/12/31', 3);
+
+    // A2: 6pt, then C2: 4pt/gd=0 before B2: 4pt/gd=-1
+    expect(rows[0].rank).toBe('A');
+    expect(rows[1].rank).toBe('C');
+    expect(rows[2].rank).toBe('B');
+  });
+
+  test('skips group when position exceeds team count', () => {
+    const results = makeThreeGroupResults();
+    // Group C has only 2 teams
+    results.C.sortedTeams = ['C1', 'C2'];
+    const config: CrossGroupStanding = { position: 3 };
+    const rows = buildCrossGroupRows(results, config, false, '9999/12/31', 3);
+
+    // Only A3 and B3
+    expect(rows).toHaveLength(2);
+    expect(rows.map(r => r.rank).sort()).toEqual(['A', 'B']);
+  });
+
+  test('populates all BaseRankRow fields', () => {
+    const results = makeThreeGroupResults();
+    const config: CrossGroupStanding = { position: 2 };
+    const rows = buildCrossGroupRows(results, config, false, '9999/12/31', 3);
+    const a2 = rows.find(r => r.rank === 'A')!;
+
+    expect(a2.point).toBe(6);
+    expect(a2.win).toBe(2);
+    expect(a2.draw).toBe(0);
+    expect(a2.loss).toBe(1);
+    expect(a2.goal_diff).toBe(2);
+    expect(a2.goal_get).toBe(5);
+    expect(a2.goal_lose).toBe(3); // goal_get - goal_diff
+    expect(a2.all_game).toBe(3);
+    expect(a2.avrg_pt).toBe('2.00');
+    expect(a2.name).toContain('A2');
+  });
+
+  // ---- exclude_from_rank tests ----
+
+  test('exclude_from_rank=4 recalculates stats without 4th-place matches', () => {
+    // Build group with real match data for the 2nd-place team
+    const a2Matches: TeamMatch[] = [
+      // vs A1: loss (0-2)
+      makeMatch({ opponent: 'A1', goal_get: 0, goal_lose: 2, point: 0 }),
+      // vs A3: win (3-1)
+      makeMatch({ opponent: 'A3', goal_get: 3, goal_lose: 1, point: 3 }),
+      // vs A4: win (4-0) — this should be excluded
+      makeMatch({ opponent: 'A4', goal_get: 4, goal_lose: 0, point: 3 }),
+    ];
+    const results: Record<string, GroupRenderResult> = {
+      A: {
+        sortedTeams: ['A1', 'A2', 'A3', 'A4'],
+        groupData: {
+          A1: buildTeamData({ point: 9, avlbl_pt: 9, all_game: 3, win: 3 }),
+          A2: buildTeamData({ point: 6, avlbl_pt: 6, all_game: 3, win: 2, loss: 1 }, a2Matches),
+          A3: buildTeamData({ point: 3, avlbl_pt: 3, all_game: 3, win: 1, loss: 2 }),
+          A4: buildTeamData({ point: 0, avlbl_pt: 0, all_game: 3, loss: 3 }),
+        },
+      },
+    };
+    const config: CrossGroupStanding = { position: 2, exclude_from_rank: 4 };
+    const rows = buildCrossGroupRows(results, config, false, '9999/12/31', 3);
+
+    expect(rows).toHaveLength(1);
+    const a2 = rows[0];
+    // Without A4 match: 1 loss (vs A1) + 1 win (vs A3) = 3pt, 2 games
+    expect(a2.point).toBe(3);
+    expect(a2.all_game).toBe(2);
+    expect(a2.win).toBe(1);
+    expect(a2.loss).toBe(1);
+    expect(a2.goal_get).toBe(3);  // 0 + 3 = 3 (A4 match excluded)
+    expect(a2.goal_lose).toBe(3); // 2 + 1 = 3
+    expect(a2.goal_diff).toBe(0);
+    expect(a2.future_game).toBe(0);
+  });
+
+  test('no exclude_from_rank uses pre-calculated stats', () => {
+    const a2Matches: TeamMatch[] = [
+      makeMatch({ opponent: 'A1', goal_get: 0, goal_lose: 2, point: 0 }),
+      makeMatch({ opponent: 'A3', goal_get: 3, goal_lose: 1, point: 3 }),
+      makeMatch({ opponent: 'A4', goal_get: 4, goal_lose: 0, point: 3 }),
+    ];
+    const results: Record<string, GroupRenderResult> = {
+      A: {
+        sortedTeams: ['A1', 'A2', 'A3', 'A4'],
+        groupData: {
+          A1: buildTeamData({ point: 9, avlbl_pt: 9, all_game: 3, win: 3 }),
+          A2: buildTeamData(
+            { point: 6, avlbl_pt: 6, all_game: 3, win: 2, loss: 1, goal_get: 7, goal_diff: 4 },
+            a2Matches,
+          ),
+          A3: buildTeamData({ point: 3, avlbl_pt: 3, all_game: 3, win: 1, loss: 2 }),
+          A4: buildTeamData({ point: 0, avlbl_pt: 0, all_game: 3, loss: 3 }),
+        },
+      },
+    };
+    const config: CrossGroupStanding = { position: 2 };
+    const rows = buildCrossGroupRows(results, config, false, '9999/12/31', 3);
+
+    // Uses latestStats, not recalculated from df
+    expect(rows[0].point).toBe(6);
+    expect(rows[0].all_game).toBe(3);
+    expect(rows[0].goal_get).toBe(7);
+  });
+
+  test('exclude_from_rank skips exclusion for groups with fewer teams than the rank', () => {
+    // Group A: 4 teams → exclude 4th (A4)
+    // Group B: 3 teams (withdrawal) → no rank 4 → no exclusion
+    const a2Matches: TeamMatch[] = [
+      makeMatch({ opponent: 'A1', goal_get: 0, goal_lose: 2, point: 0 }),
+      makeMatch({ opponent: 'A3', goal_get: 3, goal_lose: 1, point: 3 }),
+      makeMatch({ opponent: 'A4', goal_get: 4, goal_lose: 0, point: 3 }),
+    ];
+    const b2Matches: TeamMatch[] = [
+      makeMatch({ opponent: 'B1', goal_get: 1, goal_lose: 2, point: 0 }),
+      makeMatch({ opponent: 'B3', goal_get: 2, goal_lose: 0, point: 3 }),
+    ];
+    const results: Record<string, GroupRenderResult> = {
+      A: {
+        sortedTeams: ['A1', 'A2', 'A3', 'A4'],
+        groupData: {
+          A1: buildTeamData({ point: 9, avlbl_pt: 9, all_game: 3, win: 3 }),
+          A2: buildTeamData({ point: 6, avlbl_pt: 6, all_game: 3, win: 2, loss: 1 }, a2Matches),
+          A3: buildTeamData({ point: 3, avlbl_pt: 3, all_game: 3, win: 1, loss: 2 }),
+          A4: buildTeamData({ point: 0, avlbl_pt: 0, all_game: 3, loss: 3 }),
+        },
+      },
+      B: {
+        sortedTeams: ['B1', 'B2', 'B3'],
+        groupData: {
+          B1: buildTeamData({ point: 6, avlbl_pt: 6, all_game: 2, win: 2 }),
+          B2: buildTeamData({ point: 3, avlbl_pt: 3, all_game: 2, win: 1, loss: 1, goal_get: 3, goal_diff: 1 }, b2Matches),
+          B3: buildTeamData({ point: 0, avlbl_pt: 0, all_game: 2, loss: 2 }),
+        },
+      },
+    };
+    const config: CrossGroupStanding = { position: 2, exclude_from_rank: 4 };
+    const rows = buildCrossGroupRows(results, config, false, '9999/12/31', 3);
+
+    expect(rows).toHaveLength(2);
+
+    const a2 = rows.find(r => r.rank === 'A')!;
+    // Group A (4 teams): rank 4 excluded → recalc without A4
+    expect(a2.all_game).toBe(2);
+    expect(a2.point).toBe(3); // vs A1 loss + vs A3 win
+
+    const b2 = rows.find(r => r.rank === 'B')!;
+    // Group B (3 teams): no rank 4 → uses all matches (pre-calculated stats)
+    expect(b2.all_game).toBe(2);
+    expect(b2.point).toBe(3); // vs B1 loss + vs B3 win (all included)
+    expect(b2.goal_get).toBe(3); // 1 + 2 = 3
+  });
+
+  test('exclude_from_rank with unplayed matches counts them as future', () => {
+    const a2Matches: TeamMatch[] = [
+      makeMatch({ opponent: 'A1', goal_get: 0, goal_lose: 2, point: 0 }),
+      makeMatch({ opponent: 'A3', goal_get: 3, goal_lose: 1, point: 3 }),
+      // vs A4: unplayed — should be excluded entirely
+      makeMatch({ opponent: 'A4', has_result: false, goal_get: null, goal_lose: null, point: 0 }),
+      // vs A3: unplayed — should remain as future
+      makeMatch({ opponent: 'A3', has_result: false, goal_get: null, goal_lose: null, point: 0 }),
+    ];
+    const results: Record<string, GroupRenderResult> = {
+      A: {
+        sortedTeams: ['A1', 'A2', 'A3', 'A4'],
+        groupData: {
+          A1: buildTeamData({ point: 9, avlbl_pt: 9, all_game: 3, win: 3 }),
+          A2: buildTeamData({ point: 3, avlbl_pt: 9, all_game: 2, win: 1, loss: 1 }, a2Matches),
+          A3: buildTeamData({ point: 3, avlbl_pt: 3, all_game: 3, win: 1, loss: 2 }),
+          A4: buildTeamData({ point: 0, avlbl_pt: 0, all_game: 3, loss: 3 }),
+        },
+      },
+    };
+    const config: CrossGroupStanding = { position: 2, exclude_from_rank: 4 };
+    const rows = buildCrossGroupRows(results, config, false, '9999/12/31', 3);
+
+    const a2 = rows[0];
+    expect(a2.all_game).toBe(2);     // 2 played (vs A1, A3)
+    expect(a2.future_game).toBe(1);  // 1 unplayed vs A3 (A4 match removed)
+    expect(a2.avlbl_pt).toBe(6);     // 3 + 1*3
+  });
+
+  test('disp mode filters by targetDate in recalc', () => {
+    const a2Matches: TeamMatch[] = [
+      makeMatch({ opponent: 'A1', goal_get: 0, goal_lose: 2, point: 0, match_date: '2022/04/01' }),
+      makeMatch({ opponent: 'A3', goal_get: 3, goal_lose: 1, point: 3, match_date: '2022/05/01' }),
+      makeMatch({ opponent: 'A4', goal_get: 2, goal_lose: 0, point: 3, match_date: '2022/04/10' }),
+    ];
+    const results: Record<string, GroupRenderResult> = {
+      A: {
+        sortedTeams: ['A1', 'A2', 'A3', 'A4'],
+        groupData: {
+          A1: buildTeamData({ point: 9, avlbl_pt: 9, all_game: 3, win: 3 }),
+          A2: buildTeamData({ point: 6, avlbl_pt: 6, all_game: 3, win: 2, loss: 1 }, a2Matches),
+          A3: buildTeamData({ point: 3, avlbl_pt: 3, all_game: 3, win: 1, loss: 2 }),
+          A4: buildTeamData({ point: 0, avlbl_pt: 0, all_game: 3, loss: 3 }),
+        },
+      },
+    };
+    const config: CrossGroupStanding = { position: 2, exclude_from_rank: 4 };
+
+    // A4 excluded by rank. Remaining: vs A1 (04/01), vs A3 (05/01).
+    // In disp mode with targetDate='2022/04/15':
+    // vs A1 (04/01) → played → point=0, goal 0-2, loss
+    // vs A3 (05/01) → future
+    const rows = buildCrossGroupRows(results, config, true, '2022/04/15', 3);
+    const a2 = rows[0];
+    expect(a2.all_game).toBe(1);
+    expect(a2.point).toBe(0);
+    expect(a2.future_game).toBe(1);
+  });
+
+  test('match_date "未定" treated as unplayed even with has_result', () => {
+    const a2Matches: TeamMatch[] = [
+      makeMatch({ opponent: 'A1', goal_get: 1, goal_lose: 0, point: 3 }),
+      makeMatch({ opponent: 'A3', goal_get: 2, goal_lose: 2, point: 1, match_date: '未定', has_result: true }),
+      makeMatch({ opponent: 'A4', goal_get: 3, goal_lose: 0, point: 3 }),
+    ];
+    const results: Record<string, GroupRenderResult> = {
+      A: {
+        sortedTeams: ['A1', 'A2', 'A3', 'A4'],
+        groupData: {
+          A1: buildTeamData({ point: 9, avlbl_pt: 9, all_game: 3, win: 3 }),
+          A2: buildTeamData({ point: 7, avlbl_pt: 7, all_game: 3, win: 2, draw: 1 }, a2Matches),
+          A3: buildTeamData({ point: 1, avlbl_pt: 1, all_game: 3, draw: 1, loss: 2 }),
+          A4: buildTeamData({ point: 0, avlbl_pt: 0, all_game: 3, loss: 3 }),
+        },
+      },
+    };
+    const config: CrossGroupStanding = { position: 2, exclude_from_rank: 4 };
+    const rows = buildCrossGroupRows(results, config, false, '9999/12/31', 3);
+
+    // A4 excluded by rank. Remaining: vs A1 (win, 3pt), vs A3 (未定 → unplayed)
+    // 未定 match treated as future regardless of has_result
+    expect(rows[0].all_game).toBe(1);
+    expect(rows[0].point).toBe(3);
+    expect(rows[0].future_game).toBe(1);
+  });
+});

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -18,7 +18,12 @@ import { parseCsvResults } from './core/csv-parser';
 import { dateFormat } from './core/date-utils';
 import { prepareRenderData } from './core/prepare-render';
 import type { MatchSortKey } from './ranking/stats-calculator';
-import { makeRankData, makeRankTable } from './ranking/rank-table';
+import {
+  makeRankData, makeRankTable,
+  buildCrossGroupRows, makeCrossGroupTable,
+} from './ranking/rank-table';
+import type { GroupRenderResult } from './ranking/rank-table';
+import { getMaxPointsPerGame } from './core/point-calculator';
 import { renderBarGraph, findSliderIndex } from './graph/renderer';
 import { DEFAULT_HEIGHT_UNIT, getHeightUnit, setFutureOpacity, setSpace, setScale } from './graph/css-utils';
 import { loadPrefs, savePrefs, clearPrefs } from './storage/local-storage';
@@ -256,13 +261,17 @@ function renderFromCache(
   const sortableDiv = document.querySelector('#ranktable_section .sortable-table') as HTMLElement | null;
   if (sortableDiv) sortableDiv.innerHTML = '';
 
+  // Collect per-group results for cross-group comparison (populated during loop).
+  const allGroupResults: Record<string, GroupRenderResult> = {};
+
   for (const groupKey of groupKeys) {
     const singleGroupData = cache.teamMap[groupKey];
     if (!singleGroupData) continue;
 
-    // For multi-group: use per-group team count, zero promotion/relegation.
+    // For multi-group: use per-group team count from config, zero promotion/relegation.
+    const groupTeamCount = seasonInfo.groupTeamCount?.[groupKey] ?? seasonInfo.teamCount;
     const perGroupInfo: SeasonInfo = isMultiGroup
-      ? { ...seasonInfo, teamCount: Object.keys(singleGroupData).length, promotionCount: 0, relegationCount: 0 }
+      ? { ...seasonInfo, teamCount: groupTeamCount, promotionCount: 0, relegationCount: 0 }
       : seasonInfo;
 
     const { groupData, sortedTeams } = prepareRenderData({
@@ -305,6 +314,22 @@ function renderFromCache(
       sortableDiv.appendChild(table);
       const rankData = makeRankData(groupData, sortedTeams, perGroupInfo, disp, hasPk);
       makeRankTable(table, rankData, hasPk);
+    }
+
+    // Collect for cross-group comparison.
+    if (isMultiGroup && seasonInfo.crossGroupStanding) {
+      allGroupResults[groupKey] = { sortedTeams, groupData };
+    }
+  }
+
+  // Cross-group standing comparison table (after all per-group tables).
+  if (sortableDiv && seasonInfo.crossGroupStanding && Object.keys(allGroupResults).length > 1) {
+    const cgs = seasonInfo.crossGroupStanding;
+    const maxPt = getMaxPointsPerGame(seasonInfo.pointSystem);
+    const rows = buildCrossGroupRows(allGroupResults, cgs, disp, targetDate, maxPt);
+    if (rows.length > 0) {
+      sortableDiv.appendChild(document.createElement('hr'));
+      sortableDiv.appendChild(makeCrossGroupTable(rows, cgs));
     }
   }
 

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -3,6 +3,7 @@
 import type { PointSystem } from '../types/config';
 import type {
   SeasonMap, GroupEntry, CompetitionEntry, RawSeasonEntry, SeasonInfo,
+  CrossGroupStanding,
 } from '../types/season';
 
 /**
@@ -107,6 +108,19 @@ export function resolveSeasonInfo(
     ?? comp.shown_groups
     ?? undefined;
 
+  // cross_group_standing: scalar cascade (lowest defined level wins)
+  const crossGroupStanding: CrossGroupStanding | undefined = opts.cross_group_standing
+    ?? comp.cross_group_standing
+    ?? undefined;
+
+  // group_team_count: merge (lower overrides) — per-group team count overrides
+  const groupTeamCountRaw = {
+    ...(comp.group_team_count ?? {}),
+    ...(opts.group_team_count ?? {}),
+  };
+  const groupTeamCount: Record<string, number> | undefined =
+    Object.keys(groupTeamCountRaw).length > 0 ? groupTeamCountRaw : undefined;
+
   return {
     teamCount: entry[0],
     promotionCount: entry[1],
@@ -122,5 +136,7 @@ export function resolveSeasonInfo(
     tiebreakOrder,
     seasonStartMonth,
     shownGroups,
+    crossGroupStanding,
+    groupTeamCount,
   };
 }

--- a/frontend/src/ranking/rank-table.ts
+++ b/frontend/src/ranking/rank-table.ts
@@ -1,7 +1,7 @@
 // Ranking table data builder and renderer: port of make_rankdata / make_ranktable.
 
-import type { TeamData } from '../types/match';
-import type { SeasonInfo } from '../types/season';
+import type { TeamData, TeamMatch } from '../types/match';
+import type { SeasonInfo, CrossGroupStanding } from '../types/season';
 import {
   getStats,
   getSafetyLine,
@@ -16,14 +16,51 @@ declare const SortableTable: new () => {
   setData(data: unknown[]): void;
 };
 
-// Row data shape expected by SortableTable.
-// Japanese strings ('確定', '自力', etc.) are used for champion/promotion/relegation columns.
-export interface RankRow {
-  rank: number;
+// ---- Shared types and column definitions ----------------------------------
+
+// Column definition for table headers.
+type ColDef = { id?: string; label: string; sortable?: true };
+
+// Stat columns shared by all ranking table variants (between rank and goal columns).
+const STAT_COLS: ColDef[] = [
+  { id: 'name',        label: 'チーム' },
+  { id: 'all_game',    label: '試合',   sortable: true },
+  { id: 'point',       label: '勝点',   sortable: true },
+  { id: 'avrg_pt',     label: '平均',   sortable: true },
+  { id: 'avlbl_pt',    label: '最大',   sortable: true },
+  { id: 'win',         label: '勝',     sortable: true },
+  { id: 'draw',        label: '分',     sortable: true },
+  { id: 'loss',        label: '負',     sortable: true },
+];
+
+// Goal and remaining-game columns shared by all ranking table variants.
+const GOAL_COLS: ColDef[] = [
+  { id: 'goal_get',    label: '得点',   sortable: true },
+  { id: 'goal_lose',   label: '失点',   sortable: true },
+  { id: 'goal_diff',   label: '点差',   sortable: true },
+  { id: 'future_game', label: '残り',   sortable: true },
+];
+
+// Builds a <thead> row from a column definition array.
+function buildTableHead(tableEl: HTMLElement, cols: ColDef[]): void {
+  const thead = tableEl.querySelector('thead');
+  if (!thead) return;
+  const tr = document.createElement('tr');
+  for (const col of cols) {
+    const th = document.createElement('th');
+    if (col.id) th.setAttribute('data-id', col.id);
+    if (col.sortable) th.setAttribute('sortable', '');
+    th.innerHTML = col.label;
+    tr.appendChild(th);
+  }
+  thead.innerHTML = '';
+  thead.appendChild(tr);
+}
+
+// Fields shared between per-group rank rows and cross-group comparison rows.
+export interface BaseRankRow {
   name: string;      // HTML string: '<div class="TeamName">TeamName</div>'
   win: number;
-  pk_win?: number;
-  pk_loss?: number;
   draw: number;
   loss: number;
   point: number;
@@ -34,6 +71,14 @@ export interface RankRow {
   goal_lose: number;
   goal_diff: number;
   future_game: number;
+}
+
+// Row data shape for per-group ranking tables.
+// Japanese strings ('確定', '自力', etc.) are used for champion/promotion/relegation columns.
+export interface RankRow extends BaseRankRow {
+  rank: number;
+  pk_win?: number;
+  pk_loss?: number;
   champion: string;
   promotion?: string;
   relegation?: string;
@@ -154,48 +199,23 @@ export function makeRankData(
   return datalist;
 }
 
-// Dynamically builds the <thead> row for the rank table.
+// Builds the <thead> for per-group ranking tables.
 // pk_win / pk_loss columns are included only when hasPk=true.
-// promotion and relegation columns are always present (data layer controls values).
 function buildRankTableHead(tableEl: HTMLElement, hasPk: boolean): void {
-  const thead = tableEl.querySelector('thead');
-  if (!thead) return;
-
-  type ColDef = { id?: string; label: string; sortable?: true };
   const cols: ColDef[] = [
     { id: 'rank',        label: '',          sortable: true },
-    { id: 'name',        label: 'チーム' },
-    { id: 'all_game',    label: '試合',      sortable: true },
-    { id: 'point',       label: '勝点',      sortable: true },
-    { id: 'avrg_pt',     label: '平均',      sortable: true },
-    { id: 'avlbl_pt',    label: '最大',      sortable: true },
-    { id: 'win',         label: '勝',        sortable: true },
-    { id: 'draw',        label: '分',        sortable: true },
-    { id: 'loss',        label: '負',        sortable: true },
+    ...STAT_COLS,
     ...(hasPk ? [
       { id: 'pk_win',  label: 'PK勝', sortable: true as true },
       { id: 'pk_loss', label: 'PK負', sortable: true as true },
     ] : []),
-    { id: 'goal_get',    label: '得点',      sortable: true },
-    { id: 'goal_lose',   label: '失点',      sortable: true },
-    { id: 'goal_diff',   label: '点差',      sortable: true },
-    { id: 'future_game', label: '残り',      sortable: true },
+    ...GOAL_COLS,
     {                    label: '-' },
     { id: 'champion',    label: '優勝',      sortable: true },
     { id: 'promotion',   label: '昇格<br/>ACL', sortable: true },
     { id: 'relegation',  label: '残留',      sortable: true },
   ];
-
-  const tr = document.createElement('tr');
-  for (const col of cols) {
-    const th = document.createElement('th');
-    if (col.id) th.setAttribute('data-id', col.id);
-    if (col.sortable) th.setAttribute('sortable', '');
-    th.innerHTML = col.label;
-    tr.appendChild(th);
-  }
-  thead.innerHTML = '';
-  thead.appendChild(tr);
+  buildTableHead(tableEl, cols);
 }
 
 // Renders rankData into the given <table> element using SortableTable from CDN.
@@ -205,4 +225,160 @@ export function makeRankTable(tableEl: HTMLElement, rankData: RankRow[], hasPk: 
   const sortableTable = new SortableTable();
   sortableTable.setTable(tableEl);
   sortableTable.setData(rankData);
+}
+
+// ---- Cross-group standing comparison table --------------------------------
+
+// Row for the cross-group comparison table.
+// Uses string rank (group key) instead of numeric; no champion/promotion/relegation.
+export interface CrossGroupRow extends BaseRankRow {
+  rank: string;   // Group key (e.g., "A", "F")
+}
+
+// Per-group render result collected during the main rendering loop.
+export interface GroupRenderResult {
+  sortedTeams: string[];
+  groupData: Record<string, TeamData>;
+}
+
+// Intermediate stats used during recalculation (numeric avrg_pt).
+interface RecalcStats {
+  win: number; draw: number; loss: number;
+  point: number; avlbl_pt: number; avrg_pt: number;
+  all_game: number; future_game: number;
+  goal_get: number; goal_lose: number; goal_diff: number;
+}
+
+// Recalculates team stats from a filtered match list.
+// Used when exclude_bottom > 0 removes some opponents' matches.
+function recalcFromMatches(
+  matches: TeamMatch[], disp: boolean, targetDate: string, maxPtPerGame: number,
+): RecalcStats {
+  let win = 0, draw = 0, loss = 0, point = 0;
+  let goal_get = 0, goal_lose = 0, all_game = 0, future_game = 0;
+
+  for (const m of matches) {
+    const played = m.has_result && m.match_date !== '未定'
+      && (!disp || m.match_date <= targetDate);
+    if (played) {
+      point += m.point;
+      const get = m.goal_get ?? 0;
+      const lose = m.goal_lose ?? 0;
+      goal_get += get;
+      goal_lose += lose;
+      all_game++;
+      if (get > lose) win++;
+      else if (get < lose) loss++;
+      else draw++;
+    } else {
+      future_game++;
+    }
+  }
+
+  return {
+    win, draw, loss, point, goal_get, goal_lose,
+    goal_diff: goal_get - goal_lose,
+    all_game, future_game,
+    avrg_pt: all_game === 0 ? 0 : point / all_game,
+    avlbl_pt: point + future_game * maxPtPerGame,
+  };
+}
+
+// Builds comparison rows for the cross-group standing table.
+// Pure data function (no DOM access) for testability.
+export function buildCrossGroupRows(
+  groupResults: Record<string, GroupRenderResult>,
+  config: CrossGroupStanding,
+  disp: boolean,
+  targetDate: string,
+  maxPtPerGame: number,
+): CrossGroupRow[] {
+  const { position, exclude_from_rank } = config;
+  const rows: CrossGroupRow[] = [];
+
+  for (const [groupKey, { sortedTeams, groupData }] of Object.entries(groupResults)) {
+    if (sortedTeams.length < position) continue;
+
+    const teamName = sortedTeams[position - 1];
+    const td = groupData[teamName];
+    if (!td) continue;
+
+    let stats: RecalcStats;
+
+    // Exclude teams ranked at exclude_from_rank or below (if they exist in this group).
+    const excludeTeams = exclude_from_rank && sortedTeams.length >= exclude_from_rank
+      ? new Set(sortedTeams.slice(exclude_from_rank - 1))
+      : undefined;
+
+    if (excludeTeams && excludeTeams.size > 0) {
+      const filteredMatches = td.df.filter(m => !excludeTeams.has(m.opponent));
+      stats = recalcFromMatches(filteredMatches, disp, targetDate, maxPtPerGame);
+    } else {
+      const s = getStats(td, disp);
+      const rc = s.resultCounts;
+      stats = {
+        win: rc.win, draw: rc.draw, loss: rc.loss,
+        point: s.point, avlbl_pt: s.avlbl_pt, avrg_pt: s.avrg_pt,
+        all_game: s.all_game,
+        goal_get: s.goal_get,
+        goal_lose: s.goal_get - s.goal_diff,
+        goal_diff: s.goal_diff,
+        future_game: td.df.length - s.all_game,
+      };
+    }
+
+    rows.push({
+      rank: groupKey,
+      name: `<div class="${teamCssClass(teamName)}">${teamName}</div>`,
+      all_game: stats.all_game,
+      point: stats.point,
+      avrg_pt: stats.avrg_pt.toFixed(2),
+      avlbl_pt: stats.avlbl_pt,
+      win: stats.win, draw: stats.draw, loss: stats.loss,
+      goal_get: stats.goal_get, goal_lose: stats.goal_lose, goal_diff: stats.goal_diff,
+      future_game: stats.future_game,
+    });
+  }
+
+  // Sort: points desc → goal_diff desc → goal_get desc
+  rows.sort((a, b) => b.point - a.point || b.goal_diff - a.goal_diff || b.goal_get - a.goal_get);
+
+  return rows;
+}
+
+// Creates and populates a cross-group comparison <table> element.
+// Highlights top advance_count rows with .promoted CSS class.
+export function makeCrossGroupTable(
+  rows: CrossGroupRow[], config: CrossGroupStanding,
+): HTMLTableElement {
+  const { position, exclude_from_rank, advance_count = 0 } = config;
+
+  const table = document.createElement('table');
+  table.className = 'ranktable';
+
+  const caption = document.createElement('caption');
+  const posLabel = `${position}位チーム比較`;
+  const excludeLabel = exclude_from_rank ? ` (${exclude_from_rank}位以下との対戦除外)` : '';
+  caption.textContent = posLabel + excludeLabel;
+  table.appendChild(caption);
+
+  table.appendChild(document.createElement('thead'));
+  buildTableHead(table, [
+    { id: 'rank', label: 'Grp', sortable: true },
+    ...STAT_COLS,
+    ...GOAL_COLS,
+  ]);
+
+  const sortableTable = new SortableTable();
+  sortableTable.setTable(table);
+  sortableTable.setData(rows);
+
+  if (advance_count > 0) {
+    const tbodyRows = table.querySelectorAll('tbody tr');
+    tbodyRows.forEach((tr, i) => {
+      if (i < advance_count) tr.classList.add('promoted');
+    });
+  }
+
+  return table;
 }

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -22,6 +22,14 @@ import type { PointSystem } from './config';
 // Example: { "3": "promoted_playoff" }
 export type RankClassMap = Record<string, string>;
 
+// Configuration for the cross-group standing comparison table.
+// Extracts the Nth-place team from each group for side-by-side comparison.
+export interface CrossGroupStanding {
+  position: number;            // Which rank to extract (1-indexed)
+  exclude_from_rank?: number;  // Exclude teams ranked at this position or below (e.g. 4 = exclude 4th+)
+  advance_count?: number;      // How many teams advance; highlights top N rows (default: 0)
+}
+
 // Merged optional dict at season entry index 4.
 // Combines what was previously separate at index 4 (RankClassMap) and index 5 (SeasonExtraInfo).
 export interface SeasonEntryOptions {
@@ -35,6 +43,8 @@ export interface SeasonEntryOptions {
   tiebreak_order?: string[];
   season_start_month?: number;
   shown_groups?: string[];
+  cross_group_standing?: CrossGroupStanding;
+  group_team_count?: Record<string, number>;
 }
 
 // Raw array format as loaded from season_map.json (tuple type).
@@ -80,4 +90,6 @@ export interface SeasonInfo {
   tiebreakOrder: string[];
   seasonStartMonth: number;
   shownGroups?: string[];
+  crossGroupStanding?: CrossGroupStanding;
+  groupTeamCount?: Record<string, number>;
 }

--- a/src/match_utils.py
+++ b/src/match_utils.py
@@ -83,7 +83,7 @@ class SeasonEntry:
         'rank_properties', 'group_display', 'url_category',
         'league_display', 'point_system', 'css_files',
         'team_rename_map', 'tiebreak_order', 'season_start_month',
-        'shown_groups',
+        'shown_groups', 'cross_group_standing', 'group_team_count',
     }
 
     def __init__(self, season_key: str, raw: list):


### PR DESCRIPTION
Fixes #104
Fixes #102

## Summary

- マルチグループ描画基盤を実装: `shown_groups` カスケード、`renderFromCache()` マルチグループ対応
- cross_group_standing 汎用テーブルを実装: 各グループ特定順位チームの横断比較 (`exclude_from_rank`、`advance_count` ハイライト)
- 国際大会を season_map.json に追加: オリンピックGS(2021)、W杯アジア最終予選(2022/2026)、W杯GS(2022)、ACLGS(2021/2022)
- `group_team_count` オプション追加: マルチグループで全体チーム数とグループあたりチーム数のセマンティクスを修正
- Pythonスクレイパーのバグ修正: timezone `astimezone()` 文字列渡し、`get_sections_to_update()` の set→list 変換エラー

## Changes

| Commit | Description |
| --- | --- |
| `b589864` | Add multi-group bar graph rendering infrastructure |
| `d7f16d2` | Fix timezone and section-set bugs in Python scrapers |
| `6a0c6bd` | Add international competitions to season_map.json |
| `c092771` | Add cross-group standing table and ACL GS competition |
| `9785ac3` | Add sub-issue scope and parent branch detection to commit skill |

## Test plan

- [x] `uv run pytest` passed
- [x] `npx vitest run` passed (frontend/)
- [x] `npm run build` succeeded (frontend/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)