### PR TITLE
Add Playwright E2E CI workflow

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -1,0 +1,60 @@
+name: Playwright E2E tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      full_render:
+        description: 'Include @full-render tests (all seasons)'
+        type: boolean
+        default: false
+  pull_request:
+    branches:
+      - main
+      - 'feature/**'
+    paths:
+      - 'frontend/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
+        working-directory: frontend
+
+      - name: Run E2E tests
+        run: npx playwright test --grep-invert @full-render
+        working-directory: frontend
+
+      - name: Run full-render tests
+        if: github.event_name == 'workflow_dispatch' && inputs.full_render
+        run: npx playwright test --grep @full-render
+        working-directory: frontend
+
+      - name: Upload test report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/frontend/e2e/basic-render.spec.ts
+++ b/frontend/e2e/basic-render.spec.ts
@@ -16,6 +16,9 @@ test.describe('T1: Basic Rendering', () => {
     expect(await rankRows.count()).toBeGreaterThan(0);
 
     await assertInvariants(page);
+
+    // I3: no team color warning on default load
+    await expect(page.locator('#warning_msg')).toBeHidden();
   });
 
   test('status message shows row count', async ({ page }) => {

--- a/frontend/e2e/basic-render.spec.ts
+++ b/frontend/e2e/basic-render.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './helpers/test-base';
 import { waitForRender, assertInvariants } from './helpers/invariants';
 
 test.describe('T1: Basic Rendering', () => {

--- a/frontend/e2e/date-slider.spec.ts
+++ b/frontend/e2e/date-slider.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './helpers/test-base';
 import { waitForRender, assertInvariants } from './helpers/invariants';
 
 test.describe('T4: Date Slider', () => {

--- a/frontend/e2e/dropdown.spec.ts
+++ b/frontend/e2e/dropdown.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './helpers/test-base';
 import { waitForRender, assertInvariants } from './helpers/invariants';
 
 test.describe('T2: Dropdown Interaction', () => {

--- a/frontend/e2e/full-render.spec.ts
+++ b/frontend/e2e/full-render.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, expect } from './helpers/test-base';
 import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -58,6 +58,9 @@ test.describe('@full-render: All seasons invariant check', () => {
         return;
       }
       await assertInvariants(page);
+
+      // I3: no team color warning
+      await expect(page.locator('#warning_msg')).toBeHidden();
     });
   }
 });

--- a/frontend/e2e/helpers/test-base.ts
+++ b/frontend/e2e/helpers/test-base.ts
@@ -1,0 +1,16 @@
+import { test as base, expect } from '@playwright/test';
+
+/**
+ * Extended Playwright test that monitors for uncaught JavaScript errors.
+ * All spec files should import { test, expect } from this module.
+ */
+export const test = base.extend<{ pageErrors: string[] }>({
+  pageErrors: [async ({ page }, use) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+    await use(errors);
+    expect(errors, 'Uncaught JavaScript errors detected').toEqual([]);
+  }, { auto: true }],
+});
+
+export { expect };

--- a/frontend/e2e/rank-table.spec.ts
+++ b/frontend/e2e/rank-table.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './helpers/test-base';
 import { waitForRender, assertInvariants } from './helpers/invariants';
 
 test.describe('T5: Rank Table', () => {

--- a/frontend/e2e/url-params.spec.ts
+++ b/frontend/e2e/url-params.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './helpers/test-base';
 import { waitForRender, assertInvariants } from './helpers/invariants';
 
 test.describe('T3: URL Parameters', () => {
@@ -33,9 +33,6 @@ test.describe('T3: URL Parameters', () => {
   });
 
   test('invalid params fall back to defaults without error', async ({ page }) => {
-    const errors: string[] = [];
-    page.on('pageerror', (err) => errors.push(err.message));
-
     await page.goto('/j_points.html?competition=INVALID&season=INVALID');
     // Should still render something (falls back to first available)
     await waitForRender(page);
@@ -43,8 +40,7 @@ test.describe('T3: URL Parameters', () => {
     const teamColumns = page.locator('#box_container [id$="_column"]');
     expect(await teamColumns.count()).toBeGreaterThan(0);
 
-    // No uncaught errors
-    expect(errors).toEqual([]);
+    // pageerror monitoring is handled by test-base fixture
     await assertInvariants(page);
   });
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? 'github' : 'list',
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
   use: {
     baseURL: 'http://localhost:4173',
     trace: 'on-first-retry',


### PR DESCRIPTION
Fixes #133

## Summary

- Playwright E2E テストの CI ワークフローを新規追加 (`test-e2e.yaml`)
- PR 時・main push 時に `frontend/` 変更で自動実行（`@full-render` 除外）
- `workflow_dispatch` で `@full-render`（全シーズン巡回）を手動実行可能
- テスト失敗時に HTML レポートを artifact としてアップロード
- PR #131 マージ時に漏れた E2E 改善コミットも含む（pageerror フィクスチャ、I3 全シーズンチェック）

## Changes

| Commit | Description |
| --- | --- |
| `66e9bf2` | Add I3 warning absence check to basic-render E2E test |
| `1d1923c` | Add pageerror fixture and I3 check to full-render E2E tests |
| `0fb1fcd` | Add Playwright E2E CI workflow |

## Test plan

- [x] `npx vitest run` passed (frontend/)
- [x] `npx playwright test --grep-invert @full-render` passed (38 tests)
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)