### PR TITLE
Minor UI/UX fixes: Safari gap, slider UX, data source, notes

### DIFF
--- a/docs/j_points.css
+++ b/docs/j_points.css
@@ -112,14 +112,16 @@ p {
   align-items: center;
 }
 #date_slider_section {
-  margin: 0.5em 1em;
+  margin: 0.5em 0;
   display: flex;
   gap: 0.5em;
   flex-wrap: wrap;
   align-items: center;
+  width: 100%;
 }
 #date_slider {
-  width: 60%;
+  flex: 1;
+  min-width: 200px;
 }
 #appearance_controls {
   margin: 0.5em 1em;
@@ -154,6 +156,12 @@ p {
 .tooltip {
   position: relative;
   display: inline-block;
+}
+/* Inside .box, override inline-block to avoid Safari rendering gaps */
+.box.tooltip,
+.box > .tooltip {
+  display: block;
+  margin: 0;
 }
 
 /* Tooltip text */

--- a/docs/json/season_map.json
+++ b/docs/json/season_map.json
@@ -3,6 +3,11 @@
     "display_name": "Jリーグ",
     "css_files": ["team_style.css"],
     "season_start_month": 1,
+    "data_source": {
+      "label": "Jリーグ公式サイト: 日程結果",
+      "url": "https://www.jleague.jp/match/"
+    },
+    "note": "ACL: 天皇杯優勝チームがACL参加時の繰り上がり権利獲得は含まない (「なし」と表示)",
     "competitions": {
       "J1": {
         "league_display": "J1リーグ",
@@ -232,7 +237,8 @@
           "2022": [18, 2, 0,
             ["相模原", "愛媛", "北九州", "松本", "宮崎", "富山", "福島", "岐阜", "鹿児島", "YS横浜", "長野", "藤枝", "今治", "鳥取", "八戸", "沼津", "讃岐", "いわき"]],
           "2021": [15, 2, 0,
-            ["長野", "鹿児島", "鳥取", "岐阜", "今治", "熊本", "富山", "藤枝", "岩手", "沼津", "福島", "八戸", "讃岐", "YS横浜", "宮崎"]],
+            ["長野", "鹿児島", "鳥取", "岐阜", "今治", "熊本", "富山", "藤枝", "岩手", "沼津", "福島", "八戸", "讃岐", "YS横浜", "宮崎"],
+            {"note": ["2021年の宮崎はJ3昇格圏内に入ったが、所持ライセンスが足りずJ2に昇格できずJ3昇格・J2降格が1枠減った"]}],
           "2020": [18, 2, 0,
             ["鹿児島", "岐阜", "藤枝", "富山", "熊本", "Ｃ大23", "鳥取", "秋田", "長野", "八戸", "福島", "沼津", "YS横浜", "讃岐", "相模原", "Ｆ東23", "Ｇ大23", "岩手", "今治"]],
           "2019": [18, 2, 0,
@@ -254,6 +260,10 @@
   "international": {
     "display_name": "国際大会",
     "css_files": ["national_team_style.css"],
+    "data_source": {
+      "label": "JFA公式サイト: 日程・結果",
+      "url": "https://www.jfa.jp/"
+    },
     "competitions": {
       "WC_GS": {
         "league_display": "FIFAワールドカップ GS",
@@ -278,8 +288,7 @@
             {"shown_groups": ["A", "B", "C"]}],
           "2022": [6, 2, 0,
             [],
-            {"shown_groups": ["A", "B"],
-              "rank_properties": {"3": "promoted_playoff"}}]
+            {"shown_groups": ["A", "B"], "rank_properties": {"3": "promoted_playoff"}}]
         }
       },
       "Olympic_GS": {
@@ -308,6 +317,10 @@
     "display_name": "ACL",
     "css_files": ["team_style.css"],
     "season_start_month": 1,
+    "data_source": {
+      "label": "スポーツナビ: ACL日程・結果",
+      "url": "https://soccer.yahoo.co.jp/jleague/category/acle/schedule/"
+    },
     "competitions": {
       "ACL_GS": {
         "league_display": "ACL GS",
@@ -337,12 +350,7 @@
             []],
           "2022": [4, 1, 0,
             [],
-            {"group_team_count": {"J": 3},
-              "cross_group_standing": {
-              "position": 2,
-              "exclude_from_rank": 4,
-              "advance_count": 3
-            }}],
+            {"group_team_count": {"J": 3}, "cross_group_standing": {"position": 2, "exclude_from_rank": 4, "advance_count": 3}}],
           "2021": [4, 1, 0,
             []]
         }
@@ -364,6 +372,10 @@
   "prince": {
     "display_name": "Princeリーグ (J)",
     "css_files": ["team_style.css"],
+    "data_source": {
+      "label": "JFA公式サイト: 高円宮杯",
+      "url": "https://www.jfa.jp/match/"
+    },
     "competitions": {
       "PrincePremierE": {
         "league_display": "プレミアリーグEAST",
@@ -416,6 +428,10 @@
     "display_name": "WEリーグ",
     "css_files": ["team_style.css"],
     "season_start_month": 8,
+    "data_source": {
+      "label": "WEリーグ公式サイト: 試合日程・結果",
+      "url": "https://weleague.jp/matches/"
+    },
     "competitions": {
       "WE": {
         "league_display": "WEリーグ",
@@ -446,8 +462,7 @@
             {"note": ["グループステージのみ。準決勝・決勝の結果は WE_Cup_KO を参照。", "三菱重工浦和レッズレディース（23-24 WEリーグ優勝）はシードでKOラウンドから参加。"]}],
           "25-26": [12, 1, 0,
             [],
-            {"rank_properties": {"2": "promoted_playoff"},
-              "cross_group_standing": {"position": 2, "advance_count": 1}}]
+            {"rank_properties": {"2": "promoted_playoff"}, "cross_group_standing": {"position": 2, "advance_count": 1}}]
         }
       }
     }

--- a/frontend/src/__tests__/fixtures/match-data.ts
+++ b/frontend/src/__tests__/fixtures/match-data.ts
@@ -46,6 +46,7 @@ export function makeSeasonInfo(overrides: Partial<SeasonInfo> = {}): SeasonInfo 
     teamRenameMap: {},
     tiebreakOrder: ['goal_diff', 'goal_get'],
     seasonStartMonth: 7,
+    notes: [],
     ...overrides,
   };
 }

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -341,6 +341,30 @@ function renderFromCache(
     const globalMatchDates = [...globalMatchDateSet].sort();
     resetDateSlider(globalMatchDates, targetDate);
   }
+
+  // Update season notes from season_map config.
+  const notesEl = document.getElementById('season_notes');
+  if (notesEl) {
+    notesEl.replaceChildren();
+    for (const text of seasonInfo.notes) {
+      const li = document.createElement('li');
+      li.textContent = text;
+      notesEl.appendChild(li);
+    }
+  }
+
+  // Update data source link from season_map config.
+  const dsSection = document.getElementById('data_source_section');
+  if (dsSection) {
+    if (seasonInfo.dataSource) {
+      const a = document.createElement('a');
+      a.href = seasonInfo.dataSource.url;
+      a.textContent = seasonInfo.dataSource.label;
+      dsSection.replaceChildren('データ参照元: ', a);
+    } else {
+      dsSection.replaceChildren();
+    }
+  }
 }
 
 function loadAndRender(seasonMap: SeasonMap): void {
@@ -505,6 +529,13 @@ async function main(): Promise<void> {
     };
 
     dateSlider.addEventListener('change', updateFromSlider);
+
+    // Show date label in real-time while dragging (no graph redraw)
+    dateSlider.addEventListener('input', () => {
+      const date = state.currentMatchDates[parseInt(dateSlider.value, 10)];
+      if (!date) return;
+      (document.getElementById('target_date') as HTMLInputElement).value = date.replace(/\//g, '-');
+    });
 
     document.getElementById('date_slider_down')?.addEventListener('click', () => {
       dateSlider.value = String(Math.max(0, parseInt(dateSlider.value, 10) - 1));

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -3,7 +3,7 @@
 import type { PointSystem } from '../types/config';
 import type {
   SeasonMap, GroupEntry, CompetitionEntry, RawSeasonEntry, SeasonInfo,
-  CrossGroupStanding,
+  CrossGroupStanding, DataSource,
 } from '../types/season';
 
 /**
@@ -121,6 +121,21 @@ export function resolveSeasonInfo(
   const groupTeamCount: Record<string, number> | undefined =
     Object.keys(groupTeamCountRaw).length > 0 ? groupTeamCountRaw : undefined;
 
+  // data_source: scalar cascade (lowest defined level wins)
+  const dataSource: DataSource | undefined = opts.data_source
+    ?? comp.data_source
+    ?? group.data_source
+    ?? undefined;
+
+  // notes: union across all three levels (flattened, preserving order)
+  const toArray = (v: string | string[] | undefined): string[] =>
+    v == null ? [] : Array.isArray(v) ? v : [v];
+  const notes: string[] = [
+    ...toArray(group.note),
+    ...toArray(comp.note),
+    ...toArray(opts.note),
+  ];
+
   return {
     teamCount: entry[0],
     promotionCount: entry[1],
@@ -138,5 +153,7 @@ export function resolveSeasonInfo(
     shownGroups,
     crossGroupStanding,
     groupTeamCount,
+    dataSource,
+    notes,
   };
 }

--- a/frontend/src/j_points.html
+++ b/frontend/src/j_points.html
@@ -91,7 +91,7 @@
 <div id="box_container"></div>
 
 <hr/>
-データ参照元: <a href="https://www.jleague.jp/match/">Jリーグ公式サイト: 日程結果</a><br/>
+<span id="data_source_section"></span>
 <br/>
 <a href="https://github.com/mokekuma-git/JLeague_Matches-Bar_Graph">Github公開場所</a>
 <hr/>
@@ -106,9 +106,9 @@
     <li>どの判定も、3チーム以上の対戦成績の関係から、実際には確定していても「自力」「他力」と示す場合アリ</li>
     <li>(「確定」「降格」「なし」と判定されている場合は、それぞれ決定済み)</li>
     <li>昇格・降格: プレーオフ参戦決定も、それぞれ「確定」「降格」と表示</li>
-    <li>(別リーグの影響で昇格・降格数が減るケースは考慮しない 例: 2021宮崎がJ3昇格圏内になった時に、所持ライセンスのためJ2に昇格せずJ3昇格・J2降格が1枠減るケースなど)</li>
-    <li>ACL: 天皇杯優勝チームがACL参加時の繰り上がり権利獲得は含まない (「なし」と表示)</li>
+    <li>別リーグの影響で昇格・降格数が減るケースは考慮しない</li>
   </ul>
+  <ul id="season_notes"></ul>
 </section>
 </main>
 

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -30,6 +30,12 @@ export interface CrossGroupStanding {
   advance_count?: number;      // How many teams advance; highlights top N rows (default: 0)
 }
 
+// Data source reference for display at the bottom of the page.
+export interface DataSource {
+  label: string;
+  url: string;
+}
+
 // Merged optional dict at season entry index 4.
 // Combines what was previously separate at index 4 (RankClassMap) and index 5 (SeasonExtraInfo).
 export interface SeasonEntryOptions {
@@ -46,6 +52,7 @@ export interface SeasonEntryOptions {
   cross_group_standing?: CrossGroupStanding;
   group_team_count?: Record<string, number>;
   note?: string | string[];
+  data_source?: DataSource;
 }
 
 // Raw array format as loaded from season_map.json (tuple type).
@@ -93,4 +100,6 @@ export interface SeasonInfo {
   shownGroups?: string[];
   crossGroupStanding?: CrossGroupStanding;
   groupTeamCount?: Record<string, number>;
+  dataSource?: DataSource;
+  notes: string[];
 }

--- a/src/match_utils.py
+++ b/src/match_utils.py
@@ -84,7 +84,7 @@ class SeasonEntry:
         'league_display', 'point_system', 'css_files',
         'team_rename_map', 'tiebreak_order', 'season_start_month',
         'shown_groups', 'cross_group_standing', 'group_team_count',
-        'note',
+        'note', 'data_source',
     }
 
     def __init__(self, season_key: str, raw: list):


### PR DESCRIPTION
Fixes #114

## Summary
- Safari でのバーグラフ高さずれを修正 (`.tooltip` の `inline-block` を `.box` 内で `block` に上書き)
- スライドバーのドラッグ中に表示日を即時追従 (`input` イベント追加、グラフ再描画は `change` のまま)
- スライドバーセクションを100%幅に変更 (`flex: 1` + `min-width: 200px`)
- `data_source` フィールドを `season_map.json` に追加 (Group → Competition → Entry カスケード)。HTMLのハードコーディングを動的表示に置換
- `note` フィールドのカスケード解決 (Group/Competition/Entry の和集合) とフロントエンド表示を実装。Jリーグ固有のハードコーディング (ACL繰り上がり・宮崎) を `season_map.json` に移動

## Changes
| Commit | Description |
| ------ | ----------- |
| `2a14a2c` | All fixes in single commit: CSS Safari fix, slider input event, full-width slider, data_source/notes cascade + rendering |

## Test plan
- [x] `npx vitest run` passed (327 tests)
- [x] `npm run typecheck` passed
- [x] `npm run build` succeeded
- [x] `uv run pytest` passed (70 tests)
- [x] `uv run python scripts/check_type_sync.py` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)