### PR TITLE
Add configurable promotion column header via promotion_label

### DIFF
--- a/docs/json/season_map.json
+++ b/docs/json/season_map.json
@@ -11,6 +11,7 @@
     "competitions": {
       "J1": {
         "league_display": "J1リーグ",
+        "promotion_label": "ACL",
         "seasons": {
           "2026East": [10, 1, 0,
             ["鹿島", "柏", "町田", "浦和", "川崎Ｆ", "FC東京", "横浜FM", "東京Ｖ", "水戸", "千葉"],
@@ -278,6 +279,7 @@
       },
       "WC_AFC": {
         "league_display": "W杯アジア最終予選",
+        "promotion_label": "本選出場",
         "team_rename_map": {
           "オーストラリア": "豪州",
           "サウジアラビア": "サウジ"
@@ -293,6 +295,7 @@
       },
       "Olympic_GS": {
         "league_display": "オリンピック GS",
+        "promotion_label": "決勝T",
         "shown_groups": ["A", "B", "C", "D"],
         "team_rename_map": {
           "ホンジュラス": "ホンジュラ",
@@ -324,6 +327,7 @@
     "competitions": {
       "ACL_GS": {
         "league_display": "ACL GS",
+        "promotion_label": "決勝T",
         "tiebreak_order": ["head_to_head", "goal_diff", "goal_get"],
         "shown_groups": ["F", "G", "H", "I", "J"],
         "cross_group_standing": {
@@ -357,6 +361,7 @@
       },
       "ACL_Elite": {
         "league_display": "ACL Elite LS",
+        "promotion_label": "KOステージ",
         "season_start_month": 9,
         "tiebreak_order": ["head_to_head", "goal_diff", "goal_get"],
         "seasons": {
@@ -450,6 +455,7 @@
       },
       "WE_Cup": {
         "league_display": "クラシエカップ",
+        "promotion_label": "決勝T",
         "seasons": {
           "22-23": [11, 1, 0,
             [],

--- a/frontend/src/__tests__/config/season-map.test.ts
+++ b/frontend/src/__tests__/config/season-map.test.ts
@@ -305,4 +305,35 @@ describe('resolveSeasonInfo', () => {
 
     expect(info.shownGroups).toEqual(['C']);
   });
+
+  test('promotionLabel defaults to "昇格" when not set', () => {
+    const entry: RawSeasonEntry = [20, 3, 3, []];
+    const info = resolveSeasonInfo(sampleGroup, sampleGroup.competitions.J1, entry);
+
+    expect(info.promotionLabel).toBe('昇格');
+  });
+
+  test('cascade: promotion_label from competition level', () => {
+    const comp: CompetitionEntry = {
+      league_display: 'J1リーグ',
+      promotion_label: '昇格<br/>ACL',
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = [20, 3, 3, []];
+    const info = resolveSeasonInfo(sampleGroup, comp, entry);
+
+    expect(info.promotionLabel).toBe('昇格<br/>ACL');
+  });
+
+  test('cascade: promotion_label from season overrides competition', () => {
+    const comp: CompetitionEntry = {
+      league_display: 'J1リーグ',
+      promotion_label: '昇格<br/>ACL',
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = [20, 3, 3, [], { promotion_label: 'W杯本選' }];
+    const info = resolveSeasonInfo(sampleGroup, comp, entry);
+
+    expect(info.promotionLabel).toBe('W杯本選');
+  });
 });

--- a/frontend/src/__tests__/fixtures/match-data.ts
+++ b/frontend/src/__tests__/fixtures/match-data.ts
@@ -47,6 +47,7 @@ export function makeSeasonInfo(overrides: Partial<SeasonInfo> = {}): SeasonInfo 
     tiebreakOrder: ['goal_diff', 'goal_get'],
     seasonStartMonth: 7,
     notes: [],
+    promotionLabel: '昇格',
     ...overrides,
   };
 }

--- a/frontend/src/__tests__/ranking/rank-table.test.ts
+++ b/frontend/src/__tests__/ranking/rank-table.test.ts
@@ -634,3 +634,23 @@ describe('makeRankTable – thead hasPk=true', () => {
     expect(pkLossIdx).toBe(pkWinIdx + 1);
   });
 });
+
+describe('makeRankTable – promotionLabel', () => {
+  function getPromotionHeader(table: HTMLElement): string {
+    const ths = Array.from(table.querySelectorAll('thead th'));
+    const th = ths.find(el => el.getAttribute('data-id') === 'promotion');
+    return th?.innerHTML ?? '';
+  }
+
+  test('defaults to "昇格" when no label is passed', () => {
+    const table = makeTableEl();
+    makeRankTable(table, [], false);
+    expect(getPromotionHeader(table)).toBe('昇格');
+  });
+
+  test('uses provided label as innerHTML', () => {
+    const table = makeTableEl();
+    makeRankTable(table, [], false, '昇格<br/>ACL');
+    expect(getPromotionHeader(table)).toBe('昇格<br>ACL');
+  });
+});

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -315,7 +315,7 @@ function renderFromCache(
       table.appendChild(document.createElement('thead'));
       sortableDiv.appendChild(table);
       const rankData = makeRankData(groupData, sortedTeams, perGroupInfo, disp, hasPk);
-      makeRankTable(table, rankData, hasPk);
+      makeRankTable(table, rankData, hasPk, perGroupInfo.promotionLabel);
     }
 
     // Collect for cross-group comparison.

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -127,6 +127,12 @@ export function resolveSeasonInfo(
     ?? group.data_source
     ?? undefined;
 
+  // promotion_label: scalar cascade (lowest defined level wins, default '昇格')
+  const promotionLabel: string = opts.promotion_label
+    ?? comp.promotion_label
+    ?? group.promotion_label
+    ?? '昇格';
+
   // notes: union across all three levels (flattened, preserving order)
   const toArray = (v: string | string[] | undefined): string[] =>
     v == null ? [] : Array.isArray(v) ? v : [v];
@@ -155,5 +161,6 @@ export function resolveSeasonInfo(
     groupTeamCount,
     dataSource,
     notes,
+    promotionLabel,
   };
 }

--- a/frontend/src/ranking/rank-table.ts
+++ b/frontend/src/ranking/rank-table.ts
@@ -204,7 +204,7 @@ export function makeRankData(
 
 // Builds the <thead> for per-group ranking tables.
 // pk_win / pk_loss columns are included only when hasPk=true.
-function buildRankTableHead(tableEl: HTMLElement, hasPk: boolean): void {
+function buildRankTableHead(tableEl: HTMLElement, hasPk: boolean, promotionLabel: string = '昇格'): void {
   const cols: ColDef[] = [
     { id: 'rank',        label: '',          sortable: true },
     ...STAT_COLS,
@@ -215,7 +215,7 @@ function buildRankTableHead(tableEl: HTMLElement, hasPk: boolean): void {
     ...GOAL_COLS,
     {                    label: '-' },
     { id: 'champion',    label: '優勝',      sortable: true },
-    { id: 'promotion',   label: '昇格<br/>ACL', sortable: true },
+    { id: 'promotion',   label: promotionLabel, sortable: true },
     { id: 'relegation',  label: '残留',      sortable: true },
   ];
   buildTableHead(tableEl, cols);
@@ -237,8 +237,8 @@ function applyRowClasses(tbody: HTMLElement, rankMap: Map<number, string>): void
 // hasPk controls whether PK win/loss columns appear in the table header.
 // Row CSS classes (promoted/relegated/etc.) are applied based on points-based rank
 // and reapplied after every re-sort via MutationObserver.
-export function makeRankTable(tableEl: HTMLElement, rankData: RankRow[], hasPk: boolean): void {
-  buildRankTableHead(tableEl, hasPk);
+export function makeRankTable(tableEl: HTMLElement, rankData: RankRow[], hasPk: boolean, promotionLabel: string = '昇格'): void {
+  buildRankTableHead(tableEl, hasPk, promotionLabel);
   const sortableTable = new SortableTable();
   sortableTable.setTable(tableEl);
   sortableTable.setData(rankData);

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -53,6 +53,7 @@ export interface SeasonEntryOptions {
   group_team_count?: Record<string, number>;
   note?: string | string[];
   data_source?: DataSource;
+  promotion_label?: string;
 }
 
 // Raw array format as loaded from season_map.json (tuple type).
@@ -102,4 +103,5 @@ export interface SeasonInfo {
   groupTeamCount?: Record<string, number>;
   dataSource?: DataSource;
   notes: string[];
+  promotionLabel: string;
 }

--- a/src/match_utils.py
+++ b/src/match_utils.py
@@ -84,7 +84,7 @@ class SeasonEntry:
         'league_display', 'point_system', 'css_files',
         'team_rename_map', 'tiebreak_order', 'season_start_month',
         'shown_groups', 'cross_group_standing', 'group_team_count',
-        'note', 'data_source',
+        'note', 'data_source', 'promotion_label',
     }
 
     def __init__(self, season_key: str, raw: list):


### PR DESCRIPTION
Fixes #116

## Summary

- 順位表の昇格カラムヘッダーをハードコード (`'昇格<br/>ACL'`) から `season_map.json` の `promotion_label` プロパティで設定可能に変更
- スカラーカスケード (Season Entry > Competition > Group、デフォルト: `'昇格'`) で解決
- 各大会に適切なラベルを設定: J1=`ACL`, WC_AFC=`本選出場`, ACL_GS/WE_Cup=`決勝T`, ACL_Elite=`KOステージ`, Olympic_GS=`決勝T`
- Python `KNOWN_OPTION_KEYS` に追加して型同期を維持

## Changes

| Commit | Description |
| ------ | ----------- |
| `9e2e137` | Add configurable promotion column header via promotion_label |

## Test plan

- [x] `uv run python scripts/check_type_sync.py` passed
- [x] `npx vitest run` passed (frontend/)
- [x] `npm run typecheck` passed (frontend/)
- [x] `npm run build` succeeded (frontend/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)