### PR TITLE
Add historical data and fix ranking table row colors

### DIFF
--- a/docs/csv/2026_allmatch_result-WC_AFC.csv
+++ b/docs/csv/2026_allmatch_result-WC_AFC.csv
@@ -1,31 +1,91 @@
 ,match_date,section_no,start_time,stadium,home_team,away_team,status,matchNumber,home_goal,away_goal,extraTime,match_index_in_section,group
-0,2024/09/05,1,20:10,ゴールドコースト(オーストラリア)／Cbus Super Stadium,オーストラリア,バーレーン,試合終了,1,0,1,False,1,C
-1,2024/09/05,1,19:35,埼玉／埼玉スタジアム2002,日本,中国,試合終了,2,7,0,False,2,C
-2,2024/09/05,1,21:00,ジッダ(サウジアラビア)／King Abdullah Sports City Stadium,サウジアラビア,インドネシア,試合終了,3,1,1,False,3,C
-3,2024/09/10,2,19:00,ジャカルタ(インドネシア)／Gelora Bung Karno Stadium,インドネシア,オーストラリア,試合終了,4,0,0,False,1,C
-4,2024/09/10,2,20:00,大連(中国)／Dalian Suoyuwan Football Stadium,中国,サウジアラビア,試合終了,5,1,2,False,2,C
-5,2024/09/10,2,19:00,リファー(バーレーン)／Bahrain National Stadium,バーレーン,日本,試合終了,6,0,5,False,3,C
-6,2024/10/10,3,19:10,アデレード(オーストラリア)／Adelaide Oval,オーストラリア,中国,試合終了,7,3,1,False,1,C
-7,2024/10/10,3,19:00,リファー(バーレーン)／Bahrain National Stadium,バーレーン,インドネシア,試合終了,8,2,2,False,2,C
-8,2024/10/10,3,21:00,ジッダ(サウジアラビア)／King Abdullah Sports City Stadium,サウジアラビア,日本,試合終了,9,0,2,False,3,C
-9,2024/10/15,4,19:35,埼玉／埼玉スタジアム2002,日本,オーストラリア,試合終了,10,1,1,False,1,C
-10,2024/10/15,4,20:00,青島(中国)／Qingdao Youth Football Stadium,中国,インドネシア,試合終了,11,2,1,False,2,C
-11,2024/10/15,4,21:00,ジッダ(サウジアラビア)／King Abdullah Sports City Stadium,サウジアラビア,バーレーン,試合終了,12,0,0,False,3,C
-12,2024/11/14,5,17:00,リファー(バーレーン)／Bahrain National Stadium,バーレーン,中国,試合終了,13,0,1,False,1,C
-13,2024/11/14,5,19:10,メルボルン(オーストラリア)／Melbourne Rectangular Stadium,オーストラリア,サウジアラビア,試合終了,14,0,0,False,2,C
-14,2024/11/15,5,19:00,ジャカルタ(インドネシア)／Gelora Bung Karno Stadium,インドネシア,日本,試合終了,15,0,4,False,3,C
-15,2024/11/19,6,19:00,ジャカルタ(インドネシア)／Gelora Bung Karno Stadium,インドネシア,サウジアラビア,試合終了,16,2,0,False,1,C
-16,2024/11/19,6,21:15,リファー(バーレーン)／Bahrain National Stadium,バーレーン,オーストラリア,試合終了,17,2,2,False,2,C
-17,2024/11/19,6,20:00,廈門(中国)／Xiamen Egret Stadium,中国,日本,試合終了,18,1,3,False,3,C
-18,2025/03/20,7,19:35,埼玉／埼玉スタジアム2002,日本,バーレーン,試合終了,19,2,0,False,1,C
-19,2025/03/20,7,21:15,リヤド(サウジアラビア)／King Saud University Stadium,サウジアラビア,中国,試合終了,20,1,0,False,2,C
-20,2025/03/20,7,20:10,シドニー(オーストラリア)／Sydney Football Stadium,オーストラリア,インドネシア,試合終了,21,5,1,False,3,C
-21,2025/03/25,8,19:00,杭州(中国)／Hangzhou Olympic Sports Centre Stadium,中国,オーストラリア,試合終了,22,0,2,False,1,C
-22,2025/03/25,8,19:35,埼玉／埼玉スタジアム2002,日本,サウジアラビア,試合終了,23,0,0,False,2,C
-23,2025/03/25,8,20:45,ジャカルタ(インドネシア)／Gelora Bung Karno Stadium,インドネシア,バーレーン,試合終了,24,1,0,False,3,C
-24,2025/06/05,9,20:45,ジャカルタ(インドネシア)／Gelora Bung Karno Stadium,インドネシア,中国,試合終了,25,1,0,False,1,C
-25,2025/06/05,9,19:00,リファー(バーレーン)／Bahrain National Stadium,バーレーン,サウジアラビア,試合終了,26,0,2,False,2,C
-26,2025/06/05,9,19:10,パース(オーストラリア)／Perth Stadium,オーストラリア,日本,試合終了,27,1,0,False,3,C
-27,2025/06/10,10,19:00,重慶(中国)／Chongqing Longxing Football Stadium,中国,バーレーン,試合終了,28,1,0,False,1,C
-28,2025/06/10,10,19:35,大阪／市立吹田サッカースタジアム,日本,インドネシア,試合終了,29,6,0,False,2,C
-29,2025/06/10,10,21:15,ジッダ(サウジアラビア)／King Abdullah Sports City Stadium,サウジアラビア,オーストラリア,試合終了,30,1,2,False,3,C
+0,2024/09/05,1,,BUNYODKOR STADIUM (TASHKENT),ウズベキスタン,朝鮮民主主義人民共和国,試合終了,1,1,0,False,1,A
+1,2024/09/05,1,,AHMAD BIN ALI STADIUM (AL RAYYAN),カタール,UAE,試合終了,2,1,3,False,2,A
+2,2024/09/05,1,,FOOLĀD SHAHR STADIUM (FOOLADSHAHR),イラン,キルギス,試合終了,3,1,0,False,3,A
+3,2024/09/10,2,,LAO NATIONAL STADIUM KM16 (VIENTIANE),朝鮮民主主義人民共和国,カタール,試合終了,4,2,2,False,1,A
+4,2024/09/10,2,,DOLEN OMURZAKOV STADIUM (BISHKEK),キルギス,ウズベキスタン,試合終了,5,2,3,False,2,A
+5,2024/09/10,2,,HAZZA BIN ZAYED STADIUM (AL AIN),UAE,イラン,試合終了,6,0,1,False,3,A
+6,2024/10/10,3,,BUNYODKOR STADIUM (TASHKENT),ウズベキスタン,イラン,試合終了,7,0,0,False,1,A
+7,2024/10/10,3,,HAZZA BIN ZAYED STADIUM (AL AIN),UAE,朝鮮民主主義人民共和国,試合終了,8,1,1,False,2,A
+8,2024/10/10,3,,AHMAD BIN ALI STADIUM (AL RAYYAN),カタール,キルギス,試合終了,9,3,1,False,3,A
+9,2024/10/15,4,,DOLEN OMURZAKOV STADIUM (BISHKEK),キルギス,朝鮮民主主義人民共和国,試合終了,10,1,0,False,1,A
+10,2024/10/15,4,,BUNYODKOR STADIUM (TASHKENT),ウズベキスタン,UAE,試合終了,11,1,0,False,2,A
+11,2024/10/15,4,,IMAM REZA STADIUM (MASHHAD),イラン,カタール,試合終了,12,4,1,False,3,A
+12,2024/11/14,5,,AO NATIONAL STADIUM KM16 (VIENTIANE),朝鮮民主主義人民共和国,イラン,試合終了,13,2,3,False,1,A
+13,2024/11/14,5,,MOHAMMED BIN ZAYED STADIUM (ABU DHABI),UAE,キルギス,試合終了,14,3,0,False,2,A
+14,2024/11/14,5,,JASSIM BIN HAMAD STADIUM (DOHA),カタール,ウズベキスタン,試合終了,15,3,2,False,3,A
+15,2024/11/19,6,,LAO NATIONAL STADIUM KM16 (VIENTIANE),朝鮮民主主義人民共和国,ウズベキスタン,試合終了,16,0,1,False,1,A
+16,2024/11/19,6,,DOLEN OMURZAKOV STADIUM (BISHKEK),キルギス,イラン,試合終了,17,2,3,False,2,A
+17,2024/11/19,6,,HAZZA BIN ZAYED STADIUM (AL AIN),UAE,カタール,試合終了,18,5,0,False,3,A
+18,2025/03/20,7,,JASSIM BIN HAMAD STADIUM (DOHA),カタール,朝鮮民主主義人民共和国,試合終了,19,5,1,False,1,A
+19,2025/03/20,7,,BUNYODKOR STADIUM (TASHKENT),ウズベキスタン,キルギス,試合終了,20,1,0,False,2,A
+20,2025/03/20,7,,AZADI STADIUM (TEHRAN),イラン,UAE,試合終了,21,2,0,False,3,A
+21,2025/03/25,8,,PRINCE FAISAL BIN FAHD STADIUM (RIYADH),朝鮮民主主義人民共和国,UAE,試合終了,22,1,2,False,1,A
+22,2025/03/25,8,,AZADI STADIUM (TEHRAN),イラン,ウズベキスタン,試合終了,23,2,2,False,2,A
+23,2025/03/25,8,,DOLEN OMURZAKOV STADIUM (BISHKEK),キルギス,カタール,試合終了,24,3,1,False,3,A
+24,2025/06/05,9,,PRINCE FAISAL BIN FAHD STADIUM (RIYADH),朝鮮民主主義人民共和国,キルギス,試合終了,25,2,2,False,1,A
+25,2025/06/05,9,,JASSIM BIN HAMAD STADIUM (DOHA),カタール,イラン,試合終了,26,1,0,False,2,A
+26,2025/06/05,9,,AL NAHYAN STADIUM (ABU DHABI),UAE,ウズベキスタン,試合終了,27,0,0,False,3,A
+27,2025/06/10,10,,BUNYODKOR STADIUM (TASHKENT),ウズベキスタン,カタール,試合終了,28,3,0,False,1,A
+28,2025/06/10,10,,AZADI STADIUM (TEHRAN),イラン,朝鮮民主主義人民共和国,試合終了,29,3,0,False,2,A
+29,2025/06/10,10,,DOLEN OMURZAKOV STADIUM (BISHKEK),キルギス,UAE,試合終了,30,1,1,False,3,A
+30,2024/09/05,1,,SEOUL WORLD CUP STADIUM (SEOUL),韓国,パレスチナ,試合終了,1,0,0,False,1,B
+31,2024/09/05,1,,BASRA INTERNATIONAL STADIUM (BASRA),イラク,オマーン,試合終了,2,1,0,False,2,B
+32,2024/09/05,1,,AMMAN INTERNATIONAL STADIUM (AMMAN),ヨルダン,クウェート,試合終了,3,1,1,False,3,B
+33,2024/09/10,2,,KUALA LUMPUR FOOTBALL STADIUM (KUALA LUMPUR),パレスチナ,ヨルダン,試合終了,4,1,3,False,1,B
+34,2024/09/10,2,,SULTAN QABOOS SPORT COMPLEX (MUSCAT),オマーン,韓国,試合終了,5,1,3,False,2,B
+35,2024/09/10,2,,JABER AL-AHMAD INTERNATIONAL STADIUM (ARDHIYAH),クウェート,イラク,試合終了,6,0,0,False,3,B
+36,2024/10/10,3,,AMMAN INTERNATIONAL STADIUM (AMMAN),ヨルダン,韓国,試合終了,7,0,2,False,1,B
+37,2024/10/10,3,,SULTAN QABOOS SPORT COMPLEX (MUSCAT),オマーン,クウェート,試合終了,8,4,0,False,2,B
+38,2024/10/10,3,,BASRA INTERNATIONAL STADIUM (BASRA),イラク,パレスチナ,試合終了,9,1,0,False,3,B
+39,2024/10/15,4,,YONGIN MIREU STADIUM (YONGIN),韓国,イラク,試合終了,10,3,2,False,1,B
+40,2024/10/15,4,,AMMAN INTERNATIONAL STADIUM (AMMAN),ヨルダン,オマーン,試合終了,11,4,0,False,2,B
+41,2024/10/15,4,,JASSIM BIN HAMAD STADIUM (DOHA),パレスチナ,クウェート,試合終了,12,2,2,False,3,B
+42,2024/11/14,5,,JABER AL-AHMAD INTERNATIONAL STADIUM (ARDHIYAH),クウェート,韓国,試合終了,13,1,3,False,1,B
+43,2024/11/14,5,,SULTAN QABOOS SPORT COMPLEX (MUSCAT),オマーン,パレスチナ,試合終了,14,1,0,False,2,B
+44,2024/11/14,5,,BASRA INTERNATIONAL STADIUM (BASRA),イラク,ヨルダン,試合終了,15,0,0,False,3,B
+45,2024/11/19,6,,AMMAN INTERNATIONAL STADIUM (AMMAN),パレスチナ,韓国,試合終了,16,1,1,False,1,B
+46,2024/11/19,6,,SULTAN QABOOS SPORT COMPLEX (MUSCAT),オマーン,イラク,試合終了,17,0,1,False,2,B
+47,2024/11/19,6,,JABER AL-AHMAD INTERNATIONAL STADIUM (ARDHIYAH),クウェート,ヨルダン,試合終了,18,1,1,False,3,B
+48,2025/03/20,7,,BASRA INTERNATIONAL STADIUM (BASRA),イラク,クウェート,試合終了,19,2,2,False,1,B
+49,2025/03/20,7,,GOYANG STADIUM (GOYANG),韓国,オマーン,試合終了,20,1,1,False,2,B
+50,2025/03/20,7,,AMMAN INTERNATIONAL STADIUM (AMMAN),ヨルダン,パレスチナ,試合終了,21,3,1,False,3,B
+51,2025/03/25,8,,AMMAN INTERNATIONAL STADIUM (AMMAN),パレスチナ,イラク,試合終了,22,2,1,False,1,B
+52,2025/03/25,8,,SUWON WORLD CUP STADIUM (SUWON),韓国,ヨルダン,試合終了,23,1,1,False,2,B
+53,2025/03/25,8,,JABER AL-AHMAD INTERNATIONAL STADIUM (ARDHIYAH),クウェート,オマーン,試合終了,24,0,1,False,3,B
+54,2025/06/05,9,,JABER AL-AHMAD INTERNATIONAL STADIUM (ARDHIYAH),クウェート,パレスチナ,試合終了,25,0,2,False,1,B
+55,2025/06/05,9,,SULTAN QABOOS SPORT COMPLEX (MUSCAT),オマーン,ヨルダン,試合終了,26,0,3,False,2,B
+56,2025/06/05,9,,BASRA INTERNATIONAL STADIUM (BASRA),イラク,韓国,試合終了,27,0,2,False,3,B
+57,2025/06/10,10,,SEOUL WORLD CUP STADIUM (SEOUL),韓国,クウェート,試合終了,28,4,0,False,1,B
+58,2025/06/10,10,,AMMAN INTERNATIONAL STADIUM (AMMAN),ヨルダン,イラク,試合終了,29,0,1,False,2,B
+59,2025/06/10,10,,KING ABDULLAH II STADIUM (AMMAN),パレスチナ,オマーン,試合終了,30,1,1,False,3,B
+60,2024/09/05,1,20:10,ゴールドコースト(オーストラリア)／Cbus Super Stadium,オーストラリア,バーレーン,試合終了,1,0,1,False,1,C
+61,2024/09/05,1,19:35,埼玉／埼玉スタジアム2002,日本,中国,試合終了,2,7,0,False,2,C
+62,2024/09/05,1,21:00,ジッダ(サウジアラビア)／King Abdullah Sports City Stadium,サウジアラビア,インドネシア,試合終了,3,1,1,False,3,C
+63,2024/09/10,2,19:00,ジャカルタ(インドネシア)／Gelora Bung Karno Stadium,インドネシア,オーストラリア,試合終了,4,0,0,False,1,C
+64,2024/09/10,2,20:00,大連(中国)／Dalian Suoyuwan Football Stadium,中国,サウジアラビア,試合終了,5,1,2,False,2,C
+65,2024/09/10,2,19:00,リファー(バーレーン)／Bahrain National Stadium,バーレーン,日本,試合終了,6,0,5,False,3,C
+66,2024/10/10,3,19:10,アデレード(オーストラリア)／Adelaide Oval,オーストラリア,中国,試合終了,7,3,1,False,1,C
+67,2024/10/10,3,19:00,リファー(バーレーン)／Bahrain National Stadium,バーレーン,インドネシア,試合終了,8,2,2,False,2,C
+68,2024/10/10,3,21:00,ジッダ(サウジアラビア)／King Abdullah Sports City Stadium,サウジアラビア,日本,試合終了,9,0,2,False,3,C
+69,2024/10/15,4,19:35,埼玉／埼玉スタジアム2002,日本,オーストラリア,試合終了,10,1,1,False,1,C
+70,2024/10/15,4,20:00,青島(中国)／Qingdao Youth Football Stadium,中国,インドネシア,試合終了,11,2,1,False,2,C
+71,2024/10/15,4,21:00,ジッダ(サウジアラビア)／King Abdullah Sports City Stadium,サウジアラビア,バーレーン,試合終了,12,0,0,False,3,C
+72,2024/11/14,5,17:00,リファー(バーレーン)／Bahrain National Stadium,バーレーン,中国,試合終了,13,0,1,False,1,C
+73,2024/11/14,5,19:10,メルボルン(オーストラリア)／Melbourne Rectangular Stadium,オーストラリア,サウジアラビア,試合終了,14,0,0,False,2,C
+74,2024/11/15,5,19:00,ジャカルタ(インドネシア)／Gelora Bung Karno Stadium,インドネシア,日本,試合終了,15,0,4,False,3,C
+75,2024/11/19,6,19:00,ジャカルタ(インドネシア)／Gelora Bung Karno Stadium,インドネシア,サウジアラビア,試合終了,16,2,0,False,1,C
+76,2024/11/19,6,21:15,リファー(バーレーン)／Bahrain National Stadium,バーレーン,オーストラリア,試合終了,17,2,2,False,2,C
+77,2024/11/19,6,20:00,廈門(中国)／Xiamen Egret Stadium,中国,日本,試合終了,18,1,3,False,3,C
+78,2025/03/20,7,19:35,埼玉／埼玉スタジアム2002,日本,バーレーン,試合終了,19,2,0,False,1,C
+79,2025/03/20,7,21:15,リヤド(サウジアラビア)／King Saud University Stadium,サウジアラビア,中国,試合終了,20,1,0,False,2,C
+80,2025/03/20,7,20:10,シドニー(オーストラリア)／Sydney Football Stadium,オーストラリア,インドネシア,試合終了,21,5,1,False,3,C
+81,2025/03/25,8,19:00,杭州(中国)／Hangzhou Olympic Sports Centre Stadium,中国,オーストラリア,試合終了,22,0,2,False,1,C
+82,2025/03/25,8,19:35,埼玉／埼玉スタジアム2002,日本,サウジアラビア,試合終了,23,0,0,False,2,C
+83,2025/03/25,8,20:45,ジャカルタ(インドネシア)／Gelora Bung Karno Stadium,インドネシア,バーレーン,試合終了,24,1,0,False,3,C
+84,2025/06/05,9,20:45,ジャカルタ(インドネシア)／Gelora Bung Karno Stadium,インドネシア,中国,試合終了,25,1,0,False,1,C
+85,2025/06/05,9,19:00,リファー(バーレーン)／Bahrain National Stadium,バーレーン,サウジアラビア,試合終了,26,0,2,False,2,C
+86,2025/06/05,9,19:10,パース(オーストラリア)／Perth Stadium,オーストラリア,日本,試合終了,27,1,0,False,3,C
+87,2025/06/10,10,19:00,重慶(中国)／Chongqing Longxing Football Stadium,中国,バーレーン,試合終了,28,1,0,False,1,C
+88,2025/06/10,10,19:35,大阪／市立吹田サッカースタジアム,日本,インドネシア,試合終了,29,6,0,False,2,C
+89,2025/06/10,10,21:15,ジッダ(サウジアラビア)／King Abdullah Sports City Stadium,サウジアラビア,オーストラリア,試合終了,30,1,2,False,3,C

--- a/docs/csv/csv_timestamp.csv
+++ b/docs/csv/csv_timestamp.csv
@@ -24,3 +24,4 @@ file,date
 ../docs/csv/23-24_allmatch_result-WE_Cup_KO.csv,2026-03-03 17:28:05.802987+09:00
 ../docs/csv/24-25_allmatch_result-WE_Cup_KO.csv,2026-03-03 17:28:05.802987+09:00
 ../docs/csv/2024_allmatch_result-Olympic_GS.csv,2026-03-03 17:54:46.640740+09:00
+../docs/csv/2026_allmatch_result-WC_AFC.csv,2026-03-04 07:36:46.818989+09:00

--- a/docs/json/season_map.json
+++ b/docs/json/season_map.json
@@ -273,12 +273,13 @@
           "サウジアラビア": "サウジ"
         },
         "seasons": {
-          "2026": [6, 0, 0,
+          "2026": [6, 2, 0,
             [],
-            {"shown_groups": ["C"]}],
-          "2022": [6, 0, 0,
+            {"shown_groups": ["A", "B", "C"]}],
+          "2022": [6, 2, 0,
             [],
-            {"shown_groups": ["A", "B"]}]
+            {"shown_groups": ["A", "B"],
+              "rank_properties": {"3": "promoted_playoff"}}]
         }
       },
       "Olympic_GS": {

--- a/docs/national_team_style.css
+++ b/docs/national_team_style.css
@@ -195,6 +195,28 @@
     background-color: red;
 }
 
+/* ── WCQ 2026 追加チーム ──────────────────────────────────── */
+.朝鮮民主主義人民共和国 {
+  color: white;
+  background-color: #024FA2;
+}
+.キルギス {
+  color: #FCD116;
+  background-color: #CE1126;
+}
+.パレスチナ {
+  color: white;
+  background-color: #009736;
+}
+.ヨルダン {
+  color: white;
+  background-color: black;
+}
+.クウェート {
+  color: white;
+  background-color: #003366;
+}
+
 /* ── Paris 2024 追加チーム ─────────────────────────────────── */
 .イスラエル {
   color: white;

--- a/frontend/src/ranking/rank-table.ts
+++ b/frontend/src/ranking/rank-table.ts
@@ -251,8 +251,13 @@ export function makeRankTable(tableEl: HTMLElement, rankData: RankRow[], hasPk: 
   const tbody = tableEl.querySelector('tbody');
   if (!tbody) return;
   applyRowClasses(tbody as HTMLElement, rankMap);
-  new MutationObserver(() => applyRowClasses(tbody as HTMLElement, rankMap))
-    .observe(tbody, { childList: true });
+  // SortableTable replaces the entire <tbody> element on each sort
+  // (removeChild + insertAdjacentHTML), so we must observe the <table>
+  // for childList changes and find the fresh <tbody> on each mutation.
+  new MutationObserver(() => {
+    const newTbody = tableEl.querySelector('tbody');
+    if (newTbody) applyRowClasses(newTbody as HTMLElement, rankMap);
+  }).observe(tableEl, { childList: true });
 }
 
 // ---- Cross-group standing comparison table --------------------------------

--- a/src/read_wcq_html.py
+++ b/src/read_wcq_html.py
@@ -1,0 +1,223 @@
+"""Scrape WCQ Asian Final Qualifying match results from JFA HTML page.
+
+The JFA schedule.json API only provides Group C data.
+This script scrapes Groups A and B from the static HTML result page
+and merges them with the existing Group C CSV data.
+
+Usage:
+    uv run python src/read_wcq_html.py [-d] [-g A,B]
+"""
+import argparse
+import logging
+import os
+import re
+from pathlib import Path
+
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+
+from match_utils import mu
+
+logger = logging.getLogger(__name__)
+
+URL = 'https://www.jfa.jp/samuraiblue/worldcup_2026/final_q_2026/result/'
+CSV_PATH = '../docs/csv/2026_allmatch_result-WC_AFC.csv'
+
+
+def fetch_html(url: str) -> BeautifulSoup:
+    """Fetch the HTML page and return a BeautifulSoup object."""
+    logger.info("Fetching %s", url)
+    resp = requests.get(url, timeout=60)
+    resp.raise_for_status()
+    resp.encoding = 'utf-8'  # requests misdetects as ISO-8859-1
+    return BeautifulSoup(resp.text, 'html.parser')
+
+
+def parse_group(tab_div) -> tuple[str, list[dict]]:
+    """Parse a single group tab div and extract match data.
+
+    Args:
+        tab_div: BeautifulSoup element for one tab-contents div.
+
+    Returns:
+        Tuple of (group_letter, list of match dicts).
+    """
+    # Extract group letter from h3 like "Group A"
+    h3 = tab_div.find('h3', class_='result-block__ttl')
+    group_match = re.search(r'Group\s+([A-Z])', h3.get_text())
+    group = group_match.group(1)
+    logger.info("Parsing Group %s", group)
+
+    schedule_table = tab_div.find('table', class_='result-block__schedule')
+    if schedule_table is None:
+        logger.warning("No schedule table found for Group %s", group)
+        return group, []
+
+    matches = []
+    current_section = 0
+    match_index = 0
+
+    for tr in schedule_table.find('tbody').find_all('tr'):
+        tds = tr.find_all('td')
+        if not tds:
+            continue
+
+        # Check if this row starts a new matchday (has MD cell)
+        md_td = tr.find('td', class_='md')
+        if md_td:
+            md_match = re.search(r'MD(\d+)', md_td.get_text())
+            if md_match:
+                current_section = int(md_match.group(1))
+                match_index = 0
+
+        # Find the score cell (contains tdWrap1 with team/score info)
+        wrap1 = tr.find('div', class_='tdWrap1')
+        if wrap1 is None:
+            continue
+
+        match_index += 1
+
+        # Extract team names and score from <ul><li> structure
+        li_items = wrap1.find('ul').find_all('li')
+        home_team = li_items[0].get_text(strip=True)
+        score_text = li_items[1].get_text(strip=True)
+        away_team = li_items[2].get_text(strip=True)
+
+        # Parse score
+        home_goal = ''
+        away_goal = ''
+        status = 'ＶＳ'
+        score_match = re.match(r'(\d+)-(\d+)', score_text)
+        if score_match:
+            home_goal = score_match.group(1)
+            away_goal = score_match.group(2)
+            status = '試合終了'
+
+        # Extract stadium from tdWrap2
+        wrap2 = tr.find('div', class_='tdWrap2')
+        stadium = wrap2.get_text(strip=True) if wrap2 else ''
+
+        # Extract date - find the td with date pattern YYYY.MM.DD
+        # The date td may contain HOME/AWAY icon spans before the date
+        date_str = ''
+        match_number = ''
+        for td in tds:
+            if td.get('class') and 'md' in td.get('class', []):
+                continue
+            td_text = td.get_text(strip=True)
+            # Remove HOME/AWAY prefix
+            td_text_clean = re.sub(r'^(HOME|AWAY)', '', td_text)
+            date_m = re.search(r'(\d{4})\.(\d{2})\.(\d{2})', td_text_clean)
+            if date_m:
+                date_str = f"{date_m.group(1)}/{date_m.group(2)}/{date_m.group(3)}"
+            elif re.match(r'^\d+$', td_text):
+                match_number = td_text
+
+        matches.append({
+            'match_date': date_str,
+            'section_no': current_section,
+            'start_time': '',
+            'stadium': stadium,
+            'home_team': home_team,
+            'away_team': away_team,
+            'status': status,
+            'matchNumber': match_number,
+            'home_goal': home_goal,
+            'away_goal': away_goal,
+            'extraTime': 'False',
+            'match_index_in_section': match_index,
+            'group': group,
+        })
+
+    logger.info("Group %s: parsed %d matches", group, len(matches))
+    return group, matches
+
+
+def scrape_groups(url: str, target_groups: list[str]) -> pd.DataFrame:
+    """Scrape match data for the specified groups from the HTML page.
+
+    Args:
+        url: URL of the result page.
+        target_groups: List of group letters to scrape (e.g. ['A', 'B']).
+
+    Returns:
+        DataFrame with scraped match data.
+    """
+    soup = fetch_html(url)
+    tab_divs = soup.find_all('div', class_='tab-contents')
+
+    all_matches = []
+    for tab_div in tab_divs:
+        group, matches = parse_group(tab_div)
+        if group in target_groups:
+            all_matches.extend(matches)
+            logger.info("Included Group %s (%d matches)", group, len(matches))
+        else:
+            logger.info("Skipped Group %s (not in target: %s)", group, target_groups)
+
+    return pd.DataFrame(all_matches)
+
+
+def merge_with_existing(new_df: pd.DataFrame, csv_path: str) -> pd.DataFrame:
+    """Merge new group data with existing CSV, replacing groups present in new_df.
+
+    Args:
+        new_df: DataFrame with newly scraped data.
+        csv_path: Path to the existing CSV file.
+
+    Returns:
+        Merged DataFrame sorted by group, section_no, match_index_in_section.
+    """
+    new_groups = set(new_df['group'].unique())
+
+    if Path(csv_path).exists():
+        existing_df = mu.read_allmatches_csv(csv_path)
+        # Keep only groups NOT in the new data
+        keep_df = existing_df[~existing_df['group'].isin(new_groups)]
+        logger.info("Keeping %d existing rows (groups: %s)",
+                     len(keep_df),
+                     sorted(keep_df['group'].unique()) if len(keep_df) > 0 else 'none')
+        merged = pd.concat([keep_df, new_df], ignore_index=True)
+    else:
+        merged = new_df
+
+    merged = merged.sort_values(
+        ['group', 'section_no', 'match_index_in_section']
+    ).reset_index(drop=True)
+
+    return merged
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Scrape WCQ Asian Final Qualifying results from JFA HTML')
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help='Enable debug logging')
+    parser.add_argument('-g', '--groups', type=str, default='A,B',
+                        help='Comma-separated group letters to scrape (default: A,B)')
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
+        datefmt='%H:%M:%S',
+    )
+
+    target_groups = [g.strip().upper() for g in args.groups.split(',')]
+
+    new_df = scrape_groups(URL, target_groups)
+    if new_df.empty:
+        logger.warning("No matches scraped. Exiting.")
+        return
+
+    merged_df = merge_with_existing(new_df, CSV_PATH)
+    logger.info("Total matches after merge: %d", len(merged_df))
+
+    mu.update_if_diff(merged_df, CSV_PATH)
+
+
+if __name__ == '__main__':
+    os.chdir(Path(__file__).parent)
+    mu.init_config(Path(__file__).parent / '../config/jfamatch.yaml')
+    main()


### PR DESCRIPTION
Fixes #109
Fixes #112

## Summary
- WEリーグ過去データ (21-22〜24-25) のスクレイパーとCSVを追加
- ACL GS 2023/24、ACL Elite 2024/25・25-26 のスクレイパーとCSVを追加
- パリ五輪2024男子サッカーグループステージのデータを追加
- W杯アジア最終予選 Group A/B を JFA HTML ページからスクレイピングし、既存 Group C と統合
- 新チーム用CSSカラー追加 (ACL国際チーム、WCQ 5カ国)
- season_map.json に各大会の昇格/降格枠数・rank_properties を設定
- 順位表ソート時に promoted/relegated 行クラスが消えるバグを修正 (SortableTable が `<tbody>` を毎回入れ替えるため MutationObserver の監視対象を `<table>` に変更)

## Changes
| Commit | Description |
|--------|-------------|
| `889bd14` | Add WE League historical data for seasons 21-22 through 24-25 |
| `709109e` | Add ACL Elite League Stage scraper and 25-26 season data |
| `2ba7a74` | Add Wikipedia parser for ACL 2023/24 GS and ACL Elite 2024/25 LS |
| `40d6290` | Add team colors for ACL international teams and J-League full-name aliases |
| `65f72f0` | Separate WE Cup knockout rounds into dedicated CSVs and add note field |
| `79a1770` | Add Paris 2024 Olympics men's football group stage data |
| `07dbfa3` | Fix Olympic_GS season_map config and Paraguay team colors |
| `923fa23` | Keep promotionCount per group in multi-group rendering |
| `7083f9e` | Apply promoted/relegated row colors to ranking table |
| `a0a2fbc` | Set promotionCount for ACL GS, ACL Elite, and WE Cup competitions |
| `bfee57b` | Remove WE_Cup_KO from season_map to hide from bar graph view |
| `a64ac8d` | Add WCQ Asian Final Qualifying Group A/B data and team colors |
| `799905d` | Fix promoted/relegated row classes lost after ranking table re-sort |

## Test plan
- [x] `uv run pytest` passed
- [x] `npx vitest run` passed (frontend/)
- [x] `npm run build` succeeded (frontend/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)