### PR TITLE
Add tournament bracket view for WE Cup KO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ local_data/
 
 # TypeScript build artifacts (managed by CI deploy-pages.yaml, not committed to git)
 docs/j_points.html
+docs/tournament.html
 docs/assets/
 
 # Vite dev server cache

--- a/docs/csv/22-23_allmatch_result-WE_Cup_KO.csv
+++ b/docs/csv/22-23_allmatch_result-WE_Cup_KO.csv
@@ -1,2 +1,2 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,status,group,home_pk_score,away_pk_score
-0,2022/10/01,99,1,16:03,味の素フィールド西が丘,浦和,3,3,東京NB,試合終了,,4.0,2.0
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,status,group,home_pk_score,away_pk_score,round
+0,2022/10/01,99,1,16:03,味の素フィールド西が丘,浦和,3,3,東京NB,試合終了,,4.0,2.0,決勝

--- a/docs/csv/23-24_allmatch_result-WE_Cup_KO.csv
+++ b/docs/csv/23-24_allmatch_result-WE_Cup_KO.csv
@@ -1,2 +1,2 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,status,group,home_pk_score,away_pk_score
-0,2023/10/14,99,1,16:03,Uvanceとどろきスタジアム　by　Fujitsu,S広島R,0,0,新潟L,試合終了,,4.0,2.0
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,status,group,home_pk_score,away_pk_score,round
+0,2023/10/14,99,1,16:03,Uvanceとどろきスタジアム　by　Fujitsu,S広島R,0,0,新潟L,試合終了,,4.0,2.0,決勝

--- a/docs/csv/24-25_allmatch_result-WE_Cup_KO.csv
+++ b/docs/csv/24-25_allmatch_result-WE_Cup_KO.csv
@@ -1,4 +1,4 @@
-,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,status,group
-0,2024/12/08,98,1,12:05,PEACE STADIUM Connected by SoftBank,S広島R,3,2,浦和,試合終了,
-1,2024/12/08,98,2,15:49,PEACE STADIUM Connected by SoftBank,I神戸,1,0,新潟L,試合終了,
-2,2024/12/29,99,1,13:04,MUFGスタジアム,S広島R,1,0,I神戸,試合終了,
+,match_date,section_no,match_index_in_section,start_time,stadium,home_team,home_goal,away_goal,away_team,status,group,round
+0,2024/12/08,98,1,12:05,PEACE STADIUM Connected by SoftBank,S広島R,3,2,浦和,試合終了,,準決勝
+1,2024/12/08,98,2,15:49,PEACE STADIUM Connected by SoftBank,I神戸,1,0,新潟L,試合終了,,準決勝
+2,2024/12/29,99,1,13:04,MUFGスタジアム,S広島R,1,0,I神戸,試合終了,,決勝

--- a/docs/json/season_map.json
+++ b/docs/json/season_map.json
@@ -495,6 +495,7 @@
       },
       "WE_Cup_KO": {
         "league_display": "クラシエカップ KO",
+        "view_type": ["bracket"],
         "seasons": {
           "22-23": [2, 0, 0,
             ["浦和", "東京NB"],

--- a/docs/json/season_map.json
+++ b/docs/json/season_map.json
@@ -492,6 +492,20 @@
             [],
             {"rank_properties": {"2": "promoted_playoff"}, "cross_group_standing": {"position": 2, "advance_count": 1}, "point_system": "pk-win2-loss1"}]
         }
+      },
+      "WE_Cup_KO": {
+        "league_display": "クラシエカップ KO",
+        "seasons": {
+          "22-23": [2, 0, 0,
+            ["浦和", "東京NB"],
+            {"bracket_order": ["浦和", "東京NB"], "bracket_round_start": "決勝"}],
+          "23-24": [2, 0, 0,
+            ["S広島R", "新潟L"],
+            {"bracket_order": ["S広島R", "新潟L"], "bracket_round_start": "決勝"}],
+          "24-25": [4, 0, 0,
+            ["S広島R", "浦和", "I神戸", "新潟L"],
+            {"bracket_order": ["S広島R", "浦和", "I神戸", "新潟L"], "bracket_round_start": "準決勝"}]
+        }
       }
     }
   }

--- a/frontend/src/__tests__/bracket/bracket-data.test.ts
+++ b/frontend/src/__tests__/bracket/bracket-data.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { buildBracket } from '../../bracket/bracket-data';
+import type { RawMatchRow } from '../../types/match';
+
+function makeRow(overrides: Partial<RawMatchRow>): RawMatchRow {
+  return {
+    match_date: '2024/12/08',
+    section_no: '98',
+    match_index_in_section: '1',
+    start_time: '12:00',
+    stadium: 'Test Stadium',
+    home_team: '',
+    home_goal: '',
+    away_goal: '',
+    away_team: '',
+    status: '試合終了',
+    ...overrides,
+  };
+}
+
+describe('buildBracket', () => {
+  it('throws if bracket_order has fewer than 2 teams', () => {
+    expect(() => buildBracket([], ['A'])).toThrow('at least 2 teams');
+  });
+
+  it('builds a 2-team bracket (final only)', () => {
+    const rows = [
+      makeRow({
+        home_team: '浦和', away_team: '東京NB',
+        home_goal: '3', away_goal: '3',
+        home_pk_score: '4', away_pk_score: '2',
+        round: '決勝', section_no: '99',
+      }),
+    ];
+    const root = buildBracket(rows, ['浦和', '東京NB']);
+
+    expect(root.round).toBe('決勝');
+    expect(root.homeTeam).toBe('浦和');
+    expect(root.awayTeam).toBe('東京NB');
+    expect(root.homeGoal).toBe(3);
+    expect(root.awayGoal).toBe(3);
+    expect(root.homePkScore).toBe(4);
+    expect(root.awayPkScore).toBe(2);
+    expect(root.winner).toBe('浦和');
+    expect(root.children).toEqual([null, null]);
+  });
+
+  it('builds a 4-team bracket (SF + Final)', () => {
+    const rows = [
+      makeRow({
+        home_team: 'S広島R', away_team: '浦和',
+        home_goal: '3', away_goal: '2',
+        round: '準決勝', section_no: '98',
+      }),
+      makeRow({
+        home_team: 'I神戸', away_team: '新潟L',
+        home_goal: '1', away_goal: '0',
+        round: '準決勝', section_no: '98',
+      }),
+      makeRow({
+        home_team: 'S広島R', away_team: 'I神戸',
+        home_goal: '1', away_goal: '0',
+        round: '決勝', section_no: '99',
+      }),
+    ];
+    const root = buildBracket(rows, ['S広島R', '浦和', 'I神戸', '新潟L']);
+
+    // Final
+    expect(root.round).toBe('決勝');
+    expect(root.homeTeam).toBe('S広島R');
+    expect(root.awayTeam).toBe('I神戸');
+    expect(root.winner).toBe('S広島R');
+
+    // Upper SF
+    const upper = root.children[0]!;
+    expect(upper.round).toBe('準決勝');
+    expect(upper.homeTeam).toBe('S広島R');
+    expect(upper.awayTeam).toBe('浦和');
+    expect(upper.winner).toBe('S広島R');
+
+    // Lower SF
+    const lower = root.children[1]!;
+    expect(lower.round).toBe('準決勝');
+    expect(lower.homeTeam).toBe('I神戸');
+    expect(lower.awayTeam).toBe('新潟L');
+    expect(lower.winner).toBe('I神戸');
+  });
+
+  it('handles PK winner correctly', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '1', away_goal: '1',
+        home_pk_score: '3', away_pk_score: '5',
+        round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    expect(root.winner).toBe('B');
+  });
+
+  it('handles extra time winner correctly', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '1', away_goal: '1',
+        home_score_ex: '1', away_score_ex: '0',
+        round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    expect(root.winner).toBe('A');
+  });
+
+  it('handles unplayed match (no CSV row for matchup)', () => {
+    const root = buildBracket([], ['A', 'B']);
+    expect(root.homeTeam).toBe('A');
+    expect(root.awayTeam).toBe('B');
+    expect(root.winner).toBeNull();
+    expect(root.status).toBe('ＶＳ');
+  });
+
+  it('handles partially played 4-team bracket', () => {
+    // Only one SF played; final not yet played
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1',
+        round: '準決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B', 'C', 'D']);
+
+    // Upper SF completed
+    expect(root.children[0]!.winner).toBe('A');
+    // Lower SF not played
+    expect(root.children[1]!.winner).toBeNull();
+    // Final not played (no winner from lower SF)
+    expect(root.winner).toBeNull();
+    expect(root.homeTeam).toBe('A');
+    expect(root.awayTeam).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/fixtures/match-data.ts
+++ b/frontend/src/__tests__/fixtures/match-data.ts
@@ -48,6 +48,7 @@ export function makeSeasonInfo(overrides: Partial<SeasonInfo> = {}): SeasonInfo 
     seasonStartMonth: 7,
     notes: [],
     promotionLabel: '昇格',
+    viewTypes: ['league'],
     ...overrides,
   };
 }

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -13,6 +13,7 @@ import type { RawMatchRow, TeamMap } from './types/match';
 import type { SeasonMap, SeasonInfo } from './types/season';
 import {
   loadSeasonMap, getCsvFilename, findCompetition, resolveSeasonInfo,
+  getCompetitionViewTypes,
 } from './config/season-map';
 import { parseCsvResults } from './core/csv-parser';
 import { dateFormat } from './core/date-utils';
@@ -209,6 +210,7 @@ function populateCompetitionPulldown(seasonMap: SeasonMap): void {
     }
 
     for (const [compKey, comp] of Object.entries(group.competitions)) {
+      if (!getCompetitionViewTypes(group, comp).includes('league')) continue;
       const opt = document.createElement('option');
       opt.value = compKey;
       opt.textContent = comp.league_display ?? compKey;

--- a/frontend/src/bracket/bracket-data.ts
+++ b/frontend/src/bracket/bracket-data.ts
@@ -1,0 +1,124 @@
+// Build a BracketNode tree from CSV rows and bracket_order.
+//
+// The bracket_order array lists teams in their bracket position (top to bottom).
+// For 4 teams: [0] vs [1] → SF1, [2] vs [3] → SF2, winners → Final.
+
+import type { RawMatchRow } from '../types/match';
+import type { BracketNode } from './bracket-types';
+
+/**
+ * Determine the winner of a KO match from a CSV row.
+ * Returns null if the match hasn't been played.
+ */
+function determineWinner(row: RawMatchRow): string | null {
+  if (!row.home_goal || !row.away_goal) return null;
+  const hg = parseInt(row.home_goal, 10);
+  const ag = parseInt(row.away_goal, 10);
+  if (isNaN(hg) || isNaN(ag)) return null;
+
+  // PK decides
+  if (row.home_pk_score && row.away_pk_score) {
+    const hpk = parseInt(row.home_pk_score, 10);
+    const apk = parseInt(row.away_pk_score, 10);
+    return hpk > apk ? row.home_team : row.away_team;
+  }
+
+  // Total score (regular + extra time if present)
+  const hex = row.home_score_ex ? parseInt(row.home_score_ex, 10) : 0;
+  const aex = row.away_score_ex ? parseInt(row.away_score_ex, 10) : 0;
+  const totalH = hg + hex;
+  const totalA = ag + aex;
+  if (totalH !== totalA) return totalH > totalA ? row.home_team : row.away_team;
+
+  // Equal total score without PK — shouldn't happen in KO but return null
+  return null;
+}
+
+/**
+ * Find a CSV row matching a matchup between two teams.
+ */
+function findMatch(
+  rows: RawMatchRow[], teamA: string | null, teamB: string | null,
+): RawMatchRow | undefined {
+  if (!teamA || !teamB) return undefined;
+  return rows.find(r =>
+    (r.home_team === teamA && r.away_team === teamB) ||
+    (r.home_team === teamB && r.away_team === teamA),
+  );
+}
+
+/**
+ * Create a BracketNode from a CSV row (or a placeholder if no match found).
+ */
+function nodeFromMatch(
+  row: RawMatchRow | undefined,
+  upperTeam: string | null,
+  lowerTeam: string | null,
+  children: [BracketNode | null, BracketNode | null] = [null, null],
+): BracketNode {
+  if (!row) {
+    return {
+      round: '',
+      homeTeam: upperTeam,
+      awayTeam: lowerTeam,
+      status: 'ＶＳ',
+      winner: null,
+      children,
+    };
+  }
+
+  const hg = row.home_goal ? parseInt(row.home_goal, 10) : undefined;
+  const ag = row.away_goal ? parseInt(row.away_goal, 10) : undefined;
+
+  return {
+    round: row.round ?? '',
+    matchNumber: row.match_number ? parseInt(row.match_number, 10) : undefined,
+    homeTeam: row.home_team,
+    awayTeam: row.away_team,
+    homeGoal: isNaN(hg as number) ? undefined : hg,
+    awayGoal: isNaN(ag as number) ? undefined : ag,
+    homePkScore: row.home_pk_score ? parseInt(row.home_pk_score, 10) : undefined,
+    awayPkScore: row.away_pk_score ? parseInt(row.away_pk_score, 10) : undefined,
+    homeScoreEx: row.home_score_ex ? parseInt(row.home_score_ex, 10) : undefined,
+    awayScoreEx: row.away_score_ex ? parseInt(row.away_score_ex, 10) : undefined,
+    matchDate: row.match_date,
+    stadium: row.stadium,
+    status: row.status,
+    winner: determineWinner(row),
+    children,
+  };
+}
+
+/**
+ * Recursively build a bracket tree from bracket_order positions.
+ */
+function buildNode(rows: RawMatchRow[], teams: string[]): BracketNode {
+  if (teams.length === 2) {
+    const match = findMatch(rows, teams[0], teams[1]);
+    return nodeFromMatch(match, teams[0], teams[1]);
+  }
+
+  const mid = Math.floor(teams.length / 2);
+  const upper = buildNode(rows, teams.slice(0, mid));
+  const lower = buildNode(rows, teams.slice(mid));
+
+  const upperWinner = upper.winner;
+  const lowerWinner = lower.winner;
+  const match = findMatch(rows, upperWinner, lowerWinner);
+
+  return nodeFromMatch(match, upperWinner, lowerWinner, [upper, lower]);
+}
+
+/**
+ * Build the full bracket tree from CSV rows and bracket_order.
+ *
+ * @param rows - Parsed CSV rows for the KO stage.
+ * @param bracketOrder - Teams in bracket position order (top to bottom).
+ * @returns Root BracketNode of the tournament tree.
+ */
+export function buildBracket(rows: RawMatchRow[], bracketOrder: string[]): BracketNode {
+  if (bracketOrder.length < 2) {
+    throw new Error(`bracket_order must have at least 2 teams, got ${bracketOrder.length}`);
+  }
+  return buildNode(rows, bracketOrder);
+}

--- a/frontend/src/bracket/bracket-renderer.ts
+++ b/frontend/src/bracket/bracket-renderer.ts
@@ -116,13 +116,6 @@ function createConnector(): HTMLElement {
   return connector;
 }
 
-/** Create a horizontal line from connector to match card. */
-function createConnectorLine(): HTMLElement {
-  const line = document.createElement('div');
-  line.classList.add('connector-line');
-  return line;
-}
-
 /** Recursively render a BracketNode subtree. */
 function renderNode(node: BracketNode): HTMLElement {
   const [upper, lower] = node.children;
@@ -148,16 +141,21 @@ function renderNode(node: BracketNode): HTMLElement {
   const subtree = document.createElement('div');
   subtree.classList.add('bracket-subtree');
 
-  // Render child subtrees
+  // Render child subtrees, each wrapped with a horizontal connector line
   const children = document.createElement('div');
   children.classList.add('bracket-children');
-  if (upper) children.appendChild(renderNode(upper));
-  if (lower) children.appendChild(renderNode(lower));
+  const addChild = (child: BracketNode): void => {
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('bracket-child');
+    wrapper.appendChild(renderNode(child));
+    children.appendChild(wrapper);
+  };
+  if (upper) addChild(upper);
+  if (lower) addChild(lower);
   subtree.appendChild(children);
 
-  // Connector lines
+  // Vertical connector + midpoint horizontal (via ::after in CSS)
   subtree.appendChild(createConnector());
-  subtree.appendChild(createConnectorLine());
 
   // This match with label
   subtree.appendChild(wrapWithLabel(node));

--- a/frontend/src/bracket/bracket-renderer.ts
+++ b/frontend/src/bracket/bracket-renderer.ts
@@ -39,9 +39,8 @@ function createTeamRow(
   if (isHome) row.classList.add('home');
   else row.classList.add('away');
 
-  // Team color via CSS class
+  // Team color via CSS class (background-color + color from team_style.css)
   if (team) {
-    row.style.borderLeftColor = '';
     row.classList.add(teamCssClass(team));
   }
 
@@ -79,26 +78,23 @@ function createMatchCard(node: BracketNode): HTMLElement {
   const card = document.createElement('div');
   card.classList.add('bracket-match');
 
-  // Round label
-  if (node.round) {
-    const label = document.createElement('div');
-    label.classList.add('bracket-round-label');
-    label.textContent = node.round;
-    card.appendChild(label);
+  // Date line (above team rows)
+  if (node.matchDate) {
+    const dateLine = document.createElement('div');
+    dateLine.classList.add('bracket-match-date');
+    dateLine.textContent = node.matchDate;
+    card.appendChild(dateLine);
   }
 
   card.appendChild(createTeamRow(node.homeTeam, node, true));
   card.appendChild(createTeamRow(node.awayTeam, node, false));
 
-  // Match info (date, stadium)
-  if (node.matchDate || node.stadium) {
-    const info = document.createElement('div');
-    info.classList.add('bracket-match-info');
-    const parts: string[] = [];
-    if (node.matchDate) parts.push(node.matchDate);
-    if (node.stadium) parts.push(node.stadium);
-    info.textContent = parts.join(' | ');
-    card.appendChild(info);
+  // Stadium line (below team rows)
+  if (node.stadium) {
+    const stadiumLine = document.createElement('div');
+    stadiumLine.classList.add('bracket-match-stadium');
+    stadiumLine.textContent = node.stadium;
+    card.appendChild(stadiumLine);
   }
 
   return card;
@@ -131,9 +127,22 @@ function createConnectorLine(): HTMLElement {
 function renderNode(node: BracketNode): HTMLElement {
   const [upper, lower] = node.children;
 
-  // Leaf node: just the match card
+  /** Wrap a match card with its round label. */
+  const wrapWithLabel = (n: BracketNode): HTMLElement => {
+    const wrapper = document.createElement('div');
+    if (n.round) {
+      const label = document.createElement('div');
+      label.classList.add('bracket-round-label');
+      label.textContent = n.round;
+      wrapper.appendChild(label);
+    }
+    wrapper.appendChild(createMatchCard(n));
+    return wrapper;
+  };
+
+  // Leaf node: just the match card with label
   if (!upper && !lower) {
-    return createMatchCard(node);
+    return wrapWithLabel(node);
   }
 
   const subtree = document.createElement('div');
@@ -150,8 +159,8 @@ function renderNode(node: BracketNode): HTMLElement {
   subtree.appendChild(createConnector());
   subtree.appendChild(createConnectorLine());
 
-  // This match
-  subtree.appendChild(createMatchCard(node));
+  // This match with label
+  subtree.appendChild(wrapWithLabel(node));
 
   return subtree;
 }

--- a/frontend/src/bracket/bracket-renderer.ts
+++ b/frontend/src/bracket/bracket-renderer.ts
@@ -1,0 +1,173 @@
+// Render a BracketNode tree as a DOM tree using recursive flexbox layout.
+
+import type { BracketNode } from './bracket-types';
+import { teamCssClass } from '../core/team-utils';
+import './bracket.css';
+
+/**
+ * Format score text for a team line.
+ * Returns the main score and optional PK/ET annotation.
+ */
+function formatScore(
+  node: BracketNode, isHome: boolean,
+): { main: string; annotation: string } {
+  const goal = isHome ? node.homeGoal : node.awayGoal;
+  if (goal == null) return { main: '', annotation: '' };
+
+  const main = String(goal);
+  const pk = isHome ? node.homePkScore : node.awayPkScore;
+  const opponentPk = isHome ? node.awayPkScore : node.homePkScore;
+  if (pk != null && opponentPk != null) {
+    return { main, annotation: `(PK${pk}-${opponentPk})` };
+  }
+
+  const ex = isHome ? node.homeScoreEx : node.awayScoreEx;
+  const opponentEx = isHome ? node.awayScoreEx : node.homeScoreEx;
+  if (ex != null && opponentEx != null) {
+    return { main, annotation: `(ET${ex}-${opponentEx})` };
+  }
+
+  return { main, annotation: '' };
+}
+
+/** Create a team row element within a match card. */
+function createTeamRow(
+  team: string | null, node: BracketNode, isHome: boolean,
+): HTMLElement {
+  const row = document.createElement('div');
+  row.classList.add('bracket-team');
+  if (isHome) row.classList.add('home');
+  else row.classList.add('away');
+
+  // Team color via CSS class
+  if (team) {
+    row.style.borderLeftColor = '';
+    row.classList.add(teamCssClass(team));
+  }
+
+  // Winner/loser styling
+  if (node.winner) {
+    row.classList.add(node.winner === team ? 'winner' : 'loser');
+  }
+
+  // Team name
+  const nameSpan = document.createElement('span');
+  nameSpan.classList.add('bracket-team-name');
+  nameSpan.textContent = team ?? 'TBD';
+  row.appendChild(nameSpan);
+
+  // Score
+  const { main, annotation } = formatScore(node, isHome);
+  if (main) {
+    const scoreSpan = document.createElement('span');
+    scoreSpan.classList.add('bracket-score');
+    scoreSpan.textContent = main;
+    if (annotation) {
+      const pkSpan = document.createElement('span');
+      pkSpan.classList.add('bracket-score-pk');
+      pkSpan.textContent = annotation;
+      scoreSpan.appendChild(pkSpan);
+    }
+    row.appendChild(scoreSpan);
+  }
+
+  return row;
+}
+
+/** Create a match card element. */
+function createMatchCard(node: BracketNode): HTMLElement {
+  const card = document.createElement('div');
+  card.classList.add('bracket-match');
+
+  // Round label
+  if (node.round) {
+    const label = document.createElement('div');
+    label.classList.add('bracket-round-label');
+    label.textContent = node.round;
+    card.appendChild(label);
+  }
+
+  card.appendChild(createTeamRow(node.homeTeam, node, true));
+  card.appendChild(createTeamRow(node.awayTeam, node, false));
+
+  // Match info (date, stadium)
+  if (node.matchDate || node.stadium) {
+    const info = document.createElement('div');
+    info.classList.add('bracket-match-info');
+    const parts: string[] = [];
+    if (node.matchDate) parts.push(node.matchDate);
+    if (node.stadium) parts.push(node.stadium);
+    info.textContent = parts.join(' | ');
+    card.appendChild(info);
+  }
+
+  return card;
+}
+
+/** Create connector lines between child matches and their parent. */
+function createConnector(): HTMLElement {
+  const connector = document.createElement('div');
+  connector.classList.add('bracket-connector');
+
+  const top = document.createElement('div');
+  top.classList.add('connector-top');
+  connector.appendChild(top);
+
+  const bottom = document.createElement('div');
+  bottom.classList.add('connector-bottom');
+  connector.appendChild(bottom);
+
+  return connector;
+}
+
+/** Create a horizontal line from connector to match card. */
+function createConnectorLine(): HTMLElement {
+  const line = document.createElement('div');
+  line.classList.add('connector-line');
+  return line;
+}
+
+/** Recursively render a BracketNode subtree. */
+function renderNode(node: BracketNode): HTMLElement {
+  const [upper, lower] = node.children;
+
+  // Leaf node: just the match card
+  if (!upper && !lower) {
+    return createMatchCard(node);
+  }
+
+  const subtree = document.createElement('div');
+  subtree.classList.add('bracket-subtree');
+
+  // Render child subtrees
+  const children = document.createElement('div');
+  children.classList.add('bracket-children');
+  if (upper) children.appendChild(renderNode(upper));
+  if (lower) children.appendChild(renderNode(lower));
+  subtree.appendChild(children);
+
+  // Connector lines
+  subtree.appendChild(createConnector());
+  subtree.appendChild(createConnectorLine());
+
+  // This match
+  subtree.appendChild(createMatchCard(node));
+
+  return subtree;
+}
+
+/**
+ * Render a full bracket from its root node.
+ *
+ * @param root - Root BracketNode (the final match).
+ * @param _cssFiles - CSS file names for team colors (loaded via link tags in HTML).
+ * @returns DocumentFragment containing the rendered bracket.
+ */
+export function renderBracket(root: BracketNode, _cssFiles: string[]): DocumentFragment {
+  const fragment = document.createDocumentFragment();
+  const wrapper = document.createElement('div');
+  wrapper.classList.add('bracket');
+  wrapper.appendChild(renderNode(root));
+  fragment.appendChild(wrapper);
+  return fragment;
+}

--- a/frontend/src/bracket/bracket-types.ts
+++ b/frontend/src/bracket/bracket-types.ts
@@ -1,0 +1,19 @@
+/** A single node in the tournament bracket tree. */
+export interface BracketNode {
+  round: string;
+  matchNumber?: number;
+  homeTeam: string | null;
+  awayTeam: string | null;
+  homeGoal?: number;
+  awayGoal?: number;
+  homePkScore?: number;
+  awayPkScore?: number;
+  homeScoreEx?: number;
+  awayScoreEx?: number;
+  matchDate?: string;
+  stadium?: string;
+  status: string;
+  winner: string | null;
+  /** [upper child, lower child] — null for first-round byes or leaf nodes. */
+  children: [BracketNode | null, BracketNode | null];
+}

--- a/frontend/src/bracket/bracket.css
+++ b/frontend/src/bracket/bracket.css
@@ -4,6 +4,7 @@
   display: inline-flex;
   align-items: center;
   padding: 16px;
+  background: #1a1a1a;
 }
 
 .bracket-subtree {
@@ -17,7 +18,11 @@
   justify-content: center;
 }
 
-/* Connector lines between rounds */
+/* Connector lines between rounds.
+   The connector sits between the children column and the parent match.
+   It stretches to match the children's full height, then splits into
+   top/bottom halves that draw right-angle lines from each child's
+   vertical center to the midpoint, forming the classic bracket shape. */
 .bracket-connector {
   display: flex;
   flex-direction: column;
@@ -27,50 +32,71 @@
 
 .connector-top {
   flex: 1;
-  border-right: 2px solid #888;
-  border-bottom: 2px solid #888;
-  min-height: 12px;
+  border-right: 2px solid #666;
+  border-bottom: 2px solid #666;
 }
 
 .connector-bottom {
   flex: 1;
-  border-right: 2px solid #888;
-  border-top: 2px solid #888;
-  min-height: 12px;
+  border-right: 2px solid #666;
+  border-top: 2px solid #666;
 }
 
 .connector-line {
   width: 24px;
-  border-top: 2px solid #888;
+  border-top: 2px solid #666;
 }
 
 /* Match card */
 .bracket-match {
-  border: 1px solid #999;
-  margin: 4px 0;
+  border: 1px solid #555;
+  border-radius: 4px;
+  margin: 8px 0;
   min-width: 200px;
-  background: #fff;
+  background: #2a2a2a;
+  overflow: hidden;
 }
 
+/* Date line above team rows */
+.bracket-match-date {
+  font-size: 0.75em;
+  color: #aaa;
+  padding: 3px 8px;
+  border-bottom: 1px solid #444;
+  text-align: center;
+}
+
+/* Team row: team CSS class applies background-color + color directly */
 .bracket-team {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 4px 8px;
-  border-left: 4px solid transparent;
   min-height: 28px;
 }
 
 .bracket-team + .bracket-team {
-  border-top: 1px solid #ddd;
+  border-top: 1px solid #444;
 }
 
+/* Winner: bold text to distinguish from loser */
 .bracket-team.winner {
   font-weight: bold;
 }
 
+/* Loser: keep team colors fully visible, dim via translucent overlay.
+   This preserves background-color + color from team_style.css while
+   visually indicating elimination — similar to .future in league view. */
 .bracket-team.loser {
-  opacity: 0.5;
+  position: relative;
+}
+
+.bracket-team.loser::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  pointer-events: none;
 }
 
 .bracket-team-name {
@@ -85,20 +111,23 @@
 
 .bracket-score-pk {
   font-size: 0.85em;
-  color: #666;
+  opacity: 0.8;
   margin-left: 4px;
 }
 
+/* Round label above match card */
 .bracket-round-label {
   text-align: center;
   font-size: 0.85em;
-  color: #666;
+  color: #aaa;
   margin-bottom: 2px;
 }
 
-.bracket-match-info {
+/* Stadium line below team rows */
+.bracket-match-stadium {
   font-size: 0.75em;
   color: #888;
-  padding: 2px 8px;
-  border-top: 1px solid #eee;
+  padding: 3px 8px;
+  border-top: 1px solid #444;
+  text-align: center;
 }

--- a/frontend/src/bracket/bracket.css
+++ b/frontend/src/bracket/bracket.css
@@ -1,0 +1,104 @@
+/* Tournament bracket layout using recursive flexbox. */
+
+.bracket {
+  display: inline-flex;
+  align-items: center;
+  padding: 16px;
+}
+
+.bracket-subtree {
+  display: flex;
+  align-items: center;
+}
+
+.bracket-children {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+/* Connector lines between rounds */
+.bracket-connector {
+  display: flex;
+  flex-direction: column;
+  width: 24px;
+  align-self: stretch;
+}
+
+.connector-top {
+  flex: 1;
+  border-right: 2px solid #888;
+  border-bottom: 2px solid #888;
+  min-height: 12px;
+}
+
+.connector-bottom {
+  flex: 1;
+  border-right: 2px solid #888;
+  border-top: 2px solid #888;
+  min-height: 12px;
+}
+
+.connector-line {
+  width: 24px;
+  border-top: 2px solid #888;
+}
+
+/* Match card */
+.bracket-match {
+  border: 1px solid #999;
+  margin: 4px 0;
+  min-width: 200px;
+  background: #fff;
+}
+
+.bracket-team {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  border-left: 4px solid transparent;
+  min-height: 28px;
+}
+
+.bracket-team + .bracket-team {
+  border-top: 1px solid #ddd;
+}
+
+.bracket-team.winner {
+  font-weight: bold;
+}
+
+.bracket-team.loser {
+  opacity: 0.5;
+}
+
+.bracket-team-name {
+  margin-right: 12px;
+  white-space: nowrap;
+}
+
+.bracket-score {
+  font-family: monospace;
+  white-space: nowrap;
+}
+
+.bracket-score-pk {
+  font-size: 0.85em;
+  color: #666;
+  margin-left: 4px;
+}
+
+.bracket-round-label {
+  text-align: center;
+  font-size: 0.85em;
+  color: #666;
+  margin-bottom: 2px;
+}
+
+.bracket-match-info {
+  font-size: 0.75em;
+  color: #888;
+  padding: 2px 8px;
+  border-top: 1px solid #eee;
+}

--- a/frontend/src/bracket/bracket.css
+++ b/frontend/src/bracket/bracket.css
@@ -4,7 +4,6 @@
   display: inline-flex;
   align-items: center;
   padding: 16px;
-  background: #1a1a1a;
 }
 
 .bracket-subtree {
@@ -18,51 +17,90 @@
   justify-content: center;
 }
 
-/* Connector lines between rounds.
-   The connector sits between the children column and the parent match.
-   It stretches to match the children's full height, then splits into
-   top/bottom halves that draw right-angle lines from each child's
-   vertical center to the midpoint, forming the classic bracket shape. */
+/* Each child wrapped in a flex row so its ::after line aligns
+   with the child's vertical center automatically. */
+.bracket-child {
+  display: flex;
+  align-items: center;
+}
+
+.bracket-child::after {
+  content: '';
+  flex-shrink: 0;
+  width: 24px;
+  border-top: 2px solid #888;
+}
+
+/* Connector between children and parent match.
+   Draws a vertical line on the left (connecting to child ::after lines)
+   and a horizontal line at the midpoint (toward the parent match card)
+   via the ::after pseudo-element. */
 .bracket-connector {
   display: flex;
   flex-direction: column;
+  position: relative;
   width: 24px;
   align-self: stretch;
 }
 
+/* Each half covers one child's vertical extent.
+   The ::after draws the vertical line only from the child's center
+   (50% of the half) to the midpoint, so the line doesn't extend
+   beyond the children's horizontal connector lines. */
 .connector-top {
   flex: 1;
-  border-right: 2px solid #666;
-  border-bottom: 2px solid #666;
+  position: relative;
+}
+
+.connector-top::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  bottom: 0;
+  left: 0;
+  border-left: 2px solid #888;
 }
 
 .connector-bottom {
   flex: 1;
-  border-right: 2px solid #666;
-  border-top: 2px solid #666;
+  position: relative;
 }
 
-.connector-line {
-  width: 24px;
-  border-top: 2px solid #666;
+.connector-bottom::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 50%;
+  left: 0;
+  border-left: 2px solid #888;
+}
+
+/* Horizontal line from vertical connector midpoint to parent match */
+.bracket-connector::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  border-top: 2px solid #888;
 }
 
 /* Match card */
 .bracket-match {
-  border: 1px solid #555;
+  border: 1px solid #999;
   border-radius: 4px;
   margin: 8px 0;
   min-width: 200px;
-  background: #2a2a2a;
+  background: #fff;
   overflow: hidden;
 }
 
 /* Date line above team rows */
 .bracket-match-date {
   font-size: 0.75em;
-  color: #aaa;
+  color: #fff;
+  background: #333;
   padding: 3px 8px;
-  border-bottom: 1px solid #444;
   text-align: center;
 }
 
@@ -76,7 +114,7 @@
 }
 
 .bracket-team + .bracket-team {
-  border-top: 1px solid #444;
+  border-top: 1px solid #ddd;
 }
 
 /* Winner: bold text to distinguish from loser */
@@ -84,9 +122,11 @@
   font-weight: bold;
 }
 
-/* Loser: keep team colors fully visible, dim via translucent overlay.
-   This preserves background-color + color from team_style.css while
-   visually indicating elimination — similar to .future in league view. */
+/* Loser: dim background via translucent white overlay.
+   The overlay sits between the background and the text content:
+   - ::after covers the background-color (set by team CSS class)
+   - Text spans use z-index to stay above the overlay
+   Same visual effect as league view's .future on a separate bg div. */
 .bracket-team.loser {
   position: relative;
 }
@@ -95,8 +135,15 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
+  background: rgba(255, 255, 255, 0.8);
   pointer-events: none;
+}
+
+.bracket-team.loser .bracket-team-name,
+.bracket-team.loser .bracket-score {
+  position: relative;
+  z-index: 1;
+  color: #333;
 }
 
 .bracket-team-name {
@@ -111,7 +158,7 @@
 
 .bracket-score-pk {
   font-size: 0.85em;
-  opacity: 0.8;
+  color: #666;
   margin-left: 4px;
 }
 
@@ -119,15 +166,15 @@
 .bracket-round-label {
   text-align: center;
   font-size: 0.85em;
-  color: #aaa;
+  color: #666;
   margin-bottom: 2px;
 }
 
 /* Stadium line below team rows */
 .bracket-match-stadium {
   font-size: 0.75em;
-  color: #888;
+  color: #fff;
+  background: #333;
   padding: 3px 8px;
-  border-top: 1px solid #444;
   text-align: center;
 }

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -3,7 +3,7 @@
 import type { PointSystem } from '../types/config';
 import type {
   SeasonMap, GroupEntry, CompetitionEntry, RawSeasonEntry, SeasonInfo,
-  CrossGroupStanding, DataSource,
+  CrossGroupStanding, DataSource, ViewType,
 } from '../types/season';
 import { generateRuleNotes } from './rule-notes';
 import { t } from '../i18n';
@@ -49,6 +49,18 @@ export function findCompetition(
     }
   }
   return undefined;
+}
+
+/**
+ * Resolve view_type at the group → competition level (ignoring per-season).
+ * Used for dropdown filtering without resolving every season entry.
+ * Returns ['league'] as the default when no level specifies view_type.
+ */
+export function getCompetitionViewTypes(group: GroupEntry, comp: CompetitionEntry): ViewType[] {
+  const set = new Set<ViewType>();
+  for (const v of (group.view_type ?? [])) set.add(v);
+  for (const v of (comp.view_type ?? [])) set.add(v);
+  return set.size > 0 ? [...set] : ['league'];
 }
 
 /**
@@ -145,6 +157,14 @@ export function resolveSeasonInfo(
     ...generateRuleNotes(pointSystem, tiebreakOrder),
   ];
 
+  // view_type: array union across all three levels (deduplicated).
+  // Default ['league'] when no level specifies it.
+  const vtSet = new Set<ViewType>();
+  for (const v of (group.view_type ?? [])) vtSet.add(v);
+  for (const v of (comp.view_type ?? [])) vtSet.add(v);
+  for (const v of (opts.view_type ?? [])) vtSet.add(v);
+  const viewTypes: ViewType[] = vtSet.size > 0 ? [...vtSet] : ['league'];
+
   return {
     teamCount: entry[0],
     promotionCount: entry[1],
@@ -165,5 +185,6 @@ export function resolveSeasonInfo(
     dataSource,
     notes,
     promotionLabel,
+    viewTypes,
   };
 }

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -5,9 +5,10 @@
 
 import Papa from 'papaparse';
 import type { RawMatchRow } from './types/match';
-import type { SeasonMap, CompetitionEntry } from './types/season';
+import type { SeasonMap } from './types/season';
 import {
   loadSeasonMap, getCsvFilename, findCompetition, resolveSeasonInfo,
+  getCompetitionViewTypes,
 } from './config/season-map';
 import { buildBracket } from './bracket/bracket-data';
 import { renderBracket } from './bracket/bracket-renderer';
@@ -26,15 +27,6 @@ function setStatus(msg: string): void {
   if (el) el.textContent = msg;
 }
 
-// ---- Competition filtering -------------------------------------------------
-
-/** Check if a competition has any season with bracket_order. */
-function hasBracket(comp: CompetitionEntry): boolean {
-  return Object.values(comp.seasons).some(
-    entry => entry[4]?.bracket_order != null,
-  );
-}
-
 // ---- Dropdown population ---------------------------------------------------
 
 function populateCompetitionPulldown(seasonMap: SeasonMap): void {
@@ -44,7 +36,7 @@ function populateCompetitionPulldown(seasonMap: SeasonMap): void {
   const multiGroup = groups.length > 1;
   for (const [groupKey, group] of groups) {
     const bracketComps = Object.entries(group.competitions)
-      .filter(([, comp]) => hasBracket(comp));
+      .filter(([, comp]) => getCompetitionViewTypes(group, comp).includes('bracket'));
     if (bracketComps.length === 0) continue;
 
     if (multiGroup) {
@@ -68,7 +60,7 @@ function populateSeasonPulldown(seasonMap: SeasonMap, competition: string): void
   const found = findCompetition(seasonMap, competition);
   if (!found) return;
   const seasons = Object.keys(found.competition.seasons)
-    .filter(s => found.competition.seasons[s][4]?.bracket_order != null)
+    .filter(s => found.competition.seasons[s][4]?.bracket_order != null)  // bracket_order required for rendering
     .sort().reverse();
   for (const s of seasons) {
     const opt = document.createElement('option');

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -1,0 +1,211 @@
+// Tournament bracket viewer entry point.
+//
+// Loads season_map.json, filters to bracket-enabled competitions,
+// and renders a CSS Grid bracket for the selected season.
+
+import Papa from 'papaparse';
+import type { RawMatchRow } from './types/match';
+import type { SeasonMap, CompetitionEntry } from './types/season';
+import {
+  loadSeasonMap, getCsvFilename, findCompetition, resolveSeasonInfo,
+} from './config/season-map';
+import { buildBracket } from './bracket/bracket-data';
+import { renderBracket } from './bracket/bracket-renderer';
+import { loadPrefs, savePrefs } from './storage/local-storage';
+import { t, applyI18nAttributes, setLocale } from './i18n';
+import type { Locale } from './i18n';
+
+// ---- DOM helpers -----------------------------------------------------------
+
+function getSelectValue(id: string): string {
+  return (document.getElementById(id) as HTMLSelectElement).value;
+}
+
+function setStatus(msg: string): void {
+  const el = document.getElementById('status_msg');
+  if (el) el.textContent = msg;
+}
+
+// ---- Competition filtering -------------------------------------------------
+
+/** Check if a competition has any season with bracket_order. */
+function hasBracket(comp: CompetitionEntry): boolean {
+  return Object.values(comp.seasons).some(
+    entry => entry[4]?.bracket_order != null,
+  );
+}
+
+// ---- Dropdown population ---------------------------------------------------
+
+function populateCompetitionPulldown(seasonMap: SeasonMap): void {
+  const sel = document.getElementById('competition_key') as HTMLSelectElement;
+  sel.innerHTML = '';
+  const groups = Object.entries(seasonMap);
+  const multiGroup = groups.length > 1;
+  for (const [groupKey, group] of groups) {
+    const bracketComps = Object.entries(group.competitions)
+      .filter(([, comp]) => hasBracket(comp));
+    if (bracketComps.length === 0) continue;
+
+    if (multiGroup) {
+      const sep = document.createElement('option');
+      sep.disabled = true;
+      sep.textContent = `── ${group.display_name ?? groupKey} `;
+      sel.appendChild(sep);
+    }
+    for (const [compKey, comp] of bracketComps) {
+      const opt = document.createElement('option');
+      opt.value = compKey;
+      opt.textContent = comp.league_display ?? compKey;
+      sel.appendChild(opt);
+    }
+  }
+}
+
+function populateSeasonPulldown(seasonMap: SeasonMap, competition: string): void {
+  const sel = document.getElementById('season_key') as HTMLSelectElement;
+  sel.innerHTML = '';
+  const found = findCompetition(seasonMap, competition);
+  if (!found) return;
+  const seasons = Object.keys(found.competition.seasons)
+    .filter(s => found.competition.seasons[s][4]?.bracket_order != null)
+    .sort().reverse();
+  for (const s of seasons) {
+    const opt = document.createElement('option');
+    opt.value = s;
+    opt.textContent = s;
+    sel.appendChild(opt);
+  }
+}
+
+// ---- URL params ------------------------------------------------------------
+
+function readUrlParams(): { competition: string; season?: string } {
+  const params = new URLSearchParams(location.search);
+  return {
+    competition: params.get('competition') ?? '',
+    season: params.get('season') ?? undefined,
+  };
+}
+
+function writeUrlParams(competition: string, season: string): void {
+  const url = new URL(location.href);
+  url.searchParams.set('competition', competition);
+  url.searchParams.set('season', season);
+  history.replaceState(null, '', url.toString());
+}
+
+// ---- Render pipeline -------------------------------------------------------
+
+const CACHE_BUST_WINDOW_SEC = 300;
+
+function loadAndRender(seasonMap: SeasonMap): void {
+  const competition = getSelectValue('competition_key');
+  const season = getSelectValue('season_key');
+  if (!competition || !season) return;
+
+  const found = findCompetition(seasonMap, competition);
+  if (!found || !found.competition.seasons[season]) {
+    setStatus(t('status.noSeason', { competition, season }));
+    return;
+  }
+
+  const seasonInfo = resolveSeasonInfo(
+    found.group, found.competition, found.competition.seasons[season], found.groupKey,
+  );
+  const bracketOrder = found.competition.seasons[season][4]?.bracket_order;
+  if (!bracketOrder) {
+    setStatus('No bracket data for this season.');
+    return;
+  }
+
+  writeUrlParams(competition, season);
+  savePrefs({ competition, season });
+
+  const filename = getCsvFilename(competition, season);
+  const cachebuster = Math.floor(Date.now() / 1000 / CACHE_BUST_WINDOW_SEC);
+  setStatus(t('status.loading'));
+
+  Papa.parse<RawMatchRow>(filename + '?_=' + cachebuster, {
+    header: true,
+    skipEmptyLines: 'greedy',
+    download: true,
+    complete: (results) => {
+      const container = document.getElementById('bracket_container');
+      if (!container) return;
+
+      const root = buildBracket(results.data, bracketOrder);
+      container.replaceChildren(renderBracket(root, seasonInfo.cssFiles));
+
+      const leagueDisplay = seasonInfo.leagueDisplay;
+      setStatus(t('status.loaded', { league: leagueDisplay, season, rows: results.data.length }));
+    },
+    error: (err: unknown) => {
+      setStatus(t('status.error', { detail: String(err) }));
+    },
+  });
+}
+
+// ---- Initialization --------------------------------------------------------
+
+async function main(): Promise<void> {
+  const savedLocale = loadPrefs().locale;
+  if (savedLocale === 'ja' || savedLocale === 'en') setLocale(savedLocale as Locale);
+  applyI18nAttributes();
+
+  let seasonMap: SeasonMap;
+  try {
+    seasonMap = await loadSeasonMap();
+  } catch (err) {
+    setStatus(t('status.seasonMapError'));
+    console.error('Failed to load season map:', err);
+    return;
+  }
+
+  populateCompetitionPulldown(seasonMap);
+
+  const urlParams = readUrlParams();
+  const prefs = loadPrefs();
+
+  const competitionSel = document.getElementById('competition_key') as HTMLSelectElement;
+  const initCompetition = (urlParams.competition && findCompetition(seasonMap, urlParams.competition))
+    ? urlParams.competition
+    : (prefs.competition && findCompetition(seasonMap, prefs.competition))
+    ? prefs.competition
+    : competitionSel.options[0]?.value ?? '';
+  competitionSel.value = initCompetition;
+
+  populateSeasonPulldown(seasonMap, initCompetition);
+
+  const seasonSel = document.getElementById('season_key') as HTMLSelectElement;
+  const found = findCompetition(seasonMap, initCompetition);
+  const initSeason = (urlParams.season && found?.competition.seasons[urlParams.season])
+    ? urlParams.season
+    : (prefs.season && found?.competition.seasons[prefs.season])
+    ? prefs.season
+    : seasonSel.options[0]?.value ?? '';
+  seasonSel.value = initSeason;
+
+  // Locale selector
+  const localeSel = document.getElementById('locale_key') as HTMLSelectElement | null;
+  if (localeSel) {
+    if (savedLocale) localeSel.value = savedLocale;
+    localeSel.addEventListener('change', () => {
+      savePrefs({ locale: localeSel.value });
+      location.reload();
+    });
+  }
+
+  // Event wiring
+  competitionSel.addEventListener('change', () => {
+    populateSeasonPulldown(seasonMap, competitionSel.value);
+    loadAndRender(seasonMap);
+  });
+  document.getElementById('season_key')?.addEventListener('change', () => {
+    loadAndRender(seasonMap);
+  });
+
+  loadAndRender(seasonMap);
+}
+
+main().catch(console.error);

--- a/frontend/src/tournament.html
+++ b/frontend/src/tournament.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tournament Bracket</title>
+  <link rel="icon" href="favicon.ico">
+  <link rel="stylesheet" href="j_points.css">
+  <link rel="stylesheet" href="team_style.css">
+</head>
+<body>
+<main>
+
+<section id="controls">
+  <label>
+    <span data-i18n="label.competition"></span>
+    <select id="competition_key"></select>
+  </label>
+  <label>
+    <span data-i18n="label.season"></span>
+    <select id="season_key"></select>
+  </label>
+  <label>
+    <span data-i18n="label.language"></span>
+    <select id="locale_key">
+      <option value="ja">日本語</option>
+      <option value="en">English</option>
+    </select>
+  </label>
+</section>
+
+<div id="status_bar">
+  <span id="status_msg"></span>
+</div>
+
+<div id="bracket_container"></div>
+
+<hr/>
+<a href="https://github.com/mokekuma-git/JLeague_Matches-Bar_Graph" data-i18n="link.github"></a>
+
+</main>
+
+<script type="module" src="./tournament-app.ts"></script>
+</body>
+</html>

--- a/frontend/src/types/match.ts
+++ b/frontend/src/types/match.ts
@@ -16,6 +16,8 @@ export interface RawMatchRow {
   away_pk_score?: string;
   home_score_ex?: string;   // Extra-time score (column may be absent; Tier 4 preparation)
   away_score_ex?: string;
+  round?: string;           // Tournament round name (column may be absent)
+  match_number?: string;    // Tournament match number (column may be absent)
 }
 
 // Per-match data from a single team's perspective, produced by parse_csvresults.

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -54,6 +54,8 @@ export interface SeasonEntryOptions {
   note?: string | string[];
   data_source?: DataSource;
   promotion_label?: string;
+  bracket_order?: string[];
+  bracket_round_start?: string;
 }
 
 // Raw array format as loaded from season_map.json (tuple type).

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -18,6 +18,9 @@
 
 import type { PointSystem } from './config';
 
+// Which views a competition/season supports.
+export type ViewType = 'league' | 'bracket';
+
 // Map of rank → CSS class name.
 // Example: { "3": "promoted_playoff" }
 export type RankClassMap = Record<string, string>;
@@ -56,6 +59,7 @@ export interface SeasonEntryOptions {
   promotion_label?: string;
   bracket_order?: string[];
   bracket_round_start?: string;
+  view_type?: ViewType[];
 }
 
 // Raw array format as loaded from season_map.json (tuple type).
@@ -106,4 +110,5 @@ export interface SeasonInfo {
   dataSource?: DataSource;
   notes: string[];
   promotionLabel: string;
+  viewTypes: ViewType[];
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(({ command }) => ({
     rollupOptions: {
       input: {
         j_points: new URL('src/j_points.html', import.meta.url).pathname,
+        tournament: new URL('src/tournament.html', import.meta.url).pathname,
       },
     },
   },

--- a/scripts/check_point_system_csv.py
+++ b/scripts/check_point_system_csv.py
@@ -73,6 +73,20 @@ def resolve_point_system(
     return 'standard'
 
 
+def resolve_view_types(
+    group_data: dict, comp_data: dict, season_entry: list,
+) -> set[str]:
+    """Resolve view_type with array union cascade: group -> competition -> season."""
+    vt: set[str] = set()
+    for level in (group_data, comp_data):
+        for v in level.get('view_type', []):
+            vt.add(v)
+    if len(season_entry) > 4 and isinstance(season_entry[4], dict):
+        for v in season_entry[4].get('view_type', []):
+            vt.add(v)
+    return vt if vt else {'league'}
+
+
 def check_csv_pk_data(csv_path: Path) -> bool:
     """Check if a CSV contains actual PK match data (non-empty values).
 
@@ -121,6 +135,12 @@ def check_all() -> list[str]:
         for comp_key, comp_data in competitions.items():
             seasons = comp_data.get('seasons', {})
             for season_key, season_entry in seasons.items():
+                # Skip bracket-only seasons (no league view = no point calculation)
+                view_types = resolve_view_types(
+                    group_data, comp_data, season_entry)
+                if 'league' not in view_types:
+                    continue
+
                 point_system = resolve_point_system(comp_data, season_entry)
 
                 # Validate point_system is known

--- a/scripts/check_type_sync.py
+++ b/scripts/check_type_sync.py
@@ -135,6 +135,37 @@ def check_point_system_values() -> list[str]:
     return errors
 
 
+def check_view_type_consistency() -> list[str]:
+    """Check that bracket_order entries have view_type including 'bracket'."""
+    import json
+    errors: list[str] = []
+    season_map_path = PROJECT_ROOT / 'docs' / 'json' / 'season_map.json'
+    with open(season_map_path, 'r', encoding='utf-8') as f:
+        season_map = json.load(f)
+
+    for group_key, group in season_map.items():
+        if not isinstance(group, dict) or 'competitions' not in group:
+            continue
+        group_vt = set(group.get('view_type', []))
+        for comp_key, comp in group.get('competitions', {}).items():
+            if not isinstance(comp, dict):
+                continue
+            comp_vt = group_vt | set(comp.get('view_type', []))
+            for season_key, entry in comp.get('seasons', {}).items():
+                if not isinstance(entry, list) or len(entry) < 5:
+                    continue
+                opts = entry[4] if isinstance(entry[4], dict) else {}
+                resolved_vt = comp_vt | set(opts.get('view_type', []))
+                if not resolved_vt:
+                    resolved_vt = {'league'}
+                if opts.get('bracket_order') and 'bracket' not in resolved_vt:
+                    errors.append(
+                        f"{group_key}/{comp_key}/{season_key}: "
+                        f"bracket_order exists but view_type {sorted(resolved_vt)} "
+                        f"does not include 'bracket'")
+    return errors
+
+
 def main() -> int:
     all_errors: list[str] = []
 
@@ -142,6 +173,7 @@ def main() -> int:
         ('CSV columns', check_csv_columns),
         ('SeasonEntryOptions', check_season_entry_options),
         ('PointSystem values', check_point_system_values),
+        ('view_type consistency', check_view_type_consistency),
     ]
 
     for label, check_fn in checks:

--- a/src/match_utils.py
+++ b/src/match_utils.py
@@ -92,7 +92,7 @@ class SeasonEntry:
         'team_rename_map', 'tiebreak_order', 'season_start_month',
         'shown_groups', 'cross_group_standing', 'group_team_count',
         'note', 'data_source', 'promotion_label',
-        'bracket_order', 'bracket_round_start',
+        'bracket_order', 'bracket_round_start', 'view_type',
     }
 
     def __init__(self, season_key: str, raw: list):

--- a/src/match_utils.py
+++ b/src/match_utils.py
@@ -62,6 +62,8 @@ CSV_COLUMN_SCHEMA: dict[str, str] = {
     'away_pk_score': 'nullable_int',  # PK shootout (column may be absent)
     'home_score_ex': 'nullable_int',  # Extra-time score (column may be absent)
     'away_score_ex': 'nullable_int',  # Extra-time score (column may be absent)
+    'round': 'str',                   # Tournament round name (column may be absent)
+    'match_number': 'nullable_int',   # Tournament match number (column may be absent)
 }
 
 
@@ -90,6 +92,7 @@ class SeasonEntry:
         'team_rename_map', 'tiebreak_order', 'season_start_month',
         'shown_groups', 'cross_group_standing', 'group_team_count',
         'note', 'data_source', 'promotion_label',
+        'bracket_order', 'bracket_round_start',
     }
 
     def __init__(self, season_key: str, raw: list):

--- a/src/read_we_league.py
+++ b/src/read_we_league.py
@@ -39,6 +39,7 @@ _CUP_KEYWORD = 'カップ'
 _SECTION_RE = re.compile(r'第(\d+)節')
 _GROUP_RE = re.compile(r'グループ([A-Z])')
 _ROUND_SECTION: dict[str, int] = {'準々決勝': 97, '準決勝': 98, '決勝': 99}
+_SECTION_ROUND: dict[int, str] = {v: k for k, v in _ROUND_SECTION.items()}
 
 # Date extraction from match URL e.g. /matches/2026022820/
 _MATCH_DATE_RE = re.compile(r'/matches/(\d{4})(\d{2})(\d{2})\d+/')
@@ -215,6 +216,8 @@ def _read_day(
         if scores.get('home_pk_score'):
             record['home_pk_score'] = scores['home_pk_score']
             record['away_pk_score'] = scores['away_pk_score']
+        if section_no in _SECTION_ROUND:
+            record['round'] = _SECTION_ROUND[section_no]
 
         results.append((is_cup, record))
 


### PR DESCRIPTION
Fixes #139

## Summary
- WE Cup KO (2-4チーム) をデータ例としてトーナメントブラケット View の描画基盤を構築
- CSV/型拡張 (`round`, `match_number`), Vite マルチエントリ化, `bracket/` モジュール新規作成
- `view_type` カスケード (Group → Competition → Season 配列和集合) によるリーグ/ブラケット View の出し分け
- `check_type_sync.py` に `bracket_order`/`view_type` 整合性チェック追加
- コネクタ線・敗者スタイリング・日付/スタジアム表示のビジュアル調整

## Changes
| Commit | Description |
| --- | --- |
| `08a5c61` | Add tournament bracket view for WE Cup KO |
| `5828c1e` | Add view_type cascade and refine bracket visual styling |
| `c909c03` | Fix bracket connector lines and refine match card styling |

## Test plan
- [x] `uv run pytest` passed (78 tests)
- [x] `npx vitest run` passed (401 tests)
- [x] `npm run build` succeeded (j_points + tournament entries)
- [x] `uv run python scripts/check_type_sync.py` passed (4/4 checks)
- [x] Browser visual verification (WE Cup KO 24-25, 3 rounds of feedback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)