### PR TITLE
Fix PK/ET annotation color and add tournament notes

### DIFF
--- a/frontend/src/bracket/bracket.css
+++ b/frontend/src/bracket/bracket.css
@@ -139,7 +139,7 @@
 
 .bracket-score-pk {
   font-size: 0.85em;
-  color: #666;
+  color: inherit;
   margin-left: 4px;
 }
 

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -116,6 +116,11 @@ export const en: Record<MessageKey, string> = {
   'note.playoffNote': 'Promotion/Relegation: Playoff qualification is also shown as "Clinched" or "Relegated"',
   'note.otherLeague': 'Does not account for promotion/relegation slots affected by other leagues',
 
+  // Bracket notes
+  'bracketNote.aggregateScore': 'Scores in H&A (home & away) ties are the aggregate of both legs',
+  'bracketNote.etIncluded': 'When extra time (ET) is played, the main score includes extra-time goals',
+  'bracketNote.pkAnnotation': 'Penalty shootout results are shown separately as (PKn)',
+
   // Links
   'link.github': 'GitHub repository',
 

--- a/frontend/src/i18n/messages/ja.ts
+++ b/frontend/src/i18n/messages/ja.ts
@@ -114,6 +114,11 @@ export const ja = {
   'note.playoffNote': '昇格・降格: プレーオフ参戦決定も、それぞれ「確定」「降格」と表示',
   'note.otherLeague': '別リーグの影響で昇格・降格数が減るケースは考慮しない',
 
+  // Bracket notes
+  'bracketNote.aggregateScore': 'H&A (ホーム&アウェー) 方式の得点は2試合の合計です',
+  'bracketNote.etIncluded': '延長戦 (ET) がある場合、メインスコアに延長分が含まれます',
+  'bracketNote.pkAnnotation': 'PK戦の結果は (PKn) として別表示されます',
+
   // Links
   'link.github': 'Github公開場所',
 

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -562,6 +562,22 @@ function loadAndRender(seasonMap: SeasonMap): void {
       applyFutureOpacity();
       applyScale();
 
+      // Update season notes + bracket-specific notes
+      const notesEl = document.getElementById('season_notes');
+      if (notesEl) {
+        notesEl.replaceChildren();
+        const bracketNotes = [
+          t('bracketNote.aggregateScore'),
+          t('bracketNote.etIncluded'),
+          t('bracketNote.pkAnnotation'),
+        ];
+        for (const text of [...seasonInfo.notes, ...bracketNotes]) {
+          const li = document.createElement('li');
+          li.textContent = text;
+          notesEl.appendChild(li);
+        }
+      }
+
       setStatus(t('status.loaded', {
         league: seasonInfo.leagueDisplay, season, rows: results.data.length,
       }));

--- a/frontend/src/tournament.html
+++ b/frontend/src/tournament.html
@@ -66,6 +66,8 @@
 
 <div id="bracket_container"></div>
 
+<ul id="season_notes"></ul>
+
 <hr/>
 <a href="https://github.com/mokekuma-git/JLeague_Matches-Bar_Graph" data-i18n="link.github"></a>
 


### PR DESCRIPTION
Fixes #163

## Summary

- PK/ET アノテーション (例: `(PK5)`) の文字色を `#666` 固定から `inherit` に変更し、濃い背景色のチームでも視認性を確保
- トーナメント表示にリーグ表示と同様の備考欄を追加 (ブラケット下部)
- season_map からカスケードされるノート + ブラケット固有の凡例 (H&A 合計スコア、ET/PK 表記説明) を i18n 対応で表示

## Changes

| Commit | Description |
| ------ | ----------- |
| `e52a181` | Fix PK/ET annotation color and add tournament notes section |

## Test plan

- [x] `npx vitest run` passed (427 tests)
- [x] `npx tsc --noEmit` passed
- [x] `npx vite build` succeeded
- [x] Browser visual check (dark background teams, notes display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)