### PR TITLE
Add i18n infrastructure with Japanese/English support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ JLeague_Matches-Bar_Graph/
 │   │   ├── storage/                #   localStorage 永続化
 │   │   ├── types/                  #   型定義 (match, season, config)
 │   │   └── __tests__/              #   Vitest テスト
+│   ├── e2e/                        #   Playwright E2E テスト
+│   ├── playwright.config.ts
 │   ├── vite.config.ts              #   ビルド → docs/ に出力
 │   └── vitest.config.ts
 ├── src/                             # Python スクリプト (データ取得・変換)
@@ -37,7 +39,12 @@ JLeague_Matches-Bar_Graph/
 │   ├── csv/                        #   処理済みCSV
 │   └── json/                       #   season_map.json
 ├── scripts/                         #   CI/CDスクリプト, 運用ユーティリティ
-│   └── legacy/                     #   旧データ処理スクリプト (1993-2020)
+│   ├── check_type_sync.py          #   Python ↔ TS 型同期チェック (CI)
+│   ├── check_point_system_csv.py   #   PointSystem ↔ CSV 整合検証 (CI)
+│   ├── fetch_match_detail.py       #   旧試合詳細ページ取得 (1回限り)
+│   ├── enrich_match_detail.py      #   試合詳細→延長スコア反映 (1回限り)
+│   ├── parse_match_detail.py       #   試合詳細 HTML パーサー
+│   └── legacy/                     #   旧データ処理スクリプト + config (1993-2020)
 ├── .github/workflows/               #   Pages デプロイ, CSV更新, テスト, ビルドチェック
 └── pyproject.toml                   #   Python依存 (uv管理)
 ```
@@ -45,7 +52,7 @@ JLeague_Matches-Bar_Graph/
 ## 技術スタック
 
 - **Python 3.12+**: BeautifulSoup4, requests, pandas, PyYAML / パッケージ管理: uv / テスト: pytest
-- **TypeScript + Vite**: PapaParse (CSV), SortableTable (CDN) / パッケージ管理: npm / テスト: vitest (DOM: happy-dom) / Node.js 22
+- **TypeScript + Vite**: PapaParse (CSV), SortableTable (CDN) / パッケージ管理: npm / テスト: vitest (DOM: happy-dom), Playwright (E2E) / Node.js 22
 - **CI/CD**: GitHub Actions (CSV定期更新 + TSビルド&デプロイ + テスト) → GitHub Pages
 
 ## 主要コマンド
@@ -62,6 +69,11 @@ npm test                  # vitest 実行 (npx vitest run)
 npm run typecheck         # tsc --noEmit
 npm run build             # tsc && vite build → docs/ に出力
 npm run dev               # Vite開発サーバー起動
+
+# === E2E テスト (frontend/ で実行) ===
+npx playwright test                              # E2E 全テスト
+npx playwright test --grep-invert @full-render   # full-render 除外 (CI デフォルト)
+npx playwright test --grep @full-render          # full-render のみ
 ```
 
 ## デプロイモデル
@@ -135,6 +147,7 @@ npm run dev               # Vite開発サーバー起動
 - `season_start_month`: シーズン開始月。カスケード対象。コードデフォルト: `7` (秋春制)
 - `data_source`: データ参照元。`{label, url}` オブジェクト。カスケード対象 (スカラ: 下位が上書き)。フロントエンドで動的表示
 - `note`: 注記テキスト (`string | string[]`)。カスケード対象 (和集合: Group + Competition + Entry を結合)。フロントエンドで動的表示
+- `promotion_label`: 昇格枠のラベル文字列 (デフォルト: `'昇格'`)。カスケード対象 (スカラ: 下位が上書き)。HTML 許容 (例: `'昇格<br/>ACL'`)
 
 ### シーズン命名規則
 
@@ -169,7 +182,7 @@ uv run python scripts/check_type_sync.py
 
 ### TS 側のみ許容するフィールド
 
-`RawMatchRow` には Python が生成しないフィールドも含まれる (旧 CSV 互換 alias、Tier 4 準備カラム)。これらは `check_type_sync.py` 内の `TS_ONLY_CSV_FIELDS` で管理。
+`RawMatchRow` に Python 側にないフィールドがある場合、`check_type_sync.py` 内の `TS_ONLY_CSV_FIELDS` で管理する。現在は空 (全フィールドが Python ↔ TS で同期済み)。
 
 ## 設計上の決定事項
 

--- a/frontend/src/__tests__/i18n/i18n.test.ts
+++ b/frontend/src/__tests__/i18n/i18n.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { t, setLocale, getLocale, applyI18nAttributes } from '../../i18n';
+import { ja } from '../../i18n/messages/ja';
+import { en } from '../../i18n/messages/en';
+
+beforeEach(() => {
+  setLocale('ja');
+});
+
+describe('t() basic lookup', () => {
+  it('returns Japanese text by default', () => {
+    expect(t('label.competition')).toBe('大会');
+  });
+
+  it('returns English text when locale is en', () => {
+    setLocale('en');
+    expect(t('label.competition')).toBe('Competition');
+  });
+
+  it('returns the key itself for unknown keys', () => {
+    // Cast to bypass type safety for this edge-case test
+    expect(t('nonexistent.key' as never)).toBe('nonexistent.key');
+  });
+});
+
+describe('t() placeholder interpolation', () => {
+  it('replaces single placeholder', () => {
+    setLocale('en');
+    expect(t('status.loading')).toBe('Loading CSV...');
+  });
+
+  it('replaces multiple placeholders', () => {
+    setLocale('en');
+    expect(t('status.loaded', { league: 'J1', season: '2026', rows: 380 }))
+      .toBe('J1 2026 — 380 rows');
+  });
+
+  it('replaces multiple placeholders in Japanese', () => {
+    expect(t('tip.record', { win: 10, draw: 5, loss: 3 }))
+      .toBe('10勝 / 5分 / 3敗');
+  });
+
+  it('replaces repeated placeholders', () => {
+    // score.et has {get} and {lose}
+    setLocale('en');
+    expect(t('score.et', { get: 2, lose: 1 })).toBe('ET2-1');
+  });
+});
+
+describe('setLocale / getLocale', () => {
+  it('defaults to ja', () => {
+    expect(getLocale()).toBe('ja');
+  });
+
+  it('switches to en and back', () => {
+    setLocale('en');
+    expect(getLocale()).toBe('en');
+    expect(document.documentElement.lang).toBe('en');
+
+    setLocale('ja');
+    expect(getLocale()).toBe('ja');
+    expect(document.documentElement.lang).toBe('ja');
+  });
+});
+
+describe('English dictionary completeness', () => {
+  const jaKeys = Object.keys(ja) as (keyof typeof ja)[];
+
+  it('en has every key defined in ja', () => {
+    const enKeys = new Set(Object.keys(en));
+    const missing = jaKeys.filter(k => !enKeys.has(k));
+    expect(missing, `Missing English keys: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('en has no extra keys beyond ja', () => {
+    const jaKeySet = new Set(jaKeys as string[]);
+    const extra = Object.keys(en).filter(k => !jaKeySet.has(k));
+    expect(extra, `Extra English keys: ${extra.join(', ')}`).toEqual([]);
+  });
+
+  it('no en values are empty strings', () => {
+    const empty = jaKeys.filter(k => en[k] === '');
+    expect(empty, `Empty English values: ${empty.join(', ')}`).toEqual([]);
+  });
+});
+
+describe('applyI18nAttributes', () => {
+  it('replaces textContent of elements with data-i18n', () => {
+    document.body.innerHTML = '<span data-i18n="label.competition"></span>';
+    applyI18nAttributes();
+    expect(document.querySelector('span')!.textContent).toBe('大会');
+  });
+
+  it('applies English text when locale is en', () => {
+    setLocale('en');
+    document.body.innerHTML = '<span data-i18n="label.season"></span>';
+    applyI18nAttributes();
+    expect(document.querySelector('span')!.textContent).toBe('Season');
+  });
+
+  it('handles multiple elements', () => {
+    document.body.innerHTML = `
+      <span data-i18n="btn.resetDate"></span>
+      <span data-i18n="btn.resetPrefs"></span>
+    `;
+    applyI18nAttributes();
+    const spans = document.querySelectorAll('span');
+    expect(spans[0].textContent).toBe('最新にリセット');
+    expect(spans[1].textContent).toBe('設定をリセット');
+  });
+});

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -29,7 +29,8 @@ import { DEFAULT_HEIGHT_UNIT, getHeightUnit, setFutureOpacity, setSpace, setScal
 import { findTeamsWithoutColor } from './graph/css-validator';
 import { teamCssClass } from './core/team-utils';
 import { loadPrefs, savePrefs, clearPrefs } from './storage/local-storage';
-import { t, applyI18nAttributes } from './i18n';
+import { t, applyI18nAttributes, setLocale } from './i18n';
+import type { Locale } from './i18n';
 
 // ---- Application state ------------------------------------------------
 
@@ -471,6 +472,10 @@ function loadAndRender(seasonMap: SeasonMap): void {
 // ---- Initialization & event wiring ------------------------------------
 
 async function main(): Promise<void> {
+  // Restore locale from prefs before any i18n calls.
+  const savedLocale = loadPrefs().locale;
+  if (savedLocale === 'ja' || savedLocale === 'en') setLocale(savedLocale as Locale);
+
   applyI18nAttributes();
   void loadTimestampMap();
 
@@ -607,6 +612,17 @@ async function main(): Promise<void> {
     setSpace(v);
     savePrefs({ spaceColor: v });
   });
+
+  // ---- Locale selector ----
+
+  const localeSel = document.getElementById('locale_key') as HTMLSelectElement | null;
+  if (localeSel) {
+    if (savedLocale) localeSel.value = savedLocale;
+    localeSel.addEventListener('change', () => {
+      savePrefs({ locale: localeSel.value });
+      location.reload();
+    });
+  }
 
   // ---- Reset ----
 

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -29,6 +29,7 @@ import { DEFAULT_HEIGHT_UNIT, getHeightUnit, setFutureOpacity, setSpace, setScal
 import { findTeamsWithoutColor } from './graph/css-validator';
 import { teamCssClass } from './core/team-utils';
 import { loadPrefs, savePrefs, clearPrefs } from './storage/local-storage';
+import { t, applyI18nAttributes } from './i18n';
 
 // ---- Application state ------------------------------------------------
 
@@ -63,19 +64,25 @@ const CACHE_BUST_WINDOW_SEC = 300; // 5 minutes
 
 // ---- Fixed dropdown options (generated into HTML by TS) ------------------
 
-const TEAM_SORT_OPTIONS = [
-  { value: 'disp_point',    label: '勝点(表示時)' },
-  { value: 'disp_avlbl_pt', label: '最大勝点(表示時)' },
-  { value: 'point',         label: '勝点(最新)' },
-  { value: 'avlbl_pt',      label: '最大勝点(最新)' },
-] as const;
+const MATCH_SORT_VALUES = ['old_bottom', 'new_bottom', 'first_bottom', 'last_bottom'] as const;
 
-const MATCH_SORT_OPTIONS = [
-  { value: 'old_bottom',   label: '古い試合が下' },
-  { value: 'new_bottom',   label: '新しい試合が下' },
-  { value: 'first_bottom', label: '第1節が下' },
-  { value: 'last_bottom',  label: '最終節が下' },
-] as const;
+function getTeamSortOptions(): { value: string; label: string }[] {
+  return [
+    { value: 'disp_point',    label: t('sort.dispPoint') },
+    { value: 'disp_avlbl_pt', label: t('sort.dispAvlblPt') },
+    { value: 'point',         label: t('sort.point') },
+    { value: 'avlbl_pt',      label: t('sort.avlblPt') },
+  ];
+}
+
+function getMatchSortOptions(): { value: string; label: string }[] {
+  return [
+    { value: 'old_bottom',   label: t('sort.oldBottom') },
+    { value: 'new_bottom',   label: t('sort.newBottom') },
+    { value: 'first_bottom', label: t('sort.firstBottom') },
+    { value: 'last_bottom',  label: t('sort.lastBottom') },
+  ];
+}
 
 // ---- DOM helpers -------------------------------------------------------
 
@@ -155,7 +162,7 @@ function writeUrlParams(competition: string, season: string): void {
 
 // ---- Fixed dropdown population -----------------------------------------
 
-type MatchSortUiValue = typeof MATCH_SORT_OPTIONS[number]['value'];
+type MatchSortUiValue = typeof MATCH_SORT_VALUES[number];
 
 function populateFixedSelect(
   id: string,
@@ -296,7 +303,7 @@ function renderFromCache(
       groupData: singleGroupData, seasonInfo: perGroupInfo, targetDate, sortKey, matchSortKey,
     });
 
-    for (const t of sortedTeams) allTeamCssClasses.push(teamCssClass(t));
+    for (const team of sortedTeams) allTeamCssClasses.push(teamCssClass(team));
 
     if (boxCon) {
       const { fragment, matchDates } = renderBarGraph(
@@ -311,7 +318,7 @@ function renderFromCache(
         wrapper.classList.add('group_wrapper');
         const label = document.createElement('div');
         label.classList.add('group_label');
-        label.textContent = `グループ${groupKey}`;
+        label.textContent = t('graph.group', { key: groupKey });
         wrapper.appendChild(label);
         wrapper.appendChild(fragment);
         boxCon.appendChild(wrapper);
@@ -378,7 +385,7 @@ function renderFromCache(
       const a = document.createElement('a');
       a.href = seasonInfo.dataSource.url;
       a.textContent = seasonInfo.dataSource.label;
-      dsSection.replaceChildren('データ参照元: ', a);
+      dsSection.replaceChildren(t('status.dataSource'), a);
     } else {
       dsSection.replaceChildren();
     }
@@ -387,7 +394,7 @@ function renderFromCache(
   // I3: Warn about teams with undefined CSS colors.
   const undefinedTeams = findTeamsWithoutColor(allTeamCssClasses);
   if (undefinedTeams.length > 0) {
-    showWarning(`チームカラー未定義: ${undefinedTeams.join(', ')}`);
+    showWarning(t('warn.undefinedColor', { teams: undefinedTeams.join(', ') }));
   } else {
     showWarning(null);
   }
@@ -409,7 +416,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
 
   const found = findCompetition(seasonMap, competition);
   if (!found || !found.competition.seasons[season]) {
-    setStatus(`シーズン情報なし: ${competition}/${season}`);
+    setStatus(t('status.noSeason', { competition, season }));
     return;
   }
 
@@ -423,12 +430,12 @@ function loadAndRender(seasonMap: SeasonMap): void {
   if (state.teamMapCache?.key === csvKey) {
     renderFromCache(state.teamMapCache, seasonMap, competition, season, targetDate, sortKey, matchSortKey, bottomFirst, disp);
     showTimestamp(filename);
-    setStatus(`${leagueDisplay} ${season} (cached)`);
+    setStatus(t('status.cached', { league: leagueDisplay, season }));
     return;
   }
 
   const cachebuster = Math.floor(Date.now() / 1000 / CACHE_BUST_WINDOW_SEC);
-  setStatus('CSVを読み込み中...');
+  setStatus(t('status.loading'));
 
   Papa.parse<RawMatchRow>(filename + '?_=' + cachebuster, {
     header: true,
@@ -453,10 +460,10 @@ function loadAndRender(seasonMap: SeasonMap): void {
 
       renderFromCache(newCache, seasonMap, competition, season, targetDate, sortKey, matchSortKey, bottomFirst, disp);
       showTimestamp(filename);
-      setStatus(`${leagueDisplay} ${season} — ${results.data.length} 行`);
+      setStatus(t('status.loaded', { league: leagueDisplay, season, rows: results.data.length }));
     },
     error: (err: unknown) => {
-      setStatus(`CSV読み込みエラー: ${String(err)}`);
+      setStatus(t('status.error', { detail: String(err) }));
     },
   });
 }
@@ -464,13 +471,14 @@ function loadAndRender(seasonMap: SeasonMap): void {
 // ---- Initialization & event wiring ------------------------------------
 
 async function main(): Promise<void> {
+  applyI18nAttributes();
   void loadTimestampMap();
 
   let seasonMap: SeasonMap;
   try {
     seasonMap = await loadSeasonMap();
   } catch (err) {
-    setStatus('season_map.json の読み込みに失敗しました');
+    setStatus(t('status.seasonMapError'));
     console.error('Failed to load season map:', err);
     return;
   }
@@ -478,8 +486,8 @@ async function main(): Promise<void> {
   state.heightUnit = getHeightUnit();
 
   populateCompetitionPulldown(seasonMap);
-  populateFixedSelect('team_sort_key', TEAM_SORT_OPTIONS);
-  populateFixedSelect('match_sort_key', MATCH_SORT_OPTIONS);
+  populateFixedSelect('team_sort_key', getTeamSortOptions());
+  populateFixedSelect('match_sort_key', getMatchSortOptions());
 
   // Determine initial competition/season from URL params → localStorage → default
   const urlParams = readUrlParams();

--- a/frontend/src/config/rule-notes.ts
+++ b/frontend/src/config/rule-notes.ts
@@ -1,29 +1,25 @@
 // Auto-generated rule notes for non-standard point systems and tiebreak orders.
-//
-// i18n strategy: all user-facing strings live in the dictionaries below.
-// To add a locale, introduce a Record<Locale, ...> wrapper around each dictionary
-// and pass a locale parameter to generateRuleNotes().
 
 import type { PointSystem } from '../types/config';
+import type { MessageKey } from '../i18n';
+import { t } from '../i18n';
 
-/** Point system rule descriptions. 'standard' is omitted (no note needed). */
-const POINT_SYSTEM_NOTES: Partial<Record<PointSystem, string>> = {
-  'victory-count':   '勝敗数のみカウント (勝ち=1点)',
-  'win3all-pkloss1': '勝ち=3点 (90分/延長/PK共通), PK負け=1点',
-  'graduated-win':   '90分勝ち=3点, 延長勝ち=2点, PK勝ち=1点',
-  'ex-win-2':        '90分勝ち=3点, 延長勝ち=2点, 引分け=1点',
-  'pk-win2-loss1':   '勝ち=3点, PK勝ち=2点, PK負け=1点',
+/** Point system → i18n key. 'standard' is omitted (no note needed). */
+const POINT_SYSTEM_NOTE_KEYS: Partial<Record<PointSystem, MessageKey>> = {
+  'victory-count':   'rule.victoryCount',
+  'win3all-pkloss1': 'rule.win3allPkloss1',
+  'graduated-win':   'rule.graduatedWin',
+  'ex-win-2':        'rule.exWin2',
+  'pk-win2-loss1':   'rule.pkWin2Loss1',
 };
 
-/** Human-readable labels for tiebreak criteria. */
-const TIEBREAK_LABELS: Record<string, string> = {
-  head_to_head: '直接対戦',
-  goal_diff: '得失点差',
-  goal_get: '総得点',
-  wins: '勝利数',
+/** Tiebreak criteria → i18n key. */
+const TIEBREAK_LABEL_KEYS: Record<string, MessageKey> = {
+  head_to_head: 'rule.headToHead',
+  goal_diff: 'rule.goalDiff',
+  goal_get: 'rule.goalGet',
+  wins: 'rule.wins',
 };
-
-const TIEBREAK_PREFIX = '同勝点時の順位決定: ';
 
 /** Default tiebreak order — no note generated when this is the active order. */
 const DEFAULT_TIEBREAK: readonly string[] = ['goal_diff', 'goal_get'];
@@ -42,12 +38,15 @@ export function generateRuleNotes(
 ): string[] {
   const notes: string[] = [];
 
-  const psNote = POINT_SYSTEM_NOTES[pointSystem];
-  if (psNote) notes.push(psNote);
+  const psKey = POINT_SYSTEM_NOTE_KEYS[pointSystem];
+  if (psKey) notes.push(t(psKey));
 
   if (!arraysEqual(tiebreakOrder, DEFAULT_TIEBREAK)) {
-    const labels = tiebreakOrder.map(k => TIEBREAK_LABELS[k] ?? k);
-    notes.push(TIEBREAK_PREFIX + labels.join(' → '));
+    const labels = tiebreakOrder.map(k => {
+      const key = TIEBREAK_LABEL_KEYS[k];
+      return key ? t(key) : k;
+    });
+    notes.push(t('rule.tiebreakPrefix') + labels.join(' → '));
   }
 
   return notes;

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -6,6 +6,7 @@ import type {
   CrossGroupStanding, DataSource,
 } from '../types/season';
 import { generateRuleNotes } from './rule-notes';
+import { t } from '../i18n';
 
 /**
  * Returns the CSV filename for a given competition and season.
@@ -132,7 +133,7 @@ export function resolveSeasonInfo(
   const promotionLabel: string = opts.promotion_label
     ?? comp.promotion_label
     ?? group.promotion_label
-    ?? '昇格';
+    ?? t('col.promotion');
 
   // notes: union across all three levels (flattened, preserving order)
   const toArray = (v: string | string[] | undefined): string[] =>

--- a/frontend/src/core/csv-parser.ts
+++ b/frontend/src/core/csv-parser.ts
@@ -5,6 +5,12 @@ import { TeamStats } from '../types/match';
 import type { RawMatchRow, TeamMap, TeamMatch } from '../types/match';
 import { dateFormat } from './date-utils';
 import { getPointFromResult } from './point-calculator';
+import { t } from '../i18n';
+
+/** CSV status values — not translated (must match CSV data vocabulary). */
+const CSV_STATUS_FINISHED = '試合終了';
+const CSV_STATUS_VS = 'ＶＳ';
+const CSV_STATUS_LIVE = '速報中';
 
 /**
  * Returns the display status string for a match row.
@@ -13,10 +19,10 @@ import { getPointFromResult } from './point-calculator';
  */
 function makeStatusAttr(match: RawMatchRow): string {
   if (match.status === undefined) {
-    return (match.home_goal && match.away_goal) ? '試合終了' : '';
+    return (match.home_goal && match.away_goal) ? CSV_STATUS_FINISHED : '';
   }
-  if (match.status === 'ＶＳ') return '開始前';
-  return match.status.replace('速報中', '');
+  if (match.status === CSV_STATUS_VS) return t('tip.matchStatus.started');
+  return match.status.replace(CSV_STATUS_LIVE, '');
 }
 
 /**
@@ -25,7 +31,7 @@ function makeStatusAttr(match: RawMatchRow): string {
  * @returns True if the match is live, false otherwise
  */
 function makeLiveAttr(match: RawMatchRow): boolean {
-  return match.status?.includes('速報中') ?? false;
+  return match.status?.includes(CSV_STATUS_LIVE) ?? false;
 }
 
 /**

--- a/frontend/src/graph/bar-column.ts
+++ b/frontend/src/graph/bar-column.ts
@@ -8,12 +8,16 @@ import type { TeamData } from '../types/match';
 import { timeFormat } from '../core/date-utils';
 import { getPointHeightScale, getWinPoints } from '../core/point-calculator';
 import { teamCssClass } from '../core/team-utils';
+import { t } from '../i18n';
 import {
   makeBoxBody,
   makeFullContent,
   makeCancelledContent,
   makeTeamStats,
 } from './tooltip';
+
+/** CSV status value for cancelled matches (not translated — matches CSV data). */
+const CSV_STATUS_CANCELLED = '試合中止';
 
 /** CSS class name for box height based on point value. */
 const BOX_HEIGHT_CLASS: Record<number, string> = {
@@ -106,12 +110,14 @@ export function buildTeamColumn(
   const futureClass = boxHeightClass(winPt * scale);
   const cssClass = teamCssClass(teamName);
 
-  for (const row of teamData.df) {
-    // Normalize display date: empty string → '未定'
-    const matchDate = row.match_date === '' ? '未定' : row.match_date;
-    if (matchDate !== '未定') matchDateSet.add(matchDate);
+  const undecided = t('graph.undecided');
 
-    if (row.status === '試合中止') {
+  for (const row of teamData.df) {
+    // Normalize display date: empty string → undecided label
+    const matchDate = row.match_date === '' ? undecided : row.match_date;
+    if (matchDate !== undecided) matchDateSet.add(matchDate);
+
+    if (row.status === CSV_STATUS_CANCELLED) {
       lossBox.push(makeCancelledContent(row, matchDate));
       continue;
     }

--- a/frontend/src/graph/renderer.ts
+++ b/frontend/src/graph/renderer.ts
@@ -9,6 +9,7 @@ import { getPointHeightScale } from '../core/point-calculator';
 import { buildTeamColumn } from './bar-column';
 import type { ColumnResult } from './bar-column';
 import { getRankClass, joinLossBox } from './tooltip';
+import { t } from '../i18n';
 
 /** Return value of renderBarGraph, consumed by app.ts. */
 export interface RenderResult {
@@ -53,8 +54,8 @@ export function makePointColumn(maxAvblPt: number, bottomFirst: boolean, heightS
   const col = document.createElement('div');
   col.classList.add('point_column');
 
-  col.appendChild(createPointBox('順位'));
-  col.appendChild(createPointBox('勝点'));
+  col.appendChild(createPointBox(t('col.rank')));
+  col.appendChild(createPointBox(t('col.points')));
 
   const indices = Array.from({ length: maxAvblPt }, (_, i) => i + 1);
   if (bottomFirst) indices.reverse();
@@ -64,8 +65,8 @@ export function makePointColumn(maxAvblPt: number, bottomFirst: boolean, heightS
     col.appendChild(box);
   }
 
-  col.appendChild(createPointBox('勝点'));
-  col.appendChild(createPointBox('順位'));
+  col.appendChild(createPointBox(t('col.points')));
+  col.appendChild(createPointBox(t('col.rank')));
 
   return col;
 }
@@ -122,7 +123,7 @@ export function assembleTeamColumn(
     div.append(col.teamName);
     const span = document.createElement('span');
     span.classList.add('tooltiptext', 'fullW', col.cssClass);
-    span.innerHTML = `成績情報:<hr/>${col.stats}<hr/>敗戦記録:<hr/>${joinLossBox(lossBox)}`;
+    span.innerHTML = `${t('tip.statsHeader')}<hr/>${col.stats}<hr/>${t('tip.lossHeader')}<hr/>${joinLossBox(lossBox)}`;
     div.appendChild(span);
     return div;
   }
@@ -246,5 +247,5 @@ export function findSliderIndex(matchDates: string[], targetDate: string): numbe
  * which may differ from sliderDate when typed between match days).
  */
 export function formatSliderDate(sliderDate: string, targetDate: string): string {
-  return sliderDate === '1970/01/01' ? '開幕前' : targetDate;
+  return sliderDate === '1970/01/01' ? t('slider.preseason') : targetDate;
 }

--- a/frontend/src/graph/tooltip.ts
+++ b/frontend/src/graph/tooltip.ts
@@ -4,6 +4,7 @@
 import type { TeamMatch, TeamStats } from '../types/match';
 import type { SeasonInfo } from '../types/season';
 import { dateOnly, timeFormat } from '../core/date-utils';
+import { t } from '../i18n';
 
 /** Max display length for opponent name in box/tooltip content. */
 const OPPONENT_MAX_LEN = 3;
@@ -14,10 +15,10 @@ const STADIUM_MAX_LEN = 7;
 function formatScore(row: TeamMatch): string {
   let s = `${row.goal_get}-${row.goal_lose}`;
   if (row.score_ex_get != null && row.score_ex_lose != null && row.score_ex_get !== row.score_ex_lose) {
-    s += ` (ET${row.score_ex_get}-${row.score_ex_lose})`;
+    s += ` (${t('score.et', { get: row.score_ex_get, lose: row.score_ex_lose })})`;
   }
   if (row.pk_get != null && row.pk_lose != null) {
-    s += ` (PK${row.pk_get}-${row.pk_lose})`;
+    s += ` (${t('score.pk', { get: row.pk_get, lose: row.pk_lose })})`;
   }
   return s;
 }
@@ -45,7 +46,7 @@ export function makeFullContent(row: TeamMatch, matchDate: string): string {
 
 /** Content for a cancelled match shown in the lossBox tooltip. */
 export function makeCancelledContent(row: TeamMatch, matchDate: string): string {
-  const datePart = matchDate === '未定' ? '未定' : dateOnly(matchDate);
+  const datePart = matchDate === t('graph.undecided') ? t('graph.undecided') : dateOnly(matchDate);
   return `(${row.section_no}) ${datePart} ${row.opponent.substring(0, OPPONENT_MAX_LEN)}<br/>${row.status}`;
 }
 
@@ -55,18 +56,18 @@ export function makeCancelledContent(row: TeamMatch, matchDate: string): string 
  * hasPk=true → includes PK win/loss counts (omitted when the season has no PK matches).
  */
 export function makeTeamStats(stats: TeamStats, disp: boolean, hasPk = false, hasEx = false): string {
-  const label = disp ? '表示時の状態' : '最新の状態';
+  const label = disp ? t('tip.statsLabel.disp') : t('tip.statsLabel.latest');
   const rc = stats.resultCounts;
   const lines = [
-    `${label}`,
-    `${rc.win}勝 / ${rc.draw}分 / ${rc.loss}敗`,
+    label,
+    t('tip.record', { win: rc.win, draw: rc.draw, loss: rc.loss }),
   ];
-  if (hasEx) lines.push(`${rc.ex_win}延勝 / ${rc.ex_loss}延負`);
-  if (hasPk) lines.push(`${rc.pk_win}PK勝 / ${rc.pk_loss}PK負`);
+  if (hasEx) lines.push(t('tip.exRecord', { exWin: rc.ex_win, exLoss: rc.ex_loss }));
+  if (hasPk) lines.push(t('tip.pkRecord', { pkWin: rc.pk_win, pkLoss: rc.pk_loss }));
   lines.push(
-    `勝点${stats.point}, 最大${stats.avlbl_pt}`,
-    `${stats.goal_get}得点, ${stats.goal_get - stats.goal_diff}失点`,
-    `得失点差: ${stats.goal_diff}`,
+    t('tip.points', { point: stats.point, max: stats.avlbl_pt }),
+    t('tip.goals', { get: stats.goal_get, lose: stats.goal_get - stats.goal_diff }),
+    t('tip.goalDiff', { diff: stats.goal_diff }),
   );
   return lines.join('<br/>');
 }

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,36 @@
+import type { Locale } from './types';
+import { ja, type MessageKey } from './messages/ja';
+
+const messages: Record<Locale, Record<MessageKey, string>> = { ja, en: ja };
+
+let currentLocale: Locale = 'ja';
+
+export function setLocale(locale: Locale): void {
+  currentLocale = locale;
+  document.documentElement.lang = locale;
+}
+
+export function getLocale(): Locale {
+  return currentLocale;
+}
+
+/** Simple message lookup with {placeholder} interpolation. */
+export function t(key: MessageKey, params?: Record<string, string | number>): string {
+  let msg: string = messages[currentLocale][key] ?? messages['ja'][key] ?? key;
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      msg = msg.replace(new RegExp(`\\{${k}\\}`, 'g'), String(v));
+    }
+  }
+  return msg;
+}
+
+/** Replace textContent of all elements with data-i18n attribute. */
+export function applyI18nAttributes(): void {
+  document.querySelectorAll<HTMLElement>('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n') as MessageKey;
+    if (key) el.textContent = t(key);
+  });
+}
+
+export type { Locale, MessageKey };

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,7 +1,8 @@
 import type { Locale } from './types';
 import { ja, type MessageKey } from './messages/ja';
+import { en } from './messages/en';
 
-const messages: Record<Locale, Record<MessageKey, string>> = { ja, en: ja };
+const messages: Record<Locale, Record<MessageKey, string>> = { ja, en };
 
 let currentLocale: Locale = 'ja';
 

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -1,0 +1,126 @@
+import type { MessageKey } from './ja';
+
+export const en: Record<MessageKey, string> = {
+  // HTML labels
+  'label.competition': 'Competition',
+  'label.season': 'Season',
+  'label.teamSort': 'Team order',
+  'label.matchSort': 'Match order',
+  'label.displayDate': 'Display date',
+  'label.graphScale': 'Graph scale',
+  'label.scaleUnit': 'x',
+  'label.futureOpacity': 'Future match opacity',
+  'label.spaceColor': 'Space color',
+  'label.dataTimestamp': 'Data updated:',
+  'label.language': 'Language',
+
+  // Buttons
+  'btn.resetDate': 'Reset to latest',
+  'btn.resetPrefs': 'Reset preferences',
+  'btn.sliderPrev': '<',
+  'btn.sliderNext': '>',
+
+  // Status messages
+  'status.loading': 'Loading CSV...',
+  'status.loaded': '{league} {season} — {rows} rows',
+  'status.cached': '{league} {season} (cached)',
+  'status.error': 'CSV load error: {detail}',
+  'status.noSeason': 'No season info: {competition}/{season}',
+  'status.seasonMapError': 'Failed to load season_map.json',
+  'status.dataSource': 'Data source: ',
+
+  // Warnings
+  'warn.undefinedColor': 'Undefined team colors: {teams}',
+
+  // Date slider
+  'slider.preseason': 'Preseason',
+
+  // Team sort options
+  'sort.dispPoint': 'Points (displayed)',
+  'sort.dispAvlblPt': 'Max points (displayed)',
+  'sort.point': 'Points (latest)',
+  'sort.avlblPt': 'Max points (latest)',
+
+  // Match sort options
+  'sort.oldBottom': 'Older matches at bottom',
+  'sort.newBottom': 'Newer matches at bottom',
+  'sort.firstBottom': 'Matchday 1 at bottom',
+  'sort.lastBottom': 'Last matchday at bottom',
+
+  // Rank table headers
+  'col.team': 'Team',
+  'col.games': 'GP',
+  'col.points': 'Pts',
+  'col.average': 'Avg',
+  'col.maxPoints': 'Max',
+  'col.win': 'W',
+  'col.draw': 'D',
+  'col.loss': 'L',
+  'col.goalsFor': 'GF',
+  'col.goalsAgainst': 'GA',
+  'col.goalDiff': 'GD',
+  'col.remaining': 'Rem',
+  'col.pkWin': 'PKW',
+  'col.pkLoss': 'PKL',
+  'col.exWin': 'ETW',
+  'col.exLoss': 'ETL',
+  'col.champion': 'Title',
+  'col.promotion': 'Promo',
+  'col.relegation': 'Safety',
+  'col.rank': 'Rank',
+  'col.group': 'Grp',
+
+  // Rank status
+  'rank.clinched': 'Clinched',
+  'rank.eliminated': 'Out',
+  'rank.selfPower': 'In hands',
+  'rank.otherPower': 'Need help',
+  'rank.relegated': 'Relegated',
+
+  // Graph labels
+  'graph.group': 'Group {key}',
+  'graph.undecided': 'TBD',
+  'graph.cancelled': 'Cancelled',
+
+  // Tooltip
+  'tip.statsLabel.disp': 'As of displayed date',
+  'tip.statsLabel.latest': 'Latest',
+  'tip.record': '{win}W / {draw}D / {loss}L',
+  'tip.exRecord': '{exWin} ET wins / {exLoss} ET losses',
+  'tip.pkRecord': '{pkWin} PK wins / {pkLoss} PK losses',
+  'tip.points': 'Pts {point}, Max {max}',
+  'tip.goals': '{get} scored, {lose} conceded',
+  'tip.goalDiff': 'Goal diff: {diff}',
+  'tip.statsHeader': 'Stats:',
+  'tip.lossHeader': 'Defeats:',
+  'tip.matchStatus.started': 'Not started',
+
+  // Score prefixes
+  'score.et': 'ET{get}-{lose}',
+  'score.pk': 'PK{get}-{lose}',
+
+  // Cross-group
+  'crossGroup.caption': 'Comparison of teams ranked {position}',
+  'crossGroup.exclude': ' (excl. matches vs rank {rank}+)',
+
+  // Rank table footer notes
+  'note.judgmentCaveat': 'Due to multi-team head-to-head tiebreakers, clinch/elimination status may show as "In hands" or "Need help" even when mathematically decided',
+  'note.judgmentDecided': '("Clinched", "Relegated", and "Out" are confirmed results)',
+  'note.playoffNote': 'Promotion/Relegation: Playoff qualification is also shown as "Clinched" or "Relegated"',
+  'note.otherLeague': 'Does not account for promotion/relegation slots affected by other leagues',
+
+  // Links
+  'link.github': 'GitHub repository',
+
+  // Rule notes (from rule-notes.ts)
+  'rule.victoryCount': 'Win/loss count only (win = 1 pt)',
+  'rule.win3allPkloss1': 'Win = 3 pts (90 min/ET/PK), PK loss = 1 pt',
+  'rule.graduatedWin': '90-min win = 3 pts, ET win = 2 pts, PK win = 1 pt',
+  'rule.exWin2': '90-min win = 3 pts, ET win = 2 pts, draw = 1 pt',
+  'rule.pkWin2Loss1': 'Win = 3 pts, PK win = 2 pts, PK loss = 1 pt',
+  'rule.tiebreakPrefix': 'Tiebreaker order: ',
+  'rule.headToHead': 'Head-to-head',
+  'rule.goalDiff': 'Goal difference',
+  'rule.goalGet': 'Goals scored',
+  'rule.wins': 'Wins',
+};

--- a/frontend/src/i18n/messages/ja.ts
+++ b/frontend/src/i18n/messages/ja.ts
@@ -10,6 +10,7 @@ export const ja = {
   'label.futureOpacity': '未実施試合透明度',
   'label.spaceColor': '余白色',
   'label.dataTimestamp': 'データ取得時刻:',
+  'label.language': '言語',
 
   // Buttons
   'btn.resetDate': '最新にリセット',

--- a/frontend/src/i18n/messages/ja.ts
+++ b/frontend/src/i18n/messages/ja.ts
@@ -1,0 +1,125 @@
+export const ja = {
+  // HTML labels
+  'label.competition': '大会',
+  'label.season': 'シーズン',
+  'label.teamSort': 'チーム順',
+  'label.matchSort': '試合順',
+  'label.displayDate': '表示日',
+  'label.graphScale': 'グラフ縮小',
+  'label.scaleUnit': '倍',
+  'label.futureOpacity': '未実施試合透明度',
+  'label.spaceColor': '余白色',
+  'label.dataTimestamp': 'データ取得時刻:',
+
+  // Buttons
+  'btn.resetDate': '最新にリセット',
+  'btn.resetPrefs': '設定をリセット',
+  'btn.sliderPrev': '＜',
+  'btn.sliderNext': '＞',
+
+  // Status messages
+  'status.loading': 'CSVを読み込み中...',
+  'status.loaded': '{league} {season} — {rows} 行',
+  'status.cached': '{league} {season} (cached)',
+  'status.error': 'CSV読み込みエラー: {detail}',
+  'status.noSeason': 'シーズン情報なし: {competition}/{season}',
+  'status.seasonMapError': 'season_map.json の読み込みに失敗しました',
+  'status.dataSource': 'データ参照元: ',
+
+  // Warnings
+  'warn.undefinedColor': 'チームカラー未定義: {teams}',
+
+  // Date slider
+  'slider.preseason': '開幕前',
+
+  // Team sort options
+  'sort.dispPoint': '勝点(表示時)',
+  'sort.dispAvlblPt': '最大勝点(表示時)',
+  'sort.point': '勝点(最新)',
+  'sort.avlblPt': '最大勝点(最新)',
+
+  // Match sort options
+  'sort.oldBottom': '古い試合が下',
+  'sort.newBottom': '新しい試合が下',
+  'sort.firstBottom': '第1節が下',
+  'sort.lastBottom': '最終節が下',
+
+  // Rank table headers
+  'col.team': 'チーム',
+  'col.games': '試合',
+  'col.points': '勝点',
+  'col.average': '平均',
+  'col.maxPoints': '最大',
+  'col.win': '勝',
+  'col.draw': '分',
+  'col.loss': '負',
+  'col.goalsFor': '得点',
+  'col.goalsAgainst': '失点',
+  'col.goalDiff': '点差',
+  'col.remaining': '残り',
+  'col.pkWin': 'PK勝',
+  'col.pkLoss': 'PK負',
+  'col.exWin': '延勝',
+  'col.exLoss': '延負',
+  'col.champion': '優勝',
+  'col.promotion': '昇格',
+  'col.relegation': '残留',
+  'col.rank': '順位',
+  'col.group': 'Grp',
+
+  // Rank status
+  'rank.clinched': '確定',
+  'rank.eliminated': 'なし',
+  'rank.selfPower': '自力',
+  'rank.otherPower': '他力',
+  'rank.relegated': '降格',
+
+  // Graph labels
+  'graph.group': 'グループ{key}',
+  'graph.undecided': '未定',
+  'graph.cancelled': '試合中止',
+
+  // Tooltip
+  'tip.statsLabel.disp': '表示時の状態',
+  'tip.statsLabel.latest': '最新の状態',
+  'tip.record': '{win}勝 / {draw}分 / {loss}敗',
+  'tip.exRecord': '{exWin}延勝 / {exLoss}延負',
+  'tip.pkRecord': '{pkWin}PK勝 / {pkLoss}PK負',
+  'tip.points': '勝点{point}, 最大{max}',
+  'tip.goals': '{get}得点, {lose}失点',
+  'tip.goalDiff': '得失点差: {diff}',
+  'tip.statsHeader': '成績情報:',
+  'tip.lossHeader': '敗戦記録:',
+  'tip.matchStatus.started': '開始前',
+
+  // Score prefixes
+  'score.et': 'ET{get}-{lose}',
+  'score.pk': 'PK{get}-{lose}',
+
+  // Cross-group
+  'crossGroup.caption': '{position}位チーム比較',
+  'crossGroup.exclude': ' ({rank}位以下との対戦除外)',
+
+  // Rank table footer notes
+  'note.judgmentCaveat': 'どの判定も、3チーム以上の対戦成績の関係から、実際には確定していても「自力」「他力」と示す場合アリ',
+  'note.judgmentDecided': '(「確定」「降格」「なし」と判定されている場合は、それぞれ決定済み)',
+  'note.playoffNote': '昇格・降格: プレーオフ参戦決定も、それぞれ「確定」「降格」と表示',
+  'note.otherLeague': '別リーグの影響で昇格・降格数が減るケースは考慮しない',
+
+  // Links
+  'link.github': 'Github公開場所',
+
+  // Rule notes (from rule-notes.ts)
+  'rule.victoryCount': '勝敗数のみカウント (勝ち=1点)',
+  'rule.win3allPkloss1': '勝ち=3点 (90分/延長/PK共通), PK負け=1点',
+  'rule.graduatedWin': '90分勝ち=3点, 延長勝ち=2点, PK勝ち=1点',
+  'rule.exWin2': '90分勝ち=3点, 延長勝ち=2点, 引分け=1点',
+  'rule.pkWin2Loss1': '勝ち=3点, PK勝ち=2点, PK負け=1点',
+  'rule.tiebreakPrefix': '同勝点時の順位決定: ',
+  'rule.headToHead': '直接対戦',
+  'rule.goalDiff': '得失点差',
+  'rule.goalGet': '総得点',
+  'rule.wins': '勝利数',
+} as const;
+
+export type MessageKey = keyof typeof ja;

--- a/frontend/src/i18n/types.ts
+++ b/frontend/src/i18n/types.ts
@@ -1,0 +1,1 @@
+export type Locale = 'ja' | 'en';

--- a/frontend/src/j_points.html
+++ b/frontend/src/j_points.html
@@ -24,25 +24,25 @@
 
 <section id="controls">
   <label>
-    大会:
+    <span data-i18n="label.competition"></span>
     <select id="competition_key">
       <!-- populated dynamically from season_map.json -->
     </select>
   </label>
   <label>
-    シーズン:
+    <span data-i18n="label.season"></span>
     <select id="season_key"></select>
   </label>
   <label>
-    チーム順:
+    <span data-i18n="label.teamSort"></span>
     <select id="team_sort_key">
-      <!-- populated by app.ts from TEAM_SORT_OPTIONS -->
+      <!-- populated by app.ts -->
     </select>
   </label>
   <label>
-    試合順:
+    <span data-i18n="label.matchSort"></span>
     <select id="match_sort_key">
-      <!-- populated by app.ts from MATCH_SORT_OPTIONS -->
+      <!-- populated by app.ts -->
     </select>
   </label>
 
@@ -50,14 +50,14 @@
 
 <!-- Date slider -->
 <section id="date_slider_section">
-  <span id="pre_date_slider">開幕前</span>
-  <button id="date_slider_down">＜</button>
+  <span id="pre_date_slider" data-i18n="slider.preseason"></span>
+  <button id="date_slider_down" data-i18n="btn.sliderPrev"></button>
   <input type="range" id="date_slider" min="0" max="0" step="1" value="0"/>
-  <button id="date_slider_up">＞</button>
+  <button id="date_slider_up" data-i18n="btn.sliderNext"></button>
   <span id="post_date_slider"></span>
-  <button id="reset_date_slider">最新にリセット</button>
+  <button id="reset_date_slider" data-i18n="btn.resetDate"></button>
   <label>
-    表示日:
+    <span data-i18n="label.displayDate"></span>
     <input type="date" id="target_date">
   </label>
 </section>
@@ -65,26 +65,26 @@
 <!-- Appearance controls -->
 <section id="appearance_controls">
   <label>
-    グラフ縮小:
+    <span data-i18n="label.graphScale"></span>
     <input type="range" id="scale_slider" min="0.1" max="1" step="0.1" value="1"/>
-    <span id="current_scale">1</span>倍
+    <span id="current_scale">1</span><span data-i18n="label.scaleUnit"></span>
   </label>
   <label>
-    未実施試合透明度:
+    <span data-i18n="label.futureOpacity"></span>
     <input type="range" id="future_opacity" min="0" max="0.5" step="0.01" value="0.1"/>
     [<span id="current_opacity"></span>]
   </label>
   <label>
-    余白色:
+    <span data-i18n="label.spaceColor"></span>
     <input type="color" id="space_color" value="#000000"/>
   </label>
-  <button id="reset_prefs">設定をリセット</button>
+  <button id="reset_prefs" data-i18n="btn.resetPrefs"></button>
 </section>
 
 <!-- Status message and data timestamp -->
 <div id="status_bar">
   <span id="status_msg"></span>
-  <span class="timestamp-label">データ取得時刻: <span id="data_timestamp"></span></span>
+  <span class="timestamp-label"><span data-i18n="label.dataTimestamp"></span> <span id="data_timestamp"></span></span>
 </div>
 
 <!-- Warning message (team color CSS undefined etc.) -->
@@ -96,7 +96,7 @@
 <hr/>
 <span id="data_source_section"></span>
 <br/>
-<a href="https://github.com/mokekuma-git/JLeague_Matches-Bar_Graph">Github公開場所</a>
+<a href="https://github.com/mokekuma-git/JLeague_Matches-Bar_Graph" data-i18n="link.github"></a>
 <hr/>
 
 <section id="ranktable_section">
@@ -106,10 +106,10 @@
     </table>
   </div>
   <ul>
-    <li>どの判定も、3チーム以上の対戦成績の関係から、実際には確定していても「自力」「他力」と示す場合アリ</li>
-    <li>(「確定」「降格」「なし」と判定されている場合は、それぞれ決定済み)</li>
-    <li>昇格・降格: プレーオフ参戦決定も、それぞれ「確定」「降格」と表示</li>
-    <li>別リーグの影響で昇格・降格数が減るケースは考慮しない</li>
+    <li data-i18n="note.judgmentCaveat"></li>
+    <li data-i18n="note.judgmentDecided"></li>
+    <li data-i18n="note.playoffNote"></li>
+    <li data-i18n="note.otherLeague"></li>
   </ul>
   <ul id="season_notes"></ul>
 </section>

--- a/frontend/src/j_points.html
+++ b/frontend/src/j_points.html
@@ -45,6 +45,13 @@
       <!-- populated by app.ts -->
     </select>
   </label>
+  <label>
+    <span data-i18n="label.language"></span>
+    <select id="locale_key">
+      <option value="ja">日本語</option>
+      <option value="en">English</option>
+    </select>
+  </label>
 
 </section>
 

--- a/frontend/src/ranking/rank-table.ts
+++ b/frontend/src/ranking/rank-table.ts
@@ -10,6 +10,7 @@ import {
 } from '../core/sorter';
 import { teamCssClass } from '../core/team-utils';
 import { getRankClass } from '../graph/tooltip';
+import { t } from '../i18n';
 
 // SortableTable is loaded from CDN as a global (not an npm package).
 declare const SortableTable: new () => {
@@ -23,24 +24,28 @@ declare const SortableTable: new () => {
 type ColDef = { id?: string; label: string; sortable?: true };
 
 // Stat columns shared by all ranking table variants (between rank and goal columns).
-const STAT_COLS: ColDef[] = [
-  { id: 'name',        label: 'チーム' },
-  { id: 'all_game',    label: '試合',   sortable: true },
-  { id: 'point',       label: '勝点',   sortable: true },
-  { id: 'avrg_pt',     label: '平均',   sortable: true },
-  { id: 'avlbl_pt',    label: '最大',   sortable: true },
-  { id: 'win',         label: '勝',     sortable: true },
-  { id: 'draw',        label: '分',     sortable: true },
-  { id: 'loss',        label: '負',     sortable: true },
-];
+function getStatCols(): ColDef[] {
+  return [
+    { id: 'name',        label: t('col.team') },
+    { id: 'all_game',    label: t('col.games'),     sortable: true },
+    { id: 'point',       label: t('col.points'),    sortable: true },
+    { id: 'avrg_pt',     label: t('col.average'),   sortable: true },
+    { id: 'avlbl_pt',    label: t('col.maxPoints'), sortable: true },
+    { id: 'win',         label: t('col.win'),       sortable: true },
+    { id: 'draw',        label: t('col.draw'),      sortable: true },
+    { id: 'loss',        label: t('col.loss'),       sortable: true },
+  ];
+}
 
 // Goal and remaining-game columns shared by all ranking table variants.
-const GOAL_COLS: ColDef[] = [
-  { id: 'goal_get',    label: '得点',   sortable: true },
-  { id: 'goal_lose',   label: '失点',   sortable: true },
-  { id: 'goal_diff',   label: '点差',   sortable: true },
-  { id: 'future_game', label: '残り',   sortable: true },
-];
+function getGoalCols(): ColDef[] {
+  return [
+    { id: 'goal_get',    label: t('col.goalsFor'),     sortable: true },
+    { id: 'goal_lose',   label: t('col.goalsAgainst'), sortable: true },
+    { id: 'goal_diff',   label: t('col.goalDiff'),     sortable: true },
+    { id: 'future_game', label: t('col.remaining'),    sortable: true },
+  ];
+}
 
 // Builds a <thead> row from a column definition array.
 function buildTableHead(tableEl: HTMLElement, cols: ColDef[]): void {
@@ -161,32 +166,32 @@ export function makeRankData(
     };
 
     if (allGameFinished) {
-      row.champion   = rank <= 1 ? '確定' : 'なし';
+      row.champion   = rank <= 1 ? t('rank.clinched') : t('rank.eliminated');
       if (promotionCount > 0) {
-        row.promotion = rank <= promotionCount ? '確定' : 'なし';
+        row.promotion = rank <= promotionCount ? t('rank.clinched') : t('rank.eliminated');
       }
       if (relegationCount > 0) {
-        row.relegation = rank <= relegationRank ? '確定' : '降格';
+        row.relegation = rank <= relegationRank ? t('rank.clinched') : t('rank.relegated');
       }
     } else {
       // Champion calculation
       const silver      = s.avlbl_pt - silverLine;
       const champion    = s.point    - championLine;
       const selfChampion = s.avlbl_pt - getSelfPossibleLine(1, teamName, disp, groupData, seasonInfo.pointSystem);
-      row.champion = champion >= 0 ? '確定'
-        : silver < 0              ? 'なし'
-        : selfChampion >= 0       ? '自力'
-        : '他力';
+      row.champion = champion >= 0 ? t('rank.clinched')
+        : silver < 0              ? t('rank.eliminated')
+        : selfChampion >= 0       ? t('rank.selfPower')
+        : t('rank.otherPower');
 
       // Promotion calculation
       if (promotionCount > 0) {
         const remaining      = s.avlbl_pt - nonPromotLine;
         const promotion      = s.point    - promotionLine;
         const selfPromotion  = s.avlbl_pt - getSelfPossibleLine(promotionCount, teamName, disp, groupData, seasonInfo.pointSystem);
-        row.promotion = promotion >= 0  ? '確定'
-          : remaining < 0              ? 'なし'
-          : selfPromotion >= 0         ? '自力'
-          : '他力';
+        row.promotion = promotion >= 0  ? t('rank.clinched')
+          : remaining < 0              ? t('rank.eliminated')
+          : selfPromotion >= 0         ? t('rank.selfPower')
+          : t('rank.otherPower');
       }
 
       // Relegation calculation
@@ -194,12 +199,12 @@ export function makeRankData(
         const keepLeague    = s.point    - keepLeagueLine;
         const relegation    = s.avlbl_pt - relegationLine;
         const selfRelegation = s.avlbl_pt - getSelfPossibleLine(relegationRank, teamName, disp, groupData, seasonInfo.pointSystem);
-        row.relegation = keepLeague >= 0 ? '確定'
-          : relegation < 0              ? '降格'
-          : selfRelegation >= 0         ? '自力'
-          : '他力';
+        row.relegation = keepLeague >= 0 ? t('rank.clinched')
+          : relegation < 0              ? t('rank.relegated')
+          : selfRelegation >= 0         ? t('rank.selfPower')
+          : t('rank.otherPower');
       } else {
-        row.relegation = '確定';
+        row.relegation = t('rank.clinched');
       }
     }
 
@@ -212,23 +217,23 @@ export function makeRankData(
 // Builds the <thead> for per-group ranking tables.
 // pk_win / pk_loss columns are included only when hasPk=true.
 // ex_win / ex_loss columns are included only when hasEx=true.
-function buildRankTableHead(tableEl: HTMLElement, hasPk: boolean, hasEx: boolean, promotionLabel: string = '昇格'): void {
+function buildRankTableHead(tableEl: HTMLElement, hasPk: boolean, hasEx: boolean, promotionLabel: string = t('col.promotion')): void {
   const cols: ColDef[] = [
     { id: 'rank',        label: '',          sortable: true },
-    ...STAT_COLS,
+    ...getStatCols(),
     ...(hasPk ? [
-      { id: 'pk_win',  label: 'PK勝', sortable: true as true },
-      { id: 'pk_loss', label: 'PK負', sortable: true as true },
+      { id: 'pk_win',  label: t('col.pkWin'),  sortable: true as true },
+      { id: 'pk_loss', label: t('col.pkLoss'), sortable: true as true },
     ] : []),
     ...(hasEx ? [
-      { id: 'ex_win',  label: '延勝', sortable: true as true },
-      { id: 'ex_loss', label: '延負', sortable: true as true },
+      { id: 'ex_win',  label: t('col.exWin'),  sortable: true as true },
+      { id: 'ex_loss', label: t('col.exLoss'), sortable: true as true },
     ] : []),
-    ...GOAL_COLS,
+    ...getGoalCols(),
     {                    label: '-' },
-    { id: 'champion',    label: '優勝',      sortable: true },
+    { id: 'champion',    label: t('col.champion'),    sortable: true },
     { id: 'promotion',   label: promotionLabel, sortable: true },
-    { id: 'relegation',  label: '残留',      sortable: true },
+    { id: 'relegation',  label: t('col.relegation'),  sortable: true },
   ];
   buildTableHead(tableEl, cols);
 }
@@ -249,7 +254,7 @@ function applyRowClasses(tbody: HTMLElement, rankMap: Map<number, string>): void
 // hasPk controls whether PK win/loss columns appear in the table header.
 // Row CSS classes (promoted/relegated/etc.) are applied based on points-based rank
 // and reapplied after every re-sort via MutationObserver.
-export function makeRankTable(tableEl: HTMLElement, rankData: RankRow[], hasPk: boolean, hasEx: boolean = false, promotionLabel: string = '昇格'): void {
+export function makeRankTable(tableEl: HTMLElement, rankData: RankRow[], hasPk: boolean, hasEx: boolean = false, promotionLabel: string = t('col.promotion')): void {
   buildRankTableHead(tableEl, hasPk, hasEx, promotionLabel);
   const sortableTable = new SortableTable();
   sortableTable.setTable(tableEl);
@@ -402,16 +407,16 @@ export function makeCrossGroupTable(
   table.className = 'ranktable';
 
   const caption = document.createElement('caption');
-  const posLabel = `${position}位チーム比較`;
-  const excludeLabel = exclude_from_rank ? ` (${exclude_from_rank}位以下との対戦除外)` : '';
+  const posLabel = t('crossGroup.caption', { position });
+  const excludeLabel = exclude_from_rank ? t('crossGroup.exclude', { rank: exclude_from_rank }) : '';
   caption.textContent = posLabel + excludeLabel;
   table.appendChild(caption);
 
   table.appendChild(document.createElement('thead'));
   buildTableHead(table, [
-    { id: 'rank', label: 'Grp', sortable: true },
-    ...STAT_COLS,
-    ...GOAL_COLS,
+    { id: 'rank', label: t('col.group'), sortable: true },
+    ...getStatCols(),
+    ...getGoalCols(),
   ]);
 
   const sortableTable = new SortableTable();

--- a/frontend/src/storage/local-storage.ts
+++ b/frontend/src/storage/local-storage.ts
@@ -14,6 +14,7 @@ export interface ViewerPrefs {
   futureOpacity?: string;
   spaceColor?: string;
   scale?: string;
+  locale?: string;
 }
 
 export function loadPrefs(): ViewerPrefs {


### PR DESCRIPTION
Fixes #136

## Summary
- i18n 基盤を構築: `t()` 関数, `data-i18n` HTML属性, `setLocale()`/`getLocale()` によるロケール管理
- 約90箇所のハードコード日本語 UI 文字列を辞書参照に移行 (`frontend/src/i18n/messages/ja.ts`)
- 英語辞書を追加 (`frontend/src/i18n/messages/en.ts`)、全キー翻訳済み
- 言語切替セレクタ (日本語/English) を UI に追加、localStorage で永続化
- CSVマッチング定数 (`'試合終了'`, `'ＶＳ'`, `'速報中'`, `'試合中止'`) は翻訳対象外として名前付き定数に抽出
- モジュールレベル定数 (`STAT_COLS` 等) を getter 関数化し、言語切替後も正しく `t()` が評価されるよう対応
- i18n ユニットテスト追加 (15テスト: 辞書完全性, `t()` 補間, ロケール切替, `applyI18nAttributes`)

## Changes
| Commit | Description |
| --- | --- |
| `0f2fe4f` | Add i18n infrastructure and migrate UI strings to Japanese dictionary |
| `352acc8` | Add English translations and language selector UI |
| `b43b353` | Add i18n unit tests for translation, locale switching, and dictionary completeness |

## Test plan
- [x] `npx vitest run` passed (394 tests, frontend/)
- [x] `npm run typecheck` passed (frontend/)
- [x] `npm run build` succeeded (frontend/)
- [x] Browser visual confirmation (Japanese/English switching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)