### PR TITLE
Add bracket regression tests (unit + E2E)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,9 @@ uv run python scripts/check_type_sync.py
   - `'pk-win2-loss1'` (2026特別大会): 勝3/PK勝2/PK負1/負0
 - **SeasonEntry バリデーション**: index 0〜3 の型不正は即エラー。index 4 の未知キーは Warning で無視
 - **ルール説明ノート自動生成** (`config/rule-notes.ts`): `pointSystem` が `'standard'` 以外、または `tiebreakOrder` がデフォルト (`['goal_diff', 'goal_get']`) と異なる場合、`resolveSeasonInfo()` が note 配列末尾にルール説明を自動追加。メッセージは辞書オブジェクトで管理し、将来の多言語化に備える (locale 引数 + `Record<Locale, ...>` への拡張で対応可能)
+- **スコアアノテーション規則 (リーグ・トーナメント共通)**: メインスコア (`homeGoal`/`awayGoal`) は常に ET 込みの最終結果。`formatScore` が `(PKn)` / `(ETn)` アノテーションを付加。PK がある場合は PK のみ表示 (ET 後も同点なので ET スコアに情報価値なし)。単試合・H&A aggregate 共通ロジック
+  - **単試合**: CSV の `home_pk_score`/`away_pk_score`/`home_score_ex`/`away_score_ex` をそのままマッピング
+  - **H&A aggregate**: PK → 決定 leg (最終 played leg) の PK スコアを upper/lower にマッピング。ET → 全 leg の ET スコアを upper/lower で合算。合計スコアには ET が含まれるため、ET アノテーションは「合計のうち延長分がいくら」を示す
 - **ツールチップ表示規則**: ボックス内スコアは `ET`/`PK` プレフィックスで種別を明示 (`3-2 (ET1-0)`, `1-1 (PK5-3)`)。PKまで行った場合のET情報は省略 (ET後も同点のためスコアに情報価値なし)。チーム名ツールチップの成績は勝/分/敗を1行、延長勝負・PK勝負を各1行で表示
 - **描画の不変条件 (View Invariants)**: 以下はどの大会・日程・Preference でも必ず維持する。違反時はできる限り原因を調査し、適切な表示ができないことをユーザーに伝える
   - **(I1) バーグラフ高さ一致**: 全チーム列と勝ち点列の高さが等しい (スペースボックスで差を埋める)

--- a/frontend/e2e/bracket-render.spec.ts
+++ b/frontend/e2e/bracket-render.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from './helpers/test-base';
+
+/** Wait for bracket to render (status message shows loaded count). */
+async function waitForBracketRender(page: import('@playwright/test').Page): Promise<void> {
+  await page.locator('#status_msg').filter({ hasText: /\d+/ }).waitFor({ timeout: 15000 });
+  await page.locator('.bracket-match').first().waitFor({ timeout: 5000 });
+}
+
+test.describe('Bracket rendering — connectors and layout', () => {
+  test.beforeEach(async ({ page }) => {
+    // EmperorsCup 2025: simple bracket tree (R16 onward)
+    await page.goto('/tournament.html?competition=EmperorsCup&season=2025');
+    await waitForBracketRender(page);
+  });
+
+  test('SVG polylines are drawn for completed matches', async ({ page }) => {
+    const polylines = page.locator('svg polyline');
+    const count = await polylines.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('no SVG connectors when all matches masked as future', async ({ page }) => {
+    const slider = page.locator('#date_slider');
+    await slider.fill('0');
+    await slider.dispatchEvent('change');
+    await page.locator('.bracket-match').first().waitFor({ timeout: 5000 });
+
+    const polylines = page.locator('svg polyline');
+    const count = await polylines.count();
+    expect(count).toBe(0);
+  });
+
+  test('layout toggle switches to vertical and back', async ({ page }) => {
+    const bracket = page.locator('.bracket').first();
+    const layoutSel = page.locator('#layout_toggle');
+
+    // Default: horizontal
+    await expect(bracket).not.toHaveClass(/vertical/);
+
+    // Switch to vertical via select
+    await layoutSel.selectOption('vertical');
+    await page.locator('.bracket-match').first().waitFor({ timeout: 5000 });
+    const bracketAfter = page.locator('.bracket').first();
+    await expect(bracketAfter).toHaveClass(/vertical/);
+
+    // SVG overlay should still exist
+    const svg = page.locator('#bracket_container svg');
+    await expect(svg).toBeAttached();
+
+    // Switch back to horizontal
+    await layoutSel.selectOption('horizontal');
+    await page.locator('.bracket-match').first().waitFor({ timeout: 5000 });
+    const bracketBack = page.locator('.bracket').first();
+    await expect(bracketBack).not.toHaveClass(/vertical/);
+  });
+
+  test('SVG polyline count preserved after layout toggle', async ({ page }) => {
+    const toggleBtn = page.locator('#layout_toggle');
+    const beforeCount = await page.locator('svg polyline').count();
+
+    await toggleBtn.click();
+    await page.locator('.bracket-match').first().waitFor({ timeout: 5000 });
+
+    const afterCount = await page.locator('svg polyline').count();
+    expect(afterCount).toBe(beforeCount);
+  });
+});
+
+test.describe('Bracket rendering — multi-section @full-render', { tag: '@full-render' }, () => {
+  test('multi-section mode renders separate section containers', async ({ page }) => {
+    // JLeagueCup 2025 has bracket_sections (1回戦, 2回戦, プレーオフ, プライム)
+    await page.goto('/tournament.html?competition=JLeagueCup&season=2025');
+    await waitForBracketRender(page);
+
+    // Switch to multi-section mode
+    const roundSelect = page.locator('#round_start_key');
+    const options = await roundSelect.locator('option').allTextContents();
+    // Multi-section option should exist (typically the last option)
+    const multiOption = options.find(o => o.includes('全セクション') || o.includes('All'));
+    if (multiOption) {
+      await roundSelect.selectOption({ label: multiOption });
+      await page.locator('.bracket-match').first().waitFor({ timeout: 10000 });
+
+      // Multiple bracket sections should be rendered
+      const sections = page.locator('.bracket-section');
+      const sectionCount = await sections.count();
+      expect(sectionCount).toBeGreaterThan(1);
+    }
+  });
+
+  test('single_round sections render as pair-based brackets', async ({ page }) => {
+    await page.goto('/tournament.html?competition=JLeagueCup&season=2025');
+    await waitForBracketRender(page);
+
+    // Switch to multi-section mode
+    const roundSelect = page.locator('#round_start_key');
+    const options = await roundSelect.locator('option').allTextContents();
+    const multiOption = options.find(o => o.includes('全セクション') || o.includes('All'));
+    if (multiOption) {
+      await roundSelect.selectOption({ label: multiOption });
+      await page.locator('.bracket-match').first().waitFor({ timeout: 10000 });
+
+      // single_round sections (1回戦, 2回戦) should render individual match cards
+      // Each section has its own bracket wrapper
+      const brackets = page.locator('.bracket');
+      const bracketCount = await brackets.count();
+      expect(bracketCount).toBeGreaterThan(1);
+    }
+  });
+});

--- a/frontend/src/__tests__/bracket/bracket-renderer.test.ts
+++ b/frontend/src/__tests__/bracket/bracket-renderer.test.ts
@@ -1,0 +1,280 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { renderBracket } from '../../bracket/bracket-renderer';
+import { buildBracket } from '../../bracket/bracket-data';
+import type { RawMatchRow } from '../../types/match';
+import type { BracketNode } from '../../bracket/bracket-types';
+
+function makeRow(overrides: Partial<RawMatchRow>): RawMatchRow {
+  return {
+    match_date: '2024/12/08',
+    section_no: '98',
+    match_index_in_section: '1',
+    start_time: '12:00',
+    stadium: 'Test Stadium',
+    home_team: '',
+    home_goal: '',
+    away_goal: '',
+    away_team: '',
+    status: '試合終了',
+    ...overrides,
+  };
+}
+
+/** Render a bracket tree and return the container element. */
+function renderToElement(root: BracketNode): HTMLElement {
+  const fragment = renderBracket(root, []);
+  const container = document.createElement('div');
+  container.appendChild(fragment);
+  return container;
+}
+
+describe('renderBracket — DOM structure', () => {
+  it('renders a 2-team single match with team rows and scores', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1',
+        match_date: '2024/12/08', round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const el = renderToElement(root);
+
+    // One match card
+    const cards = el.querySelectorAll('.bracket-match');
+    expect(cards).toHaveLength(1);
+
+    // Two team rows
+    const teamRows = cards[0].querySelectorAll('.bracket-team');
+    expect(teamRows).toHaveLength(2);
+
+    // Team names
+    const names = el.querySelectorAll('.bracket-team-name');
+    expect(names[0].textContent).toBe('A');
+    expect(names[1].textContent).toBe('B');
+
+    // Scores
+    const scores = el.querySelectorAll('.bracket-score');
+    expect(scores[0].textContent).toContain('2');
+    expect(scores[1].textContent).toContain('1');
+  });
+
+  it('applies winner/loser classes', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1',
+        round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const el = renderToElement(root);
+
+    const teamRows = el.querySelectorAll('.bracket-team');
+    expect(teamRows[0].classList.contains('winner')).toBe(true);
+    expect(teamRows[1].classList.contains('loser')).toBe(true);
+  });
+
+  it('applies bracket-future class for TBD teams', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1',
+        match_date: '2024/12/01', round: '準決勝',
+      }),
+      makeRow({
+        home_team: 'C', away_team: 'D',
+        home_goal: '', away_goal: '',
+        match_date: '2024/12/15', round: '準決勝', status: 'ＶＳ',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B', 'C', 'D']);
+    const el = renderToElement(root);
+
+    // Final: A vs null (lower SF pending) → away team is TBD
+    // The final has one null team → bracket-future
+    const futureRows = el.querySelectorAll('.bracket-future');
+    expect(futureRows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders H&A aggregate with leg date range', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1',
+        match_date: '2024/12/01', round: '決勝', leg: '1',
+      }),
+      makeRow({
+        home_team: 'B', away_team: 'A',
+        home_goal: '0', away_goal: '1',
+        match_date: '2024/12/08', round: '決勝', leg: '2',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const el = renderToElement(root);
+
+    // Date line should show date range
+    const dateLine = el.querySelector('.bracket-match-date');
+    expect(dateLine).not.toBeNull();
+    expect(dateLine!.textContent).toContain('12/01');
+    expect(dateLine!.textContent).toContain('12/08');
+  });
+
+  it('renders bye leaf with bracket-bye-team class', () => {
+    // 4-team bracket: A has leaf-level bye
+    const rows = [
+      makeRow({
+        home_team: 'C', away_team: 'D',
+        home_goal: '1', away_goal: '0',
+        round: '準決勝',
+      }),
+      makeRow({
+        home_team: 'A', away_team: 'C',
+        home_goal: '2', away_goal: '1',
+        round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', null, 'C', 'D']);
+    const el = renderToElement(root);
+
+    const byeTeams = el.querySelectorAll('.bracket-bye-team');
+    expect(byeTeams.length).toBeGreaterThanOrEqual(1);
+    expect(byeTeams[0].textContent).toBe('A');
+  });
+
+  it('renders ghost cards for multi-level bye chains', () => {
+    // 8-team bracket: A byes through QF and SF (positions [0, null, null, null])
+    const rows = [
+      makeRow({
+        home_team: 'E', away_team: 'F',
+        home_goal: '2', away_goal: '0', round: '準々決勝',
+      }),
+      makeRow({
+        home_team: 'G', away_team: 'H',
+        home_goal: '1', away_goal: '0', round: '準々決勝',
+      }),
+      makeRow({
+        home_team: 'E', away_team: 'G',
+        home_goal: '3', away_goal: '1', round: '準決勝',
+      }),
+      makeRow({
+        home_team: 'A', away_team: 'E',
+        home_goal: '2', away_goal: '1', round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', null, null, null, 'E', 'F', 'G', 'H']);
+    const el = renderToElement(root);
+
+    // Ghost cards for multi-level bye chain (QF + SF levels)
+    const ghosts = el.querySelectorAll('.bracket-ghost');
+    expect(ghosts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders PK annotation in score', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '1', away_goal: '1',
+        home_pk_score: '4', away_pk_score: '2',
+        round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const el = renderToElement(root);
+
+    const pkAnnotations = el.querySelectorAll('.bracket-score-pk');
+    expect(pkAnnotations).toHaveLength(2);
+    expect(pkAnnotations[0].textContent).toBe('(PK4)');
+    expect(pkAnnotations[1].textContent).toBe('(PK2)');
+  });
+
+  it('renders ET annotation in score', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1',
+        home_score_ex: '1', away_score_ex: '0',
+        round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const el = renderToElement(root);
+
+    const etAnnotations = el.querySelectorAll('.bracket-score-pk');
+    expect(etAnnotations).toHaveLength(2);
+    expect(etAnnotations[0].textContent).toBe('(ET1)');
+    expect(etAnnotations[1].textContent).toBe('(ET0)');
+  });
+
+  it('renders aggregate PK annotation for H&A tied on aggregate', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '1', away_goal: '0',
+        match_date: '2024/12/01', round: '決勝', leg: '1',
+      }),
+      makeRow({
+        home_team: 'B', away_team: 'A',
+        home_goal: '1', away_goal: '0',
+        home_pk_score: '4', away_pk_score: '3',
+        home_score_ex: '0', away_score_ex: '0',
+        match_date: '2024/12/08', round: '決勝', leg: '2',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const el = renderToElement(root);
+
+    // Aggregate: A=1, B=1, PK 4-3 for B (home in leg 2)
+    const pkAnnotations = el.querySelectorAll('.bracket-score-pk');
+    expect(pkAnnotations).toHaveLength(2);
+    // B is lower (away in bracket), PK mapped: A(upper)→3, B(lower)→4
+    const texts = Array.from(pkAnnotations).map(e => e.textContent);
+    expect(texts).toContain('(PK3)');
+    expect(texts).toContain('(PK4)');
+  });
+
+  it('renders aggregate ET annotation for H&A with extra time in a leg', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '1', away_goal: '1',
+        match_date: '2024/12/01', round: '決勝', leg: '1',
+      }),
+      makeRow({
+        home_team: 'B', away_team: 'A',
+        home_goal: '3', away_goal: '2',
+        home_score_ex: '1', away_score_ex: '0',
+        match_date: '2024/12/08', round: '決勝', leg: '2',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const el = renderToElement(root);
+
+    // Aggregate: A=1+2=3, B=1+3=4, ET in leg2: B(home)=1, A(away)=0
+    // Mapped to upper/lower: A(upper) ET=0, B(lower) ET=1
+    const etAnnotations = el.querySelectorAll('.bracket-score-pk');
+    expect(etAnnotations).toHaveLength(2);
+    const texts = Array.from(etAnnotations).map(e => e.textContent);
+    expect(texts).toContain('(ET0)');
+    expect(texts).toContain('(ET1)');
+  });
+
+  it('renders single-round pair (2-team minimal bracket)', () => {
+    const rows = [
+      makeRow({
+        home_team: 'X', away_team: 'Y',
+        home_goal: '3', away_goal: '0',
+        round: '1回戦',
+      }),
+    ];
+    const root = buildBracket(rows, ['X', 'Y']);
+    const el = renderToElement(root);
+
+    // Exactly one match card with round label
+    const cards = el.querySelectorAll('.bracket-match');
+    expect(cards).toHaveLength(1);
+    const roundLabel = el.querySelector('.bracket-round-label');
+    expect(roundLabel!.textContent).toBe('1回戦');
+  });
+});

--- a/frontend/src/__tests__/bracket/mask-bracket-for-date.test.ts
+++ b/frontend/src/__tests__/bracket/mask-bracket-for-date.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { buildBracket, maskBracketForDate } from '../../bracket/bracket-data';
+import type { RawMatchRow } from '../../types/match';
+import type { BracketNode } from '../../bracket/bracket-types';
+
+function makeRow(overrides: Partial<RawMatchRow>): RawMatchRow {
+  return {
+    match_date: '2024/12/08',
+    section_no: '98',
+    match_index_in_section: '1',
+    start_time: '12:00',
+    stadium: 'Test Stadium',
+    home_team: '',
+    home_goal: '',
+    away_goal: '',
+    away_team: '',
+    status: '試合終了',
+    ...overrides,
+  };
+}
+
+describe('maskBracketForDate', () => {
+  it('clears scores and winner for future single matches', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1',
+        match_date: '2024/12/15', round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const masked = maskBracketForDate(root, '2024/12/10');
+
+    expect(masked.homeGoal).toBeUndefined();
+    expect(masked.awayGoal).toBeUndefined();
+    expect(masked.winner).toBeNull();
+    expect(masked.decidedBy).toBe('pending');
+    expect(masked.status).toBe('ＶＳ');
+    // Teams preserved
+    expect(masked.homeTeam).toBe('A');
+    expect(masked.awayTeam).toBe('B');
+  });
+
+  it('preserves past matches unchanged', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1',
+        match_date: '2024/12/01', round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const masked = maskBracketForDate(root, '2024/12/10');
+
+    expect(masked.homeGoal).toBe(2);
+    expect(masked.awayGoal).toBe(1);
+    expect(masked.winner).toBe('A');
+    expect(masked.decidedBy).toBe('score');
+  });
+
+  it('clears PK and ET scores for future matches', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '1', away_goal: '1',
+        home_pk_score: '4', away_pk_score: '3',
+        match_date: '2024/12/15', round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const masked = maskBracketForDate(root, '2024/12/10');
+
+    expect(masked.homePkScore).toBeUndefined();
+    expect(masked.awayPkScore).toBeUndefined();
+    expect(masked.homeScoreEx).toBeUndefined();
+    expect(masked.awayScoreEx).toBeUndefined();
+  });
+
+  it('sets child winner teams to TBD (null) when child match is future', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1',
+        match_date: '2024/12/15', round: '準決勝',
+      }),
+      makeRow({
+        home_team: 'C', away_team: 'D',
+        home_goal: '3', away_goal: '0',
+        match_date: '2024/12/15', round: '準決勝',
+      }),
+      makeRow({
+        home_team: 'A', away_team: 'C',
+        home_goal: '1', away_goal: '0',
+        match_date: '2024/12/22', round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B', 'C', 'D']);
+    const masked = maskBracketForDate(root, '2024/12/10');
+
+    // SFs are future → winners unknown
+    expect(masked.children[0]!.winner).toBeNull();
+    expect(masked.children[1]!.winner).toBeNull();
+    // Final teams derived from child winners → null (TBD)
+    expect(masked.homeTeam).toBeNull();
+    expect(masked.awayTeam).toBeNull();
+  });
+
+  it('propagates known SF winner to final when SF is past but final is future', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1',
+        match_date: '2024/12/01', round: '準決勝',
+      }),
+      makeRow({
+        home_team: 'C', away_team: 'D',
+        home_goal: '3', away_goal: '0',
+        match_date: '2024/12/01', round: '準決勝',
+      }),
+      makeRow({
+        home_team: 'A', away_team: 'C',
+        home_goal: '1', away_goal: '0',
+        match_date: '2024/12/22', round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B', 'C', 'D']);
+    const masked = maskBracketForDate(root, '2024/12/10');
+
+    // SFs completed → winners known
+    expect(masked.children[0]!.winner).toBe('A');
+    expect(masked.children[1]!.winner).toBe('C');
+    // Final is future but teams are known from SF winners
+    expect(masked.homeTeam).toBe('A');
+    expect(masked.awayTeam).toBe('C');
+    expect(masked.winner).toBeNull();
+    expect(masked.homeGoal).toBeUndefined();
+  });
+
+  describe('H&A aggregate masking', () => {
+    function buildHABracket(): BracketNode {
+      const rows = [
+        makeRow({
+          home_team: 'A', away_team: 'B',
+          home_goal: '2', away_goal: '1',
+          match_date: '2024/12/01', round: '決勝', leg: '1',
+        }),
+        makeRow({
+          home_team: 'B', away_team: 'A',
+          home_goal: '1', away_goal: '0',
+          match_date: '2024/12/08', round: '決勝', leg: '2',
+        }),
+      ];
+      return buildBracket(rows, ['A', 'B']);
+    }
+
+    it('shows partial aggregate when between legs', () => {
+      const root = buildHABracket();
+      // After leg 1 (12/01) but before leg 2 (12/08)
+      const masked = maskBracketForDate(root, '2024/12/05');
+
+      // Only leg 1 counted: A home=2, away=1 → upper(A)=2, lower(B)=1
+      expect(masked.homeGoal).toBe(2);
+      expect(masked.awayGoal).toBe(1);
+      expect(masked.winner).toBeNull();
+      expect(masked.decidedBy).toBe('pending');
+      expect(masked.status).toBe('ＶＳ');
+    });
+
+    it('clears PK/ET scores in partial aggregate', () => {
+      const root = buildHABracket();
+      const masked = maskBracketForDate(root, '2024/12/05');
+
+      expect(masked.homePkScore).toBeUndefined();
+      expect(masked.awayPkScore).toBeUndefined();
+      expect(masked.homeScoreEx).toBeUndefined();
+      expect(masked.awayScoreEx).toBeUndefined();
+    });
+
+    it('shows full aggregate when all legs are past', () => {
+      const root = buildHABracket();
+      const masked = maskBracketForDate(root, '2024/12/15');
+
+      // Both legs counted: A=2+0=2, B=1+1=2 → tied, no PK → no winner
+      expect(masked.homeGoal).toBe(2);
+      expect(masked.awayGoal).toBe(2);
+    });
+
+    it('hides entire aggregate when all legs are future', () => {
+      const root = buildHABracket();
+      const masked = maskBracketForDate(root, '2024/11/01');
+
+      expect(masked.homeGoal).toBeUndefined();
+      expect(masked.awayGoal).toBeUndefined();
+      expect(masked.winner).toBeNull();
+      expect(masked.legs).toBeUndefined();
+    });
+
+    it('filters legs in partial masking', () => {
+      const root = buildHABracket();
+      const masked = maskBracketForDate(root, '2024/12/05');
+
+      // Only leg 1 should be in the masked legs
+      expect(masked.legs).toHaveLength(1);
+      expect(masked.legs![0].matchDate).toBe('2024/12/01');
+    });
+  });
+});

--- a/frontend/src/bracket/bracket-data.ts
+++ b/frontend/src/bracket/bracket-data.ts
@@ -278,3 +278,85 @@ export function buildBracket(rows: RawMatchRow[], bracketOrder: (string | null)[
   }
   return buildNode(rows, bracketOrder);
 }
+
+/**
+ * Mask a bracket tree for a target date.
+ * - Nodes with matchDate > targetDate: clear scores and winner, keep date/stadium
+ * - Aggregate (H&A) nodes: use earliest leg date; partially mask if between legs
+ * - Nodes whose child winner is unknown: set corresponding team to null (TBD)
+ * Walks bottom-up (children before parent) so winner propagation works correctly.
+ */
+export function maskBracketForDate(node: BracketNode, targetDate: string): BracketNode {
+  // Recurse into children first
+  const [upper, lower] = node.children;
+  const maskedUpper = upper ? maskBracketForDate(upper, targetDate) : null;
+  const maskedLower = lower ? maskBracketForDate(lower, targetDate) : null;
+
+  // Determine effective match date.
+  // Aggregate (H&A) nodes don't have matchDate; derive from earliest leg date.
+  let effectiveDate = node.matchDate;
+  if (!effectiveDate && node.legs) {
+    const legDates = node.legs
+      .map(l => l.matchDate)
+      .filter((d): d is string => d != null)
+      .sort();
+    if (legDates.length > 0) effectiveDate = legDates[0];
+  }
+
+  const isFuture = effectiveDate != null && effectiveDate > targetDate;
+
+  if (isFuture) {
+    // Replace teams with child winners (may be null = TBD)
+    const homeTeam = maskedUpper ? maskedUpper.winner : node.homeTeam;
+    const awayTeam = maskedLower ? maskedLower.winner : node.awayTeam;
+    return {
+      ...node,
+      homeTeam,
+      awayTeam,
+      homeGoal: undefined,
+      awayGoal: undefined,
+      homePkScore: undefined,
+      awayPkScore: undefined,
+      homeScoreEx: undefined,
+      awayScoreEx: undefined,
+      legs: undefined,
+      status: 'ＶＳ',
+      winner: null,
+      decidedBy: 'pending',
+      children: [maskedUpper, maskedLower],
+    };
+  }
+
+  // Partial H&A masking: some legs played, some still in the future.
+  // Show only played legs and recalculate partial aggregate (no winner yet).
+  if (node.legs && node.legs.some(l => l.matchDate != null && l.matchDate > targetDate)) {
+    const playedLegs = node.legs.filter(
+      l => !l.matchDate || l.matchDate <= targetDate,
+    );
+    let upperTotal = 0;
+    let lowerTotal = 0;
+    for (const leg of playedLegs) {
+      if (leg.homeGoal == null || leg.awayGoal == null) continue;
+      const isUpperHome = leg.homeTeam === node.homeTeam;
+      upperTotal += isUpperHome ? leg.homeGoal : leg.awayGoal;
+      lowerTotal += isUpperHome ? leg.awayGoal : leg.homeGoal;
+    }
+    return {
+      ...node,
+      homeGoal: playedLegs.length > 0 ? upperTotal : undefined,
+      awayGoal: playedLegs.length > 0 ? lowerTotal : undefined,
+      homePkScore: undefined,
+      awayPkScore: undefined,
+      homeScoreEx: undefined,
+      awayScoreEx: undefined,
+      winner: null,
+      decidedBy: 'pending',
+      status: 'ＶＳ',
+      legs: playedLegs.length > 0 ? playedLegs : undefined,
+      children: [maskedUpper, maskedLower],
+    };
+  }
+
+  // Not future: keep original data but use masked children
+  return { ...node, children: [maskedUpper, maskedLower] };
+}

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -11,7 +11,7 @@ import {
   loadSeasonMap, getCsvFilename, findCompetition, resolveSeasonInfo,
   getCompetitionViewTypes,
 } from './config/season-map';
-import { buildBracket } from './bracket/bracket-data';
+import { buildBracket, maskBracketForDate } from './bracket/bracket-data';
 import { renderBracket, adjustBracketPositions, drawBracketConnectors, unpinTooltip } from './bracket/bracket-renderer';
 import { loadPrefs, savePrefs } from './storage/local-storage';
 import { t, applyI18nAttributes, setLocale } from './i18n';
@@ -272,88 +272,6 @@ function getTargetDate(): string | null {
   if (!slider) return null;
   const idx = parseInt(slider.value, 10);
   return currentState.matchDates[idx] ?? null;
-}
-
-/**
- * Mask a bracket tree for a target date.
- * - Nodes with matchDate > targetDate: clear scores and winner, keep date/stadium
- * - Aggregate (H&A) nodes: use earliest leg date; partially mask if between legs
- * - Nodes whose child winner is unknown: set corresponding team to null (TBD)
- * Walks bottom-up (children before parent) so winner propagation works correctly.
- */
-function maskBracketForDate(node: BracketNode, targetDate: string): BracketNode {
-  // Recurse into children first
-  const [upper, lower] = node.children;
-  const maskedUpper = upper ? maskBracketForDate(upper, targetDate) : null;
-  const maskedLower = lower ? maskBracketForDate(lower, targetDate) : null;
-
-  // Determine effective match date.
-  // Aggregate (H&A) nodes don't have matchDate; derive from earliest leg date.
-  let effectiveDate = node.matchDate;
-  if (!effectiveDate && node.legs) {
-    const legDates = node.legs
-      .map(l => l.matchDate)
-      .filter((d): d is string => d != null)
-      .sort();
-    if (legDates.length > 0) effectiveDate = legDates[0];
-  }
-
-  const isFuture = effectiveDate != null && effectiveDate > targetDate;
-
-  if (isFuture) {
-    // Replace teams with child winners (may be null = TBD)
-    const homeTeam = maskedUpper ? maskedUpper.winner : node.homeTeam;
-    const awayTeam = maskedLower ? maskedLower.winner : node.awayTeam;
-    return {
-      ...node,
-      homeTeam,
-      awayTeam,
-      homeGoal: undefined,
-      awayGoal: undefined,
-      homePkScore: undefined,
-      awayPkScore: undefined,
-      homeScoreEx: undefined,
-      awayScoreEx: undefined,
-      legs: undefined,
-      status: 'ＶＳ',
-      winner: null,
-      decidedBy: 'pending',
-      children: [maskedUpper, maskedLower],
-    };
-  }
-
-  // Partial H&A masking: some legs played, some still in the future.
-  // Show only played legs and recalculate partial aggregate (no winner yet).
-  if (node.legs && node.legs.some(l => l.matchDate != null && l.matchDate > targetDate)) {
-    const playedLegs = node.legs.filter(
-      l => !l.matchDate || l.matchDate <= targetDate,
-    );
-    let upperTotal = 0;
-    let lowerTotal = 0;
-    for (const leg of playedLegs) {
-      if (leg.homeGoal == null || leg.awayGoal == null) continue;
-      const isUpperHome = leg.homeTeam === node.homeTeam;
-      upperTotal += isUpperHome ? leg.homeGoal : leg.awayGoal;
-      lowerTotal += isUpperHome ? leg.awayGoal : leg.homeGoal;
-    }
-    return {
-      ...node,
-      homeGoal: playedLegs.length > 0 ? upperTotal : undefined,
-      awayGoal: playedLegs.length > 0 ? lowerTotal : undefined,
-      homePkScore: undefined,
-      awayPkScore: undefined,
-      homeScoreEx: undefined,
-      awayScoreEx: undefined,
-      winner: null,
-      decidedBy: 'pending',
-      status: 'ＶＳ',
-      legs: playedLegs.length > 0 ? playedLegs : undefined,
-      children: [maskedUpper, maskedLower],
-    };
-  }
-
-  // Not future: keep original data but use masked children
-  return { ...node, children: [maskedUpper, maskedLower] };
 }
 
 /** Check if the current dropdown selection is multi-section mode. */


### PR DESCRIPTION
## Summary

ブラケットビューの回帰テストを追加。

| ファイル | 変更内容 |
| --- | --- |
| `frontend/src/bracket/bracket-data.ts` | `maskBracketForDate` を `tournament-app.ts` から移動・エクスポート |
| `frontend/src/tournament-app.ts` | ローカル関数削除、インポートに置換 |
| `CLAUDE.md` | スコアアノテーション規則を追記 (#157 由来) |
| `frontend/src/__tests__/bracket/mask-bracket-for-date.test.ts` | 日付マスク Unit テスト 10 件 (新規) |
| `frontend/src/__tests__/bracket/bracket-renderer.test.ts` | DOM 描画 Unit テスト 11 件 (新規, happy-dom) |
| `frontend/e2e/bracket-render.spec.ts` | SVG コネクタ・layout toggle・multi-section E2E 6 件 (新規) |

テスト総数: 既存 406 → **427** (+21 unit) + **6** E2E

## Test plan

- [x] `npx vitest run` — 427 テスト全通過
- [x] `npm run typecheck` — 通過
- [x] `npm run build` — 通過
- [x] `check_type_sync.py` — 通過
- [x] E2E `npx playwright test e2e/bracket-render.spec.ts` — 6 テスト全通過 (chromium)

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)