### PR TITLE
Add click-to-pin behavior for bracket tooltips

### DIFF
--- a/frontend/e2e/bracket-tooltip.spec.ts
+++ b/frontend/e2e/bracket-tooltip.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from './helpers/test-base';
+
+/** Wait for bracket to render (status message shows loaded count). */
+async function waitForBracketRender(page: import('@playwright/test').Page): Promise<void> {
+  await page.locator('#status_msg').filter({ hasText: /\d+/ }).waitFor({ timeout: 15000 });
+  // Wait for at least one match card to appear
+  await page.locator('.bracket-match').first().waitFor({ timeout: 5000 });
+}
+
+test.describe('Bracket tooltip pin/unpin', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/tournament.html?competition=JLeagueCup&season=2025');
+    await waitForBracketRender(page);
+  });
+
+  test('click pins tooltip, background click unpins', async ({ page }) => {
+    const card = page.locator('.bracket-match').first();
+    const tooltip = page.locator('.bracket-tooltip');
+
+    // Click card → tooltip pinned
+    await card.click();
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toHaveClass(/pinned/);
+
+    // Click background → tooltip dismissed
+    await page.locator('#bracket_container').click({ position: { x: 0, y: 0 } });
+    await expect(tooltip).toBeHidden();
+  });
+
+  test('click pinned card again unpins', async ({ page }) => {
+    const card = page.locator('.bracket-match').first();
+    const tooltip = page.locator('.bracket-tooltip');
+
+    // Pin
+    await card.click();
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toHaveClass(/pinned/);
+
+    // Click same card again → unpin
+    await card.click();
+    await expect(tooltip).toBeHidden();
+  });
+
+  test('Escape key unpins tooltip', async ({ page }) => {
+    const card = page.locator('.bracket-match').first();
+    const tooltip = page.locator('.bracket-tooltip');
+
+    await card.click();
+    await expect(tooltip).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(tooltip).toBeHidden();
+  });
+
+  test('hover does not switch tooltip while another card is pinned', async ({ page }) => {
+    const cards = page.locator('.bracket-match');
+    const tooltip = page.locator('.bracket-tooltip');
+
+    // Pin first card
+    await cards.first().click();
+    await expect(tooltip).toBeVisible();
+    const pinnedContent = await tooltip.innerHTML();
+
+    // Hover over a different card — tooltip should not change
+    // force: true because the pinned tooltip may overlay the target card
+    const secondCard = cards.nth(1);
+    await secondCard.hover({ force: true });
+    // Small wait to ensure any handler would have fired
+    await page.waitForTimeout(200);
+    await expect(tooltip).toBeVisible();
+    expect(await tooltip.innerHTML()).toBe(pinnedContent);
+  });
+
+  test('date slider change dismisses pinned tooltip', async ({ page }) => {
+    const card = page.locator('.bracket-match').first();
+    const tooltip = page.locator('.bracket-tooltip');
+
+    // Pin
+    await card.click();
+    await expect(tooltip).toBeVisible();
+
+    // Change date slider → re-render → pin dismissed
+    // (tooltip may reappear unpinned if cursor hovers a new card after re-render)
+    const slider = page.locator('#date_slider');
+    const max = Number(await slider.getAttribute('max'));
+    if (max > 0) {
+      await slider.fill(String(max - 1));
+      await slider.dispatchEvent('change');
+      await waitForBracketRender(page);
+      await expect(tooltip).not.toHaveClass(/pinned/);
+    }
+  });
+});

--- a/frontend/src/bracket/bracket-renderer.ts
+++ b/frontend/src/bracket/bracket-renderer.ts
@@ -73,6 +73,8 @@ function formatLegAnnotation(leg: LegDetail): string {
 // ---- Tooltip (shared floating element) ------------------------------------
 
 let tooltipEl: HTMLElement | null = null;
+let pinnedCardId: string | null = null;
+let _globalListenersAttached = false;
 
 function getTooltip(): HTMLElement {
   if (!tooltipEl) {
@@ -81,6 +83,35 @@ function getTooltip(): HTMLElement {
     document.body.appendChild(tooltipEl);
   }
   return tooltipEl;
+}
+
+/** Unpin the tooltip and hide it. Called on re-render and dismissal. */
+export function unpinTooltip(): void {
+  pinnedCardId = null;
+  if (tooltipEl) {
+    tooltipEl.style.display = 'none';
+    tooltipEl.classList.remove('pinned');
+  }
+}
+
+/** Set up document-level listeners for background click and Escape to dismiss pinned tooltip. */
+function setupGlobalListeners(): void {
+  if (_globalListenersAttached) return;
+  _globalListenersAttached = true;
+
+  document.addEventListener('click', (e) => {
+    if (pinnedCardId == null) return;
+    const target = e.target as Element;
+    // Keep tooltip open when clicking on the tooltip itself
+    if (target.closest('.bracket-tooltip')) return;
+    unpinTooltip();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && pinnedCardId != null) {
+      unpinTooltip();
+    }
+  });
 }
 
 /** Build tooltip inner HTML for an H&A aggregate node. */
@@ -135,28 +166,58 @@ function buildSingleTooltip(node: BracketNode): string {
   return lines.join('');
 }
 
-/** Attach tooltip hover events to a match card. */
+/** Show tooltip content for a node, positioned below the card. */
+function showTooltipForCard(card: HTMLElement, node: BracketNode): void {
+  const tip = getTooltip();
+  const isAggregate = node.legs != null && node.legs.length > 0;
+  tip.innerHTML = isAggregate
+    ? buildAggregateTooltip(node)
+    : buildSingleTooltip(node);
+  tip.style.display = 'block';
+
+  const rect = card.getBoundingClientRect();
+  tip.style.left = `${rect.left + window.scrollX}px`;
+  tip.style.top = `${rect.bottom + window.scrollY + 4}px`;
+}
+
+/** Attach tooltip hover/click events to a match card. */
 function attachTooltip(card: HTMLElement, node: BracketNode): void {
   // Only show tooltip for played matches
   if (node.status === 'ＶＳ' && !node.legs) return;
 
-  card.addEventListener('mouseenter', () => {
-    const tip = getTooltip();
-    const isAggregate = node.legs != null && node.legs.length > 0;
-    tip.innerHTML = isAggregate
-      ? buildAggregateTooltip(node)
-      : buildSingleTooltip(node);
-    tip.style.display = 'block';
+  setupGlobalListeners();
+  card.style.cursor = 'pointer';
 
-    // Position below the card
-    const rect = card.getBoundingClientRect();
-    tip.style.left = `${rect.left + window.scrollX}px`;
-    tip.style.top = `${rect.bottom + window.scrollY + 4}px`;
+  card.addEventListener('mouseenter', () => {
+    const cardId = card.getAttribute('data-bracket-id');
+    // Another card is pinned — suppress hover
+    if (pinnedCardId != null && pinnedCardId !== cardId) return;
+    showTooltipForCard(card, node);
   });
 
   card.addEventListener('mouseleave', () => {
+    const cardId = card.getAttribute('data-bracket-id');
+    // This card is pinned — keep tooltip visible
+    if (pinnedCardId === cardId) return;
     const tip = getTooltip();
     tip.style.display = 'none';
+  });
+
+  card.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const cardId = card.getAttribute('data-bracket-id');
+    if (!cardId) return;
+
+    if (pinnedCardId === cardId) {
+      // Click pinned card again → unpin
+      unpinTooltip();
+      return;
+    }
+
+    // Pin this card
+    pinnedCardId = cardId;
+    showTooltipForCard(card, node);
+    getTooltip().classList.add('pinned');
   });
 }
 

--- a/frontend/src/bracket/bracket.css
+++ b/frontend/src/bracket/bracket.css
@@ -176,6 +176,13 @@
   pointer-events: none;
 }
 
+/* Pinned tooltip: interactable and visually highlighted */
+.bracket-tooltip.pinned {
+  pointer-events: auto;
+  border-color: #4a90d9;
+  box-shadow: 0 2px 12px rgba(74, 144, 217, 0.3);
+}
+
 .bracket-tooltip-title {
   font-weight: bold;
   margin-bottom: 6px;

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -12,7 +12,7 @@ import {
   getCompetitionViewTypes,
 } from './config/season-map';
 import { buildBracket } from './bracket/bracket-data';
-import { renderBracket, adjustBracketPositions, drawBracketConnectors } from './bracket/bracket-renderer';
+import { renderBracket, adjustBracketPositions, drawBracketConnectors, unpinTooltip } from './bracket/bracket-renderer';
 import { loadPrefs, savePrefs } from './storage/local-storage';
 import { t, applyI18nAttributes, setLocale } from './i18n';
 import type { Locale } from './i18n';
@@ -472,6 +472,9 @@ function renderWithDateFilter(): void {
   if (!currentState) return;
   const container = document.getElementById('bracket_container');
   if (!container) return;
+
+  // Dismiss any pinned tooltip before re-render (DOM will be replaced)
+  unpinTooltip();
 
   // Multi-section mode: render all sections independently
   if (isMultiSectionMode() && currentState.bracketSections) {


### PR DESCRIPTION
## Summary

ブラケットビューのツールチップにクリック/タップでの固定表示を追加。モバイルでも試合詳細にアクセス可能にする。

Fixes #152

## Changes

| File | Change |
| --- | --- |
| `bracket-renderer.ts` | `pinnedCardId` 状態変数、click/hover/Escape ハンドラ、`unpinTooltip()` エクスポート |
| `bracket.css` | `.bracket-tooltip.pinned` スタイル (pointer-events, 青枠ハイライト) |
| `tournament-app.ts` | 再描画時に `unpinTooltip()` を呼び出し |
| `bracket-tooltip.spec.ts` | E2E テスト 5 件 (pin/unpin/hover 抑制/Escape/再描画解除) |

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npx vitest run` — 406 tests passed
- [x] `npx playwright test` — 68 tests passed (Chromium + WebKit)
- [x] `npm run build` — success
- [x] `uv run pytest` — 78 tests passed
- [x] 手動確認: デスクトップで click pin → hover 抑制 → 背景 click 解除
- [x] 手動確認: モバイル (touch) で tap pin → 背景 tap 解除

🤖 Generated with [Claude Code](https://claude.com/claude-code)