### PR TITLE
Expand DecidedBy with extra_time, aggregate_score, aggregate_penalties

### DIFF
--- a/frontend/src/__tests__/bracket/bracket-data.test.ts
+++ b/frontend/src/__tests__/bracket/bracket-data.test.ts
@@ -116,7 +116,7 @@ describe('buildBracket', () => {
     ];
     const root = buildBracket(rows, ['A', 'B']);
     expect(root.winner).toBe('A');
-    expect(root.decidedBy).toBe('score');
+    expect(root.decidedBy).toBe('extra_time');
     expect(root.homeGoal).toBe(2);
     expect(root.awayGoal).toBe(1);
     expect(root.homeScoreEx).toBe(1);
@@ -266,7 +266,7 @@ describe('buildBracket — H&A aggregate', () => {
     const root = buildBracket(rows, ['A', 'B']);
     // A total: 2+1=3, B total: 1+0=1
     expect(root.winner).toBe('A');
-    expect(root.decidedBy).toBe('score');
+    expect(root.decidedBy).toBe('aggregate_score');
     expect(root.legs).toHaveLength(2);
   });
 
@@ -287,7 +287,7 @@ describe('buildBracket — H&A aggregate', () => {
     const root = buildBracket(rows, ['A', 'B']);
     // Aggregate: A=1, B=1 (tied) → PK in leg 2: B wins (home=B, 4-3)
     expect(root.winner).toBe('B');
-    expect(root.decidedBy).toBe('penalties');
+    expect(root.decidedBy).toBe('aggregate_penalties');
     expect(root.legs).toHaveLength(2);
   });
 

--- a/frontend/src/bracket/bracket-data.ts
+++ b/frontend/src/bracket/bracket-data.ts
@@ -100,6 +100,8 @@ function nodeFromMatch(
     decidedBy = 'pending';
   } else if (hPk != null && aPk != null) {
     decidedBy = 'penalties';
+  } else if (hEx != null && aEx != null) {
+    decidedBy = 'extra_time';
   } else {
     decidedBy = 'score';
   }
@@ -211,9 +213,9 @@ function nodeFromAggregate(
     decidedBy = 'pending';
   } else if (upperTotal === lowerTotal) {
     // Aggregate tied → winner decided by PK
-    decidedBy = 'penalties';
+    decidedBy = 'aggregate_penalties';
   } else {
-    decidedBy = 'score';
+    decidedBy = 'aggregate_score';
   }
 
   return {

--- a/frontend/src/bracket/bracket-types.ts
+++ b/frontend/src/bracket/bracket-types.ts
@@ -14,7 +14,13 @@ export interface LegDetail {
 }
 
 /** How the winner of a bracket node was decided. */
-export type DecidedBy = 'score' | 'penalties' | 'pending';
+export type DecidedBy =
+  | 'score'             // Single match, regular time
+  | 'extra_time'        // Single match, decided in extra time
+  | 'penalties'         // Single match, decided by PK
+  | 'aggregate_score'   // H&A aggregate, total goals differ
+  | 'aggregate_penalties' // H&A aggregate tied, decided by PK
+  | 'pending';          // Not yet decided
 
 /** A single node in the tournament bracket tree. */
 export interface BracketNode {


### PR DESCRIPTION
Fixes #161

## Summary

- `DecidedBy` 型を3値 → 6値に拡張 (`extra_time`, `aggregate_score`, `aggregate_penalties` 追加)
- `nodeFromMatch`: ET 列検出時に `extra_time` を返すよう分岐追加
- `nodeFromAggregate`: H&A 決着を `aggregate_score` / `aggregate_penalties` で区別
- 既存テストのアサーション値を新しい値に更新

## Changes

| Commit | Description |
| --- | --- |
| `1cec118` | Expand DecidedBy to distinguish ET, aggregate score, and aggregate PK |

## Test plan

- [x] `npx vitest run` passed (frontend/)
- [x] `npm run typecheck` passed (frontend/)
- [x] `npm run build` succeeded (frontend/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)