### PR TITLE
Add team color CSS undefined warning (I3 view invariant)

### DIFF
--- a/docs/j_points.css
+++ b/docs/j_points.css
@@ -139,6 +139,15 @@ p {
   color: #999;
   margin-left: 1em;
 }
+#warning_msg {
+  margin: 0.3em 1em;
+  padding: 0.4em 0.8em;
+  background-color: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 4px;
+  color: #856404;
+  font-size: 0.85em;
+}
 #ranktable_section {
   margin: 1em;
 }

--- a/frontend/src/__tests__/graph/css-validator.test.ts
+++ b/frontend/src/__tests__/graph/css-validator.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'vitest';
+import { findTeamsWithoutColor } from '../../graph/css-validator';
+
+describe('findTeamsWithoutColor', () => {
+  const defined = new Set(['鹿島', '浦和', '柏', '広島']);
+
+  test('returns empty when all teams have CSS colors defined', () => {
+    expect(findTeamsWithoutColor(['鹿島', '浦和'], defined)).toEqual([]);
+  });
+
+  test('returns teams without CSS color defined', () => {
+    expect(findTeamsWithoutColor(['鹿島', '未知チーム'], defined)).toEqual(['未知チーム']);
+  });
+
+  test('returns all teams when none have CSS colors', () => {
+    const empty = new Set<string>();
+    expect(findTeamsWithoutColor(['A', 'B'], empty)).toEqual(['A', 'B']);
+  });
+
+  test('deduplicates input CSS classes', () => {
+    expect(findTeamsWithoutColor(['未知', '未知', '未知'], defined)).toEqual(['未知']);
+  });
+
+  test('returns empty for empty input', () => {
+    expect(findTeamsWithoutColor([], defined)).toEqual([]);
+  });
+
+  test('preserves insertion order of first occurrence', () => {
+    const result = findTeamsWithoutColor(['X', 'Y', 'X', 'Z'], defined);
+    expect(result).toEqual(['X', 'Y', 'Z']);
+  });
+});

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -26,6 +26,8 @@ import type { GroupRenderResult } from './ranking/rank-table';
 import { getMaxPointsPerGame } from './core/point-calculator';
 import { renderBarGraph, findSliderIndex } from './graph/renderer';
 import { DEFAULT_HEIGHT_UNIT, getHeightUnit, setFutureOpacity, setSpace, setScale } from './graph/css-utils';
+import { findTeamsWithoutColor } from './graph/css-validator';
+import { teamCssClass } from './core/team-utils';
 import { loadPrefs, savePrefs, clearPrefs } from './storage/local-storage';
 
 // ---- Application state ------------------------------------------------
@@ -84,6 +86,18 @@ function getSelectValue(id: string): string {
 function setStatus(msg: string): void {
   const el = document.getElementById('status_msg');
   if (el) el.textContent = msg;
+}
+
+function showWarning(msg: string | null): void {
+  const el = document.getElementById('warning_msg');
+  if (!el) return;
+  if (msg) {
+    el.textContent = msg;
+    el.hidden = false;
+  } else {
+    el.textContent = '';
+    el.hidden = true;
+  }
 }
 
 // ---- Timestamp management ----------------------------------------------
@@ -255,6 +269,7 @@ function renderFromCache(
   const isMultiGroup = groupKeys.length > 1;
 
   const globalMatchDateSet = new Set<string>();
+  const allTeamCssClasses: string[] = [];
   const boxCon = document.getElementById('box_container') as HTMLElement | null;
   if (boxCon) boxCon.replaceChildren();
 
@@ -280,6 +295,8 @@ function renderFromCache(
     const { groupData, sortedTeams } = prepareRenderData({
       groupData: singleGroupData, seasonInfo: perGroupInfo, targetDate, sortKey, matchSortKey,
     });
+
+    for (const t of sortedTeams) allTeamCssClasses.push(teamCssClass(t));
 
     if (boxCon) {
       const { fragment, matchDates } = renderBarGraph(
@@ -365,6 +382,14 @@ function renderFromCache(
     } else {
       dsSection.replaceChildren();
     }
+  }
+
+  // I3: Warn about teams with undefined CSS colors.
+  const undefinedTeams = findTeamsWithoutColor(allTeamCssClasses);
+  if (undefinedTeams.length > 0) {
+    showWarning(`チームカラー未定義: ${undefinedTeams.join(', ')}`);
+  } else {
+    showWarning(null);
   }
 }
 

--- a/frontend/src/graph/css-validator.ts
+++ b/frontend/src/graph/css-validator.ts
@@ -1,0 +1,49 @@
+// CSS class validation for team color definitions.
+//
+// Scans loaded stylesheets for background-color rules and identifies
+// team CSS classes that have no color defined (I3 view invariant).
+
+/**
+ * Collects CSS class names that define `background-color` in any loaded stylesheet.
+ *
+ * Cross-origin stylesheets (CDN) are silently skipped because their
+ * `cssRules` access throws SecurityError.
+ */
+function collectColorClasses(): Set<string> {
+  const defined = new Set<string>();
+  for (let si = 0; si < document.styleSheets.length; si++) {
+    const sheet = document.styleSheets[si];
+    let rules: CSSRuleList;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      // Cross-origin stylesheet — skip
+      continue;
+    }
+    for (let ri = 0; ri < rules.length; ri++) {
+      const rule = rules[ri];
+      if (!(rule instanceof CSSStyleRule)) continue;
+      if (!rule.style.backgroundColor) continue;
+      const matches = rule.selectorText.match(/\.([^\s.,:>+~[\]()]+)/g);
+      if (matches) {
+        for (const m of matches) defined.add(m.slice(1));
+      }
+    }
+  }
+  return defined;
+}
+
+/**
+ * Returns team CSS classes from `teamCssClasses` that have no `background-color`
+ * defined in any loaded stylesheet.
+ *
+ * @param definedOverride  Injected set for testing; production code omits this.
+ */
+export function findTeamsWithoutColor(
+  teamCssClasses: string[],
+  definedOverride?: Set<string>,
+): string[] {
+  const defined = definedOverride ?? collectColorClasses();
+  const unique = [...new Set(teamCssClasses)];
+  return unique.filter(cls => !defined.has(cls));
+}

--- a/frontend/src/j_points.html
+++ b/frontend/src/j_points.html
@@ -87,6 +87,9 @@
   <span class="timestamp-label">データ取得時刻: <span id="data_timestamp"></span></span>
 </div>
 
+<!-- Warning message (team color CSS undefined etc.) -->
+<div id="warning_msg" hidden></div>
+
 <!-- Bar graph container -->
 <div id="box_container"></div>
 


### PR DESCRIPTION
Fixes #130

## Summary
- I3 不変条件（チームカラー未定義の警告）をフロントエンドに実装
- 描画後に `document.styleSheets` をスキャンし、`background-color` 未定義のチーム CSS クラスを検出
- 該当チームがあれば黄色の警告バナーで表示（描画はブロックしない）

## Changes
| Commit | Description |
| ------ | ----------- |
| `c08bbd4` | Add team color CSS undefined warning (I3 view invariant) |

## Test plan
- [x] `npx vitest run` passed (frontend/)
- [x] `npm run typecheck` passed (frontend/)
- [x] `npm run build` succeeded (frontend/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)