### PR TITLE
Show aggregate tiebreak reason in bracket view

### DIFF
--- a/frontend/src/__tests__/bracket/bracket-renderer.test.ts
+++ b/frontend/src/__tests__/bracket/bracket-renderer.test.ts
@@ -260,6 +260,52 @@ describe('renderBracket — DOM structure', () => {
     expect(texts).toContain('(ET1)');
   });
 
+  it('renders aggregate away-goals decision note on the card', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '1', away_goal: '0',
+        match_date: '2024/12/01', round: '決勝', leg: '1',
+      }),
+      makeRow({
+        home_team: 'B', away_team: 'A',
+        home_goal: '3', away_goal: '2',
+        match_date: '2024/12/08', round: '決勝', leg: '2',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B'], ['away_goals', 'penalties']);
+    const el = renderToElement(root);
+
+    const decisionLine = el.querySelector('.bracket-match-decision');
+    expect(decisionLine).not.toBeNull();
+    expect(decisionLine!.textContent).toBe('AがAG勝ち上がり');
+  });
+
+  it('renders aggregate decision reason in tooltip', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '1', away_goal: '0',
+        match_date: '2024/12/01', round: '決勝', leg: '1',
+      }),
+      makeRow({
+        home_team: 'B', away_team: 'A',
+        home_goal: '1', away_goal: '0',
+        home_pk_score: '4', away_pk_score: '3',
+        match_date: '2024/12/08', round: '決勝', leg: '2',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B'], ['away_goals', 'penalties']);
+    const el = renderToElement(root);
+
+    const card = el.querySelector('.bracket-match') as HTMLElement;
+    card.dispatchEvent(new Event('mouseenter'));
+
+    const tooltip = document.body.querySelector('.bracket-tooltip');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip!.textContent).toContain('BがPK勝ち上がり');
+  });
+
   it('renders single-round pair (2-team minimal bracket)', () => {
     const rows = [
       makeRow({

--- a/frontend/src/bracket/bracket-renderer.ts
+++ b/frontend/src/bracket/bracket-renderer.ts
@@ -70,6 +70,17 @@ function formatLegAnnotation(leg: LegDetail): string {
   return '';
 }
 
+function aggregateDecisionText(node: BracketNode): string {
+  switch (node.decidedBy) {
+    case 'aggregate_away_goals':
+      return 'AG勝ち上がり';
+    case 'aggregate_penalties':
+      return 'PK勝ち上がり';
+    default:
+      return '';
+  }
+}
+
 // ---- Tooltip (shared floating element) ------------------------------------
 
 let tooltipEl: HTMLElement | null = null;
@@ -138,6 +149,10 @@ function buildAggregateTooltip(node: BracketNode): string {
   const hTotal = node.homeGoal ?? '';
   const aTotal = node.awayGoal ?? '';
   lines.push(`<div class="bracket-tooltip-total">合計: ${upper} ${hTotal}-${aTotal} ${lower}</div>`);
+  const decisionText = aggregateDecisionText(node);
+  if (decisionText && node.winner) {
+    lines.push(`<div class="bracket-tooltip-note">${node.winner}が${decisionText}</div>`);
+  }
 
   return lines.join('');
 }
@@ -307,6 +322,15 @@ function createMatchCard(node: BracketNode, bracketId: number): HTMLElement {
     ? legStadiums(node.legs!)
     : (node.stadium || '\u00A0');
   card.appendChild(stadiumLine);
+
+  // Aggregate decision note — keep a fixed row so card heights stay aligned.
+  const decisionLine = document.createElement('div');
+  decisionLine.classList.add('bracket-match-decision');
+  const decisionText = aggregateDecisionText(node);
+  decisionLine.textContent = (decisionText && node.winner)
+    ? `${node.winner}が${decisionText}`
+    : '\u00A0';
+  card.appendChild(decisionLine);
 
   attachTooltip(card, node);
 

--- a/frontend/src/bracket/bracket.css
+++ b/frontend/src/bracket/bracket.css
@@ -160,6 +160,15 @@
   text-align: center;
 }
 
+.bracket-match-decision {
+  font-size: 0.72em;
+  color: #7a4b00;
+  background: #f8ecd1;
+  padding: 3px 8px;
+  text-align: center;
+  min-height: 1.2em;
+}
+
 /* ---- Tooltip (floating, appended to body) ---- */
 
 .bracket-tooltip {
@@ -210,6 +219,12 @@
   margin-top: 6px;
   padding-top: 4px;
   border-top: 1px solid #ddd;
+  font-weight: bold;
+}
+
+.bracket-tooltip-note {
+  margin-top: 4px;
+  color: #7a4b00;
   font-weight: bold;
 }
 


### PR DESCRIPTION
Refs #176

> このPRは `feature/issue-167-jleaguecup-historical-views` への統合PRです。`main` への統合は親Issue #167 の完了PRで行います。

## Summary
- H&A aggregate が away goals / penalties で決着した場合の勝ち上がり理由を bracket card に表示
- tooltip の合計行にも勝ち上がり理由を追記し、アウェイゴール決着を判別しやすく調整
- aggregate 表示の DOM test を追加

## Changes
| Commit | Description |
|--------|-------------|
| `f0bd28d` | aggregate tiebreak の勝ち上がり理由を UI に表示 |

## Test plan
- [x] `cd frontend && npm test -- --run src/__tests__/bracket/bracket-data.test.ts src/__tests__/bracket/bracket-renderer.test.ts`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)