### PR TITLE
Add point_system validation and unify CSV column aliases

### DIFF
--- a/.github/workflows/check-type-sync.yaml
+++ b/.github/workflows/check-type-sync.yaml
@@ -9,6 +9,8 @@ on:
       - 'src/match_utils.py'
       - 'frontend/src/types/**'
       - 'scripts/check_type_sync.py'
+      - 'docs/json/season_map.json'
+      - 'scripts/check_point_system_csv.py'
   push:
     branches:
       - main
@@ -16,6 +18,8 @@ on:
       - 'src/match_utils.py'
       - 'frontend/src/types/**'
       - 'scripts/check_type_sync.py'
+      - 'docs/json/season_map.json'
+      - 'scripts/check_point_system_csv.py'
 
 jobs:
   check:
@@ -34,3 +38,6 @@ jobs:
 
       - name: Check type sync
         run: uv run python scripts/check_type_sync.py
+
+      - name: Check point_system × CSV consistency
+        run: uv run python scripts/check_point_system_csv.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,6 @@ npm run dev               # Vite開発サーバー起動
 - `group`: グループ名 (グループ分けがある場合のみ)
 - `home_pk_score`/`away_pk_score`: PK得点 (省略可能。JFA JSONの命名に倣った)
 - `home_score_ex`/`away_score_ex`: 延長戦得点 (省略可能。延長戦がない大会では列自体が存在しない)
-- `home_pk`/`away_pk`: `home_pk_score`/`away_pk_score` の旧名エイリアス (1993-1998 CSV)
 
 ## season_map.json 構造
 

--- a/docs/csv/1993A_allmatch_result-J1.csv
+++ b/docs/csv/1993A_allmatch_result-J1.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk,away_pk,home_score_ex,away_score_ex
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk_score,away_pk_score,home_score_ex,away_score_ex
 0,1993/05/15,1,1,19:29,国立,Ｖ川崎,1,2,横浜M,,59626,,,,
 1,1993/05/16,1,2,13:05,三ツ沢,横浜Ｆ,3,2,清水,,14126,,,,
 2,1993/05/16,1,3,13:59,広島ス,広島,2,1,市原,,11875,,,,

--- a/docs/csv/1993B_allmatch_result-J1.csv
+++ b/docs/csv/1993B_allmatch_result-J1.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk,away_pk,home_score_ex,away_score_ex
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk_score,away_pk_score,home_score_ex,away_score_ex
 0,1993/07/24,1,1,16:02,市原,市原,1,0,清水,,9358,,,,
 1,1993/07/24,1,2,18:31,神戸ユ,名古屋,1,2,横浜Ｆ,,38757,,,,
 2,1993/07/24,1,3,18:33,三ツ沢,横浜M,3,0,Ｖ川崎,,14248,,,,

--- a/docs/csv/1994A_allmatch_result-J1.csv
+++ b/docs/csv/1994A_allmatch_result-J1.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk,away_pk,home_score_ex,away_score_ex
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk_score,away_pk_score,home_score_ex,away_score_ex
 0,1994/03/12,1,1,14:33,広島ビ,広島,2,0,名古屋,,11503,,,,
 1,1994/03/12,1,2,14:59,日本平,清水,1,0,横浜Ｆ,,10071,,,,
 2,1994/03/12,1,3,15:00,市原,市原,5,1,Ｇ大阪,,10044,,,,

--- a/docs/csv/1994B_allmatch_result-J1.csv
+++ b/docs/csv/1994B_allmatch_result-J1.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk,away_pk,home_score_ex,away_score_ex
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk_score,away_pk_score,home_score_ex,away_score_ex
 0,1994/08/10,1,1,19:01,等々力,Ｖ川崎,1,2,平塚,,10630,,,,
 1,1994/08/10,1,2,19:01,三ツ沢,横浜M,3,0,浦和,,13639,,,,
 2,1994/08/10,1,3,19:02,市原,市原,5,2,Ｇ大阪,,10563,,,,

--- a/docs/csv/1995A_allmatch_result-J1.csv
+++ b/docs/csv/1995A_allmatch_result-J1.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk,away_pk,home_score_ex,away_score_ex
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk_score,away_pk_score,home_score_ex,away_score_ex
 0,1995/03/18,1,1,15:02,万博,Ｇ大阪,3,1,名古屋,,14007,,,,
 1,1995/03/18,1,2,15:03,市原,市原,1,0,磐田,,13637,,,,
 2,1995/03/18,1,3,15:03,三ツ沢,横浜Ｆ,1,0,浦和,,12236,,,,

--- a/docs/csv/1995B_allmatch_result-J1.csv
+++ b/docs/csv/1995B_allmatch_result-J1.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk,away_pk,home_score_ex,away_score_ex
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk_score,away_pk_score,home_score_ex,away_score_ex
 0,1995/08/12,1,1,12:00,札幌,市原,2,1,Ｇ大阪,,9518,,,1,0
 1,1995/08/12,1,2,19:01,日本平,清水,0,1,広島,,20117,,,,
 2,1995/08/12,1,3,19:02,カシマ,鹿島,0,2,横浜M,,16162,,,,

--- a/docs/csv/1996_allmatch_result-J1.csv
+++ b/docs/csv/1996_allmatch_result-J1.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk,away_pk,home_score_ex,away_score_ex
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk_score,away_pk_score,home_score_ex,away_score_ex
 0,1996/03/16,1,1,14:03,等々力,Ｖ川崎,1,0,京都,,12835,,,,
 1,1996/03/16,1,2,15:03,駒場,浦和,2,1,柏,,20124,,,,
 2,1996/03/16,1,3,15:03,瑞穂陸,名古屋,4,1,平塚,,22021,,,,

--- a/docs/csv/1997A_allmatch_result-J1.csv
+++ b/docs/csv/1997A_allmatch_result-J1.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk,away_pk,home_score_ex,away_score_ex
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk_score,away_pk_score,home_score_ex,away_score_ex
 0,1997/04/12,1,1,15:00,三ツ沢,横浜Ｆ,3,1,福岡,,8019,,,,
 1,1997/04/12,1,2,15:01,万博,Ｇ大阪,4,1,平塚,,6205,,,,
 2,1997/04/12,1,3,15:03,瑞穂陸,名古屋,2,3,Ｃ大阪,,17480,,,,

--- a/docs/csv/1997B_allmatch_result-J1.csv
+++ b/docs/csv/1997B_allmatch_result-J1.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk,away_pk,home_score_ex,away_score_ex
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk_score,away_pk_score,home_score_ex,away_score_ex
 0,1997/07/30,1,1,19:01,日本平,清水,3,1,横浜Ｆ,,8014,,,,
 1,1997/07/30,1,2,19:01,長居,Ｃ大阪,3,1,神戸,,5897,,,,
 2,1997/07/30,1,3,19:01,広島ビ,広島,1,0,名古屋,,4176,,,,

--- a/docs/csv/1998A_allmatch_result-J1.csv
+++ b/docs/csv/1998A_allmatch_result-J1.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk,away_pk
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk_score,away_pk_score
 0,1998/03/21,1,1,12:03,瑞穂陸,名古屋,2,3,神戸,,19181,,
 1,1998/03/21,1,2,14:06,平塚,平塚,4,1,Ｖ川崎,,13254,,
 2,1998/03/21,1,3,15:00,カシマ,鹿島,4,2,福岡,,15306,,

--- a/docs/csv/1998B_allmatch_result-J1.csv
+++ b/docs/csv/1998B_allmatch_result-J1.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk,away_pk
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,broadcast,attendance,home_pk_score,away_pk_score
 0,1998/08/22,1,1,18:31,市原,市原,1,3,鹿島,,7539,,
 1,1998/08/22,1,2,18:33,平塚,平塚,0,4,浦和,,13088,,
 2,1998/08/22,1,3,19:00,神戸ユ,神戸,0,2,柏,,3938,,

--- a/docs/csv/2021_allmatch_result-ACL_GS.csv
+++ b/docs/csv/2021_allmatch_result-ACL_GS.csv
@@ -1,4 +1,4 @@
-,group,match_date,start_time,section_no,home_team,home_goal,away_goal,match_status,away_team,stadium,match_index_in_section
+,group,match_date,start_time,section_no,home_team,home_goal,away_goal,status,away_team,stadium,match_index_in_section
 0,A,2021-04-16,04:00:00,1,イスティクロル,0,0,試合終了,アルアハリ,キングファハド,0
 1,B,2021-04-15,00:00:00,1,パフタコール,3,3,試合終了,トラクター,シャールジャ,0
 2,C,2021-04-16,02:45:00,1,アルドゥハイル,2,0,試合終了,アルショルタ,KASC,0

--- a/frontend/src/__tests__/core/csv-parser.test.ts
+++ b/frontend/src/__tests__/core/csv-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { parseCsvResults, normalizeColumnAliases } from '../../core/csv-parser';
+import { parseCsvResults } from '../../core/csv-parser';
 import { calculateTeamStats } from '../../ranking/stats-calculator';
 import type { RawMatchRow } from '../../types/match';
 
@@ -194,54 +194,8 @@ describe('parseCsvResults', () => {
     });
   });
 
-  describe('column alias normalization', () => {
-    test('match_status is normalized to status', () => {
-      const fields = ['match_date', 'section_no', 'match_index_in_section', 'start_time',
-        'stadium', 'home_team', 'home_goal', 'away_goal', 'away_team', 'match_status'];
-      const row = makeRow({ status: undefined as unknown as string, match_status: '試合終了' });
-      const result = parseCsvResults([row], fields, ['TeamA', 'TeamB'], 'DefaultGroup');
-      expect(result['DefaultGroup']['TeamA'].df[0].status).toBe('試合終了');
-    });
-
-    test('status takes precedence over match_status when both exist', () => {
-      const row = makeRow({ status: '試合終了', match_status: '前半' });
-      const result = parseCsvResults([row], BASE_FIELDS, ['TeamA', 'TeamB'], 'DefaultGroup');
-      expect(result['DefaultGroup']['TeamA'].df[0].status).toBe('試合終了');
-    });
-
-    test('home_pk / away_pk aliases are normalized to home_pk_score / away_pk_score', () => {
-      const fields = [...BASE_FIELDS, 'home_pk', 'away_pk'];
-      const row = makeRow({
-        home_goal: '1', away_goal: '1',
-        home_pk: '5', away_pk: '3',
-      });
-      const result = parseCsvResults([row], fields, ['TeamA', 'TeamB'], 'DefaultGroup');
-      expect(result['DefaultGroup']['TeamA'].df[0].pk_get).toBe(5);
-      expect(result['DefaultGroup']['TeamA'].df[0].pk_lose).toBe(3);
-      expect(result['DefaultGroup']['TeamA'].df[0].point).toBe(0); // PK win under standard (pk_win=0)
-    });
-
-    test('home_pk_score takes precedence over home_pk when both exist', () => {
-      const fields = [...BASE_FIELDS, 'home_pk_score', 'away_pk_score', 'home_pk', 'away_pk'];
-      const row = makeRow({
-        home_goal: '1', away_goal: '1',
-        home_pk_score: '4', away_pk_score: '3',
-        home_pk: '99', away_pk: '99',
-      });
-      const result = parseCsvResults([row], fields, ['TeamA', 'TeamB'], 'DefaultGroup');
-      expect(result['DefaultGroup']['TeamA'].df[0].pk_get).toBe(4);
-      expect(result['DefaultGroup']['TeamA'].df[0].pk_lose).toBe(3);
-    });
-
-    test('normalizeColumnAliases is a no-op for standard rows', () => {
-      const row = makeRow();
-      const original = { ...row };
-      normalizeColumnAliases(row);
-      expect(row.status).toBe(original.status);
-      expect(row.home_pk_score).toBe(original.home_pk_score);
-    });
-
-    test('missing status with no alias falls back to goal-based detection', () => {
+  describe('missing status column', () => {
+    test('missing status falls back to goal-based detection', () => {
       const fields = BASE_FIELDS.filter(f => f !== 'status');
       const row = makeRow({ status: undefined as unknown as string });
       const result = parseCsvResults([row], fields, ['TeamA', 'TeamB'], 'DefaultGroup');

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -420,7 +420,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
         seasonInfo.pointSystem,
       );
       const fields = results.meta.fields ?? [];
-      const hasPk = fields.includes('home_pk_score') || fields.includes('home_pk');
+      const hasPk = fields.includes('home_pk_score');
       const hasEx = fields.includes('home_score_ex');
 
       const newCache = { key: csvKey, teamMap, teamCount: seasonInfo.teamCount, hasPk, hasEx };

--- a/frontend/src/core/csv-parser.ts
+++ b/frontend/src/core/csv-parser.ts
@@ -7,26 +7,6 @@ import { dateFormat } from './date-utils';
 import { getPointFromResult } from './point-calculator';
 
 /**
- * Normalizes column name aliases so that downstream code only needs to check
- * canonical field names.
- *
- * Known aliases:
- *   match_status → status      (ACL 2021 CSV)
- *   home_pk / away_pk → home_pk_score / away_pk_score  (1993-1998 CSVs)
- */
-export function normalizeColumnAliases(match: RawMatchRow): void {
-  if (match.status === undefined && match.match_status !== undefined) {
-    match.status = match.match_status;
-  }
-  if (match.home_pk_score === undefined && match.home_pk !== undefined) {
-    match.home_pk_score = match.home_pk;
-  }
-  if (match.away_pk_score === undefined && match.away_pk !== undefined) {
-    match.away_pk_score = match.away_pk;
-  }
-}
-
-/**
  * Returns the display status string for a match row.
  * @param match - RawMatchRow object (must be normalized first)
  * @returns Display status string
@@ -72,7 +52,6 @@ export function parseCsvResults(
   const hasGroupColumn = fields.includes('group');
 
   for (const match of data) {
-    normalizeColumnAliases(match);
     const csvGroup = hasGroupColumn ? match.group : undefined;
     const group = (csvGroup && csvGroup !== '') ? csvGroup : (defaultGroup ?? 'DefaultGroup');
 

--- a/frontend/src/types/match.ts
+++ b/frontend/src/types/match.ts
@@ -1,7 +1,5 @@
 // Raw CSV row as returned by PapaParse.
 // Field names match the CSV header columns in docs/csv/*.csv exactly.
-// Some competitions use different column names (aliases); these are normalized
-// in csv-parser.ts before processing.
 export interface RawMatchRow {
   match_date: string;
   section_no: string;
@@ -18,10 +16,6 @@ export interface RawMatchRow {
   away_pk_score?: string;
   home_score_ex?: string;   // Extra-time score (column may be absent; Tier 4 preparation)
   away_score_ex?: string;
-  // Column aliases used in some competition CSVs:
-  match_status?: string;    // ACL 2021 CSV uses this instead of 'status'
-  home_pk?: string;         // 1993-1998 CSVs may use this instead of 'home_pk_score'
-  away_pk?: string;
 }
 
 // Per-match data from a single team's perspective, produced by parse_csvresults.

--- a/scripts/check_point_system_csv.py
+++ b/scripts/check_point_system_csv.py
@@ -1,0 +1,168 @@
+"""Validate point_system settings against CSV data.
+
+Cross-checks season_map.json point_system configuration with CSV files
+in docs/csv/ to catch mismatches that cause runtime errors (e.g. a CSV
+with PK match data paired with a point_system where pk_win = 0).
+
+Exit code 0 = all checks pass (warnings are OK), 1 = error(s) found.
+
+Usage:
+    uv run python scripts/check_point_system_csv.py
+"""
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SEASON_MAP_PATH = PROJECT_ROOT / 'docs' / 'json' / 'season_map.json'
+CSV_DIR = PROJECT_ROOT / 'docs' / 'csv'
+CONFIG_TS = PROJECT_ROOT / 'frontend' / 'src' / 'types' / 'config.ts'
+
+# CSV column names that indicate PK data (old alias + current name)
+PK_COLUMNS = {'home_pk_score', 'home_pk'}
+
+
+def parse_point_maps_pk(config_path: Path) -> dict[str, int]:
+    """Parse POINT_MAPS from config.ts and extract pk_win values.
+
+    Returns:
+        dict mapping point_system name -> pk_win value.
+    """
+    content = config_path.read_text(encoding='utf-8')
+    match = re.search(
+        r'export const POINT_MAPS\s*=\s*\{(.*?)\}\s*satisfies',
+        content,
+        re.DOTALL,
+    )
+    if not match:
+        raise ValueError("POINT_MAPS not found in config.ts")
+
+    result: dict[str, int] = {}
+    for entry_match in re.finditer(
+        r"'([^']+)'\s*:\s*\{([^}]+)\}", match.group(1)
+    ):
+        system_name = entry_match.group(1)
+        body = entry_match.group(2)
+        pk_match = re.search(r'pk_win:\s*(\d+)', body)
+        if pk_match:
+            result[system_name] = int(pk_match.group(1))
+        else:
+            raise ValueError(
+                f"pk_win not found in POINT_MAPS entry '{system_name}'")
+    return result
+
+
+def resolve_point_system(
+    comp_data: dict, season_entry: list,
+) -> str:
+    """Resolve point_system with cascade: season options -> competition -> default."""
+    # Season entry options (index 4)
+    if len(season_entry) > 4 and isinstance(season_entry[4], dict):
+        ps = season_entry[4].get('point_system')
+        if ps:
+            return ps
+    # Competition level
+    ps = comp_data.get('point_system')
+    if ps:
+        return ps
+    return 'standard'
+
+
+def check_csv_pk_data(csv_path: Path) -> bool:
+    """Check if a CSV contains actual PK match data (non-empty values).
+
+    Returns True only if the CSV has a PK column AND at least one row
+    with a non-empty PK value.  Columns without data are ignored so that
+    CSVs with a unified column schema (PK columns always present) do not
+    trigger false positives.
+    """
+    with open(csv_path, 'r', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None:
+            return False
+        pk_col = next(
+            (c for c in reader.fieldnames if c.strip() in PK_COLUMNS), None,
+        )
+        if pk_col is None:
+            return False
+        # Scan rows for actual PK data (stop at first hit)
+        return any(row.get(pk_col, '').strip() for row in reader)
+
+
+def check_all() -> list[str]:
+    """Run all point_system × CSV consistency checks.
+
+    Returns:
+        List of error messages (empty = all OK).
+    """
+    errors: list[str] = []
+
+    # 1. Parse POINT_MAPS pk_win values from config.ts
+    try:
+        pk_win_map = parse_point_maps_pk(CONFIG_TS)
+    except Exception as e:
+        return [f"Failed to parse POINT_MAPS from config.ts: {e}"]
+
+    # 2. Load season_map.json
+    try:
+        with open(SEASON_MAP_PATH, 'r', encoding='utf-8') as f:
+            season_map = json.load(f)
+    except Exception as e:
+        return [f"Failed to load season_map.json: {e}"]
+
+    # 3. Iterate all groups -> competitions -> seasons
+    for group_key, group_data in season_map.items():
+        competitions = group_data.get('competitions', {})
+        for comp_key, comp_data in competitions.items():
+            seasons = comp_data.get('seasons', {})
+            for season_key, season_entry in seasons.items():
+                point_system = resolve_point_system(comp_data, season_entry)
+
+                # Validate point_system is known
+                if point_system not in pk_win_map:
+                    errors.append(
+                        f"{comp_key}/{season_key}: unknown point_system "
+                        f"'{point_system}'")
+                    continue
+
+                pk_win = pk_win_map[point_system]
+
+                # Find corresponding CSV
+                csv_name = f"{season_key}_allmatch_result-{comp_key}.csv"
+                csv_path = CSV_DIR / csv_name
+                if not csv_path.exists():
+                    continue  # CSV not yet available; skip
+
+                has_pk_data = check_csv_pk_data(csv_path)
+
+                # Check: CSV has PK data but pk_win == 0 → ERROR
+                # This is the exact bug pattern from hotfix 3aacd23.
+                if has_pk_data and pk_win == 0:
+                    errors.append(
+                        f"{comp_key}/{season_key}: CSV '{csv_name}' has PK "
+                        f"match data but point_system '{point_system}' maps "
+                        f"pk_win to 0 (will cause runtime error)")
+
+    return errors
+
+
+def main() -> int:
+    errors = check_all()
+
+    if errors:
+        for e in errors:
+            print(f"FAIL: {e}")
+        print(f"\n{len(errors)} point_system × CSV error(s) found.")
+        return 1
+
+    print("All point_system × CSV checks passed.")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/check_type_sync.py
+++ b/scripts/check_type_sync.py
@@ -33,9 +33,7 @@ CONFIG_TS = TS_TYPES_DIR / 'config.ts'
 # TS-only CSV fields that Python does not produce (yet).
 # These are expected to exist in RawMatchRow but NOT in CSV_COLUMN_SCHEMA.
 # ---------------------------------------------------------------------------
-TS_ONLY_CSV_FIELDS: set[str] = {
-    'match_status', 'home_pk', 'away_pk',  # Backward-compat aliases for old CSVs
-}
+TS_ONLY_CSV_FIELDS: set[str] = set()
 
 
 def _parse_interface_fields(content: str, interface_name: str) -> dict[str, str]:

--- a/scripts/legacy/make_old_matches_csv.py
+++ b/scripts/legacy/make_old_matches_csv.py
@@ -75,11 +75,11 @@ def make_each_csv(filename: str, comp_index: int) -> dict[str, pd.DataFrame]:
     columns_list = config.columns_list.copy()
     if year <= 1998:  # Until 1998, there was a penalty kick rule
         matches['away_goal'] = matches['away_goal'].str.replace(r'\(PK.*', '', regex=True)
-        matches['home_pk'] = matches['スコア'].str.extract(r'\(PK(\d+)\-', expand=False)
-        matches['home_pk'] = matches['home_pk'].fillna('')
-        matches['away_pk'] = matches['スコア'].str.extract(r'\(PK\d+\-(\d+)\)', expand=False)
-        matches['away_pk'] = matches['away_pk'].fillna('')
-        columns_list.extend(['home_pk', 'away_pk'])
+        matches['home_pk_score'] = matches['スコア'].str.extract(r'\(PK(\d+)\-', expand=False)
+        matches['home_pk_score'] = matches['home_pk_score'].fillna('')
+        matches['away_pk_score'] = matches['スコア'].str.extract(r'\(PK\d+\-(\d+)\)', expand=False)
+        matches['away_pk_score'] = matches['away_pk_score'].fillna('')
+        columns_list.extend(['home_pk_score', 'away_pk_score'])
     if 'home_score_ex' in matches.columns:
         for col in ('home_score_ex', 'away_score_ex'):
             matches[col] = matches[col].fillna('').apply(


### PR DESCRIPTION
Fixes #124

## Summary

- `point_system` 設定と CSV 内の PK データの整合性を CI で自動検証するスクリプトを追加
- CSV カラム名のエイリアス (`home_pk`/`away_pk`, `match_status`) を正規名に統一し、フロントエンドの `normalizeColumnAliases()` とTS 型の alias フィールドを除去

## Changes

| Commit | Description |
| ------ | ----------- |
| `530238a` | Add `check_point_system_csv.py` + CI workflow step |
| `a730f99` | Unify CSV column aliases to canonical names |

## Test plan

- [x] `uv run pytest` passed
- [x] `npx vitest run` passed (frontend/)
- [x] `npm run typecheck` passed (frontend/)
- [x] `uv run python scripts/check_type_sync.py` passed
- [x] `uv run python scripts/check_point_system_csv.py` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)