### PR TITLE
Add bracket interactivity: date slider, opacity, zoom, layout

### DIFF
--- a/frontend/src/bracket/bracket-renderer.ts
+++ b/frontend/src/bracket/bracket-renderer.ts
@@ -44,6 +44,11 @@ function createTeamRow(
     row.classList.add(teamCssClass(team));
   }
 
+  // TBD team: future styling (opacity controlled by slider)
+  if (!team) {
+    row.classList.add('bracket-future');
+  }
+
   // Winner/loser styling
   if (node.winner) {
     row.classList.add(node.winner === team ? 'winner' : 'loser');

--- a/frontend/src/bracket/bracket.css
+++ b/frontend/src/bracket/bracket.css
@@ -85,6 +85,12 @@
   border-top: 2px solid #888;
 }
 
+/* Unplayed match: translucent for future/pending state.
+   Opacity controlled dynamically via slider. */
+.bracket-future {
+  opacity: 0.2;
+}
+
 /* Match card */
 .bracket-match {
   border: 1px solid #999;
@@ -177,4 +183,72 @@
   background: #333;
   padding: 3px 8px;
   text-align: center;
+}
+
+/* ---- Vertical layout (bottom-to-top) ---- */
+
+.bracket.vertical {
+  flex-direction: column-reverse;
+}
+
+.bracket.vertical .bracket-subtree {
+  flex-direction: column-reverse;
+}
+
+.bracket.vertical .bracket-children {
+  flex-direction: row;
+  justify-content: center;
+}
+
+.bracket.vertical .bracket-child {
+  flex-direction: column-reverse;
+}
+
+.bracket.vertical .bracket-child::after {
+  width: auto;
+  height: 24px;
+  border-top: none;
+  border-left: 2px solid #888;
+}
+
+.bracket.vertical .bracket-connector {
+  flex-direction: row;
+  width: auto;
+  height: 24px;
+  align-self: stretch;
+}
+
+.bracket.vertical .connector-top {
+  flex: 1;
+}
+
+.bracket.vertical .connector-top::after {
+  top: auto;
+  bottom: 0;
+  left: 50%;
+  right: 0;
+  border-left: none;
+  border-top: 2px solid #888;
+}
+
+.bracket.vertical .connector-bottom {
+  flex: 1;
+}
+
+.bracket.vertical .connector-bottom::after {
+  top: auto;
+  bottom: 0;
+  left: 0;
+  right: 50%;
+  border-left: none;
+  border-top: 2px solid #888;
+}
+
+.bracket.vertical .bracket-connector::after {
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  right: auto;
+  border-top: none;
+  border-left: 2px solid #888;
 }

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -13,6 +13,9 @@ export const en: Record<MessageKey, string> = {
   'label.spaceColor': 'Space color',
   'label.dataTimestamp': 'Data updated:',
   'label.language': 'Language',
+  'label.bracketLayout': 'Layout',
+  'label.layoutHorizontal': 'Horizontal (L→R)',
+  'label.layoutVertical': 'Vertical (bottom→up)',
 
   // Buttons
   'btn.resetDate': 'Reset to latest',

--- a/frontend/src/i18n/messages/ja.ts
+++ b/frontend/src/i18n/messages/ja.ts
@@ -11,6 +11,9 @@ export const ja = {
   'label.spaceColor': '余白色',
   'label.dataTimestamp': 'データ取得時刻:',
   'label.language': '言語',
+  'label.bracketLayout': '表示方向',
+  'label.layoutHorizontal': '横 (左→右)',
+  'label.layoutVertical': '縦 (下→上)',
 
   // Buttons
   'btn.resetDate': '最新にリセット',

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -1,7 +1,8 @@
 // Tournament bracket viewer entry point.
 //
 // Loads season_map.json, filters to bracket-enabled competitions,
-// and renders a CSS Grid bracket for the selected season.
+// and renders a CSS bracket for the selected season.
+// Provides date slider, opacity, zoom, and layout controls.
 
 import Papa from 'papaparse';
 import type { RawMatchRow } from './types/match';
@@ -15,6 +16,20 @@ import { renderBracket } from './bracket/bracket-renderer';
 import { loadPrefs, savePrefs } from './storage/local-storage';
 import { t, applyI18nAttributes, setLocale } from './i18n';
 import type { Locale } from './i18n';
+import type { BracketNode } from './bracket/bracket-types';
+
+// ---- State ------------------------------------------------------------------
+
+interface BracketState {
+  csvRows: RawMatchRow[];
+  bracketOrder: string[];
+  matchDates: string[];       // sorted unique dates from CSV
+  cssFiles: string[];
+  leagueDisplay: string;
+  season: string;
+}
+
+let currentState: BracketState | null = null;
 
 // ---- DOM helpers -----------------------------------------------------------
 
@@ -25,6 +40,21 @@ function getSelectValue(id: string): string {
 function setStatus(msg: string): void {
   const el = document.getElementById('status_msg');
   if (el) el.textContent = msg;
+}
+
+// ---- Match date collection --------------------------------------------------
+
+const PRESEASON_SENTINEL = '1970/01/01';
+
+function collectMatchDates(rows: RawMatchRow[]): string[] {
+  const dates = new Set<string>();
+  for (const r of rows) {
+    if (r.match_date) dates.add(r.match_date);
+  }
+  const sorted = Array.from(dates).sort();
+  // Prepend sentinel so slider index 0 = "before any match"
+  sorted.unshift(PRESEASON_SENTINEL);
+  return sorted;
 }
 
 // ---- Dropdown population ---------------------------------------------------
@@ -60,7 +90,7 @@ function populateSeasonPulldown(seasonMap: SeasonMap, competition: string): void
   const found = findCompetition(seasonMap, competition);
   if (!found) return;
   const seasons = Object.keys(found.competition.seasons)
-    .filter(s => found.competition.seasons[s][4]?.bracket_order != null)  // bracket_order required for rendering
+    .filter(s => found.competition.seasons[s][4]?.bracket_order != null)
     .sort().reverse();
   for (const s of seasons) {
     const opt = document.createElement('option');
@@ -85,6 +115,116 @@ function writeUrlParams(competition: string, season: string): void {
   url.searchParams.set('competition', competition);
   url.searchParams.set('season', season);
   history.replaceState(null, '', url.toString());
+}
+
+// ---- Bracket rendering with date filter ------------------------------------
+
+function getTargetDate(): string | null {
+  if (!currentState) return null;
+  const slider = document.getElementById('date_slider') as HTMLInputElement | null;
+  if (!slider) return null;
+  const idx = parseInt(slider.value, 10);
+  return currentState.matchDates[idx] ?? null;
+}
+
+/**
+ * Mask a bracket tree for a target date.
+ * - Nodes with matchDate > targetDate: clear scores and winner, keep date/stadium
+ * - Nodes whose child winner is unknown: set corresponding team to null (TBD)
+ * Walks bottom-up (children before parent) so winner propagation works correctly.
+ */
+function maskBracketForDate(node: BracketNode, targetDate: string): BracketNode {
+  // Recurse into children first
+  const [upper, lower] = node.children;
+  const maskedUpper = upper ? maskBracketForDate(upper, targetDate) : null;
+  const maskedLower = lower ? maskBracketForDate(lower, targetDate) : null;
+
+  // Determine if this match is in the future
+  const isFuture = node.matchDate != null && node.matchDate > targetDate;
+
+  if (isFuture) {
+    // Replace teams with child winners (may be null = TBD)
+    const homeTeam = maskedUpper ? maskedUpper.winner : node.homeTeam;
+    const awayTeam = maskedLower ? maskedLower.winner : node.awayTeam;
+    return {
+      ...node,
+      homeTeam,
+      awayTeam,
+      homeGoal: undefined,
+      awayGoal: undefined,
+      homePkScore: undefined,
+      awayPkScore: undefined,
+      homeScoreEx: undefined,
+      awayScoreEx: undefined,
+      status: 'ＶＳ',
+      winner: null,
+      children: [maskedUpper, maskedLower],
+    };
+  }
+
+  // Not future: keep original data but use masked children
+  return { ...node, children: [maskedUpper, maskedLower] };
+}
+
+function renderWithDateFilter(): void {
+  if (!currentState) return;
+  const container = document.getElementById('bracket_container');
+  if (!container) return;
+
+  // Build full tree from all CSV data, then mask for target date
+  const fullRoot = buildBracket(currentState.csvRows, currentState.bracketOrder);
+  const targetDate = getTargetDate();
+  const lastDate = currentState.matchDates[currentState.matchDates.length - 1];
+  const root = (targetDate && targetDate < lastDate)
+    ? maskBracketForDate(fullRoot, targetDate)
+    : fullRoot;
+
+  container.replaceChildren(renderBracket(root, currentState.cssFiles));
+
+  // Apply layout class
+  applyLayout();
+}
+
+function updateSliderDisplay(): void {
+  if (!currentState) return;
+  const slider = document.getElementById('date_slider') as HTMLInputElement | null;
+  const display = document.getElementById('post_date_slider');
+  if (!slider || !display) return;
+  const idx = parseInt(slider.value, 10);
+  const date = currentState.matchDates[idx];
+  display.textContent = date === PRESEASON_SENTINEL ? t('slider.preseason') : (date ?? '');
+}
+
+// ---- Controls: opacity, scale, layout --------------------------------------
+
+function setBracketFutureOpacity(value: string): void {
+  const container = document.getElementById('bracket_container');
+  if (!container) return;
+  for (const el of Array.from(container.querySelectorAll('.bracket-future'))) {
+    (el as HTMLElement).style.opacity = value;
+  }
+  const display = document.getElementById('current_opacity');
+  if (display) display.textContent = value;
+}
+
+function setBracketScale(value: string): void {
+  const container = document.getElementById('bracket_container');
+  if (!container) return;
+  container.style.transform = `scale(${value})`;
+  container.style.transformOrigin = 'top left';
+  const display = document.getElementById('current_scale');
+  if (display) display.textContent = value;
+}
+
+function applyLayout(): void {
+  const layoutSel = document.getElementById('layout_toggle') as HTMLSelectElement | null;
+  const bracket = document.querySelector('.bracket');
+  if (!bracket || !layoutSel) return;
+  if (layoutSel.value === 'vertical') {
+    bracket.classList.add('vertical');
+  } else {
+    bracket.classList.remove('vertical');
+  }
 }
 
 // ---- Render pipeline -------------------------------------------------------
@@ -123,14 +263,39 @@ function loadAndRender(seasonMap: SeasonMap): void {
     skipEmptyLines: 'greedy',
     download: true,
     complete: (results) => {
-      const container = document.getElementById('bracket_container');
-      if (!container) return;
+      const matchDates = collectMatchDates(results.data);
 
-      const root = buildBracket(results.data, bracketOrder);
-      container.replaceChildren(renderBracket(root, seasonInfo.cssFiles));
+      currentState = {
+        csvRows: results.data,
+        bracketOrder,
+        matchDates,
+        cssFiles: seasonInfo.cssFiles,
+        leagueDisplay: seasonInfo.leagueDisplay,
+        season,
+      };
 
-      const leagueDisplay = seasonInfo.leagueDisplay;
-      setStatus(t('status.loaded', { league: leagueDisplay, season, rows: results.data.length }));
+      // Set up date slider
+      const slider = document.getElementById('date_slider') as HTMLInputElement | null;
+      if (slider && matchDates.length > 0) {
+        slider.min = '0';
+        slider.max = String(matchDates.length - 1);
+        slider.value = String(matchDates.length - 1);
+      }
+
+      renderWithDateFilter();
+      updateSliderDisplay();
+
+      // Apply saved opacity
+      const opacitySlider = document.getElementById('future_opacity') as HTMLInputElement | null;
+      if (opacitySlider) setBracketFutureOpacity(opacitySlider.value);
+
+      // Apply saved scale
+      const scaleSlider = document.getElementById('scale_slider') as HTMLInputElement | null;
+      if (scaleSlider) setBracketScale(scaleSlider.value);
+
+      setStatus(t('status.loaded', {
+        league: seasonInfo.leagueDisplay, season, rows: results.data.length,
+      }));
     },
     error: (err: unknown) => {
       setStatus(t('status.error', { detail: String(err) }));
@@ -188,7 +353,79 @@ async function main(): Promise<void> {
     });
   }
 
-  // Event wiring
+  // ---- Restore saved preferences -------------------------------------------
+
+  const opacitySlider = document.getElementById('future_opacity') as HTMLInputElement | null;
+  if (opacitySlider && prefs.futureOpacity) opacitySlider.value = prefs.futureOpacity;
+
+  const scaleSlider = document.getElementById('scale_slider') as HTMLInputElement | null;
+  if (scaleSlider && prefs.scale) scaleSlider.value = prefs.scale;
+
+  // ---- Date slider events --------------------------------------------------
+
+  const dateSlider = document.getElementById('date_slider') as HTMLInputElement | null;
+  if (dateSlider) {
+    dateSlider.addEventListener('input', () => {
+      updateSliderDisplay();
+    });
+    dateSlider.addEventListener('change', () => {
+      renderWithDateFilter();
+      // Re-apply opacity after re-render
+      if (opacitySlider) setBracketFutureOpacity(opacitySlider.value);
+    });
+
+    document.getElementById('date_slider_down')?.addEventListener('click', () => {
+      dateSlider.value = String(Math.max(0, parseInt(dateSlider.value, 10) - 1));
+      updateSliderDisplay();
+      renderWithDateFilter();
+      if (opacitySlider) setBracketFutureOpacity(opacitySlider.value);
+    });
+    document.getElementById('date_slider_up')?.addEventListener('click', () => {
+      dateSlider.value = String(Math.min(
+        parseInt(dateSlider.max, 10), parseInt(dateSlider.value, 10) + 1,
+      ));
+      updateSliderDisplay();
+      renderWithDateFilter();
+      if (opacitySlider) setBracketFutureOpacity(opacitySlider.value);
+    });
+    document.getElementById('date_slider_reset')?.addEventListener('click', () => {
+      if (!currentState) return;
+      dateSlider.value = String(currentState.matchDates.length - 1);
+      updateSliderDisplay();
+      renderWithDateFilter();
+      if (opacitySlider) setBracketFutureOpacity(opacitySlider.value);
+    });
+  }
+
+  // ---- Opacity slider events -----------------------------------------------
+
+  if (opacitySlider) {
+    opacitySlider.addEventListener('input', () => {
+      setBracketFutureOpacity(opacitySlider.value);
+      savePrefs({ futureOpacity: opacitySlider.value });
+    });
+  }
+
+  // ---- Scale slider events -------------------------------------------------
+
+  if (scaleSlider) {
+    scaleSlider.addEventListener('input', () => {
+      setBracketScale(scaleSlider.value);
+      savePrefs({ scale: scaleSlider.value });
+    });
+  }
+
+  // ---- Layout toggle events ------------------------------------------------
+
+  const layoutSel = document.getElementById('layout_toggle') as HTMLSelectElement | null;
+  if (layoutSel) {
+    layoutSel.addEventListener('change', () => {
+      applyLayout();
+    });
+  }
+
+  // ---- Competition/season change events ------------------------------------
+
   competitionSel.addEventListener('change', () => {
     populateSeasonPulldown(seasonMap, competitionSel.value);
     loadAndRender(seasonMap);

--- a/frontend/src/tournament.html
+++ b/frontend/src/tournament.html
@@ -29,6 +29,33 @@
   </label>
 </section>
 
+<section id="bracket_controls">
+  <div id="date_slider_section">
+    <button id="date_slider_down" data-i18n="btn.sliderPrev">＜</button>
+    <input type="range" id="date_slider" min="0" max="0" step="1" value="0"/>
+    <button id="date_slider_up" data-i18n="btn.sliderNext">＞</button>
+    <span id="post_date_slider"></span>
+    <button id="date_slider_reset" data-i18n="btn.resetDate">最新にリセット</button>
+  </div>
+  <label>
+    <span data-i18n="label.futureOpacity">未実施試合透明度</span>
+    <input type="range" id="future_opacity" min="0" max="0.5" step="0.01" value="0.2"/>
+    [<span id="current_opacity">0.2</span>]
+  </label>
+  <label>
+    <span data-i18n="label.graphScale">表示縮小</span>
+    <input type="range" id="scale_slider" min="0.3" max="1" step="0.1" value="1"/>
+    <span id="current_scale">1</span><span data-i18n="label.scaleUnit">倍</span>
+  </label>
+  <label>
+    <span data-i18n="label.bracketLayout">表示方向</span>
+    <select id="layout_toggle">
+      <option value="horizontal" data-i18n="label.layoutHorizontal">横 (左→右)</option>
+      <option value="vertical" data-i18n="label.layoutVertical">縦 (下→上)</option>
+    </select>
+  </label>
+</section>
+
 <div id="status_bar">
   <span id="status_msg"></span>
 </div>


### PR DESCRIPTION
Fixes #141

## Summary
- トーナメントブラケットビューアに4つのインタラクティブコントロールを追加
  - **日付スライダー**: 任意の日付に戻して未実施試合をTBD表示（開幕前対応あり）
  - **透明度スライダー**: TBDチーム行の透明度を調整（日付・スタジアム行は常時表示）
  - **ズームスライダー**: ブラケット全体の縮小表示
  - **レイアウト切替**: 横（左→右）/ 縦（下→上）のCSS切替

## Changes
| Commit | Description |
| --- | --- |
| `8e4e93b` | Add bracket interactivity controls: date slider, opacity, zoom, layout |

## Test plan
- [x] `uv run pytest` passed (78 tests)
- [x] `npx vitest run` passed (401 tests)
- [x] `npm run typecheck` passed
- [x] `npm run build` succeeded
- [x] `uv run python scripts/check_type_sync.py` passed
- [x] ブラウザ目視確認: 日付スライダー・透明度・ズーム・レイアウト切替の動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)