### PR TITLE
Clarify tournament bracket render flow

### DIFF
--- a/.github/workflows/check-build-artifacts.yaml
+++ b/.github/workflows/check-build-artifacts.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'feature/**'
+      - 'refactor/**'
 
 jobs:
   check:

--- a/.github/workflows/check-type-sync.yaml
+++ b/.github/workflows/check-type-sync.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'feature/**'
+      - 'refactor/**'
     paths:
       - 'src/match_utils.py'
       - 'frontend/src/types/**'

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
       - 'feature/**'
+      - 'refactor/**'
     paths:
       - 'frontend/**'
   push:

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'feature/**'
+      - 'refactor/**'
     paths:
       - 'src/**'
       - 'scripts/**'

--- a/.github/workflows/test-typescript.yaml
+++ b/.github/workflows/test-typescript.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - 'feature/**'
+      - 'refactor/**'
     paths:
       - 'frontend/**'
   push:

--- a/frontend/src/__tests__/tournament/tournament-app.test.ts
+++ b/frontend/src/__tests__/tournament/tournament-app.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { __testables } from '../../tournament-app';
 import type { RawMatchRow } from '../../types/match';
 import type { BracketSection } from '../../types/season';
+import type { BracketNode } from '../../bracket/bracket-types';
 
 function makeRow(overrides: Partial<RawMatchRow> = {}): RawMatchRow {
   const base: RawMatchRow = {
@@ -18,6 +19,19 @@ function makeRow(overrides: Partial<RawMatchRow> = {}): RawMatchRow {
     round: '準決勝 第1戦',
   };
   return { ...base, ...overrides };
+}
+
+function makeNode(overrides: Partial<BracketNode> = {}): BracketNode {
+  return {
+    round: '準決勝',
+    homeTeam: null,
+    awayTeam: null,
+    status: '試合終了',
+    winner: null,
+    decidedBy: null,
+    children: [null, null],
+    ...overrides,
+  };
 }
 
 describe('tournament-app helpers', () => {
@@ -99,5 +113,58 @@ describe('tournament-app helpers', () => {
     ];
     const collected = __testables.collectBracketSourceRows(rows, sections);
     expect(collected).toHaveLength(1);
+  });
+
+  describe('resolveInclusiveBracketOrder', () => {
+    const fullRoot = makeNode({
+      round: '決勝',
+      winner: 'TeamA',
+      children: [
+        makeNode({ round: '準決勝', winner: 'TeamA' }),
+        makeNode({ round: '準決勝', winner: 'TeamC' }),
+      ],
+    });
+
+    test('collapses to winners when a later round is selected', () => {
+      const order = __testables.resolveInclusiveBracketOrder({
+        fullRoot,
+        bracketOrder: ['TeamA', 'TeamB', 'TeamC', 'TeamD'],
+        roundsByDepth: ['決勝', '準決勝'],
+        allRounds: ['準決勝', '決勝'],
+        csvRows: [],
+      }, '決勝');
+
+      expect(order).toEqual(['TeamA', 'TeamC']);
+    });
+
+    test('extends backward when an earlier round is selected', () => {
+      const order = __testables.resolveInclusiveBracketOrder({
+        fullRoot,
+        bracketOrder: ['TeamA', 'TeamB', 'TeamC', 'TeamD'],
+        roundsByDepth: ['決勝', '2回戦'],
+        allRounds: ['1回戦', '2回戦', '決勝'],
+        csvRows: [
+          makeRow({ round: '1回戦', home_team: 'TeamA', away_team: 'TeamX' }),
+          makeRow({ round: '1回戦', home_team: 'TeamC', away_team: 'TeamY' }),
+          makeRow({ round: '1回戦', home_team: 'TeamD', away_team: 'TeamZ' }),
+        ],
+      }, '1回戦');
+
+      expect(order).toEqual(['TeamA', 'TeamX', 'TeamB', null, 'TeamC', 'TeamY', 'TeamD', 'TeamZ']);
+    });
+  });
+
+  describe('shouldRenderMultiSectionView', () => {
+    test('returns true only when multi-section option and sections are both present', () => {
+      expect(__testables.shouldRenderMultiSectionView(
+        [{ label: 'A', bracket_order: ['TeamA', 'TeamB'] }],
+        '__multi_section__',
+      )).toBe(true);
+      expect(__testables.shouldRenderMultiSectionView(
+        [{ label: 'A', bracket_order: ['TeamA', 'TeamB'] }],
+        '準決勝',
+      )).toBe(false);
+      expect(__testables.shouldRenderMultiSectionView(undefined, '__multi_section__')).toBe(false);
+    });
   });
 });

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -46,6 +46,15 @@ interface ControlState {
   roundStart: string | null;
 }
 
+interface SingleBracketRenderInput {
+  rows: RawMatchRow[];
+  order: (string | null)[];
+  aggregateTiebreakOrder: AggregateTiebreakCriterion[];
+  targetDate: string | null;
+  lastDate: string;
+  cssFiles: string[];
+}
+
 const MULTI_SECTION_VALUE = '__multi_section__';
 
 let currentState: BracketState | null = null;
@@ -242,6 +251,8 @@ export const __testables = {
   resolveSectionRoundFilters,
   collectBracketSourceRows,
   collectRoundsFromCsv,
+  resolveInclusiveBracketOrder,
+  shouldRenderMultiSectionView,
 };
 
 /** Collect winners at a given tree depth (in bracket positional order). */
@@ -320,12 +331,13 @@ function populateRoundStartPulldown(
   }
 }
 
-/** Get effective bracket order for the selected start round. */
-function getEffectiveBracketOrder(): (string | null)[] {
-  if (!currentState) return [];
-  const { fullRoot, bracketOrder, roundsByDepth, allRounds, csvRows } = currentState;
-  const selected = controlState.roundStart ?? '';
-
+/** Resolve bracket order for the single-tree ("inclusive") bracket view. */
+function resolveInclusiveBracketOrder(
+  state: Pick<BracketState, 'fullRoot' | 'bracketOrder' | 'roundsByDepth' | 'allRounds' | 'csvRows'>,
+  selectedRoundStart: string | null,
+): (string | null)[] {
+  const { fullRoot, bracketOrder, roundsByDepth, allRounds, csvRows } = state;
+  const selected = selectedRoundStart ?? '';
   const leafRound = roundsByDepth[roundsByDepth.length - 1];
   const leafIdx = allRounds.indexOf(leafRound);
   const selectedIdx = allRounds.indexOf(selected);
@@ -355,9 +367,12 @@ function getTargetDate(): string | null {
   return controlState.selectedDate;
 }
 
-/** Check if the current dropdown selection is multi-section mode. */
-function isMultiSectionMode(): boolean {
-  return controlState.roundStart === MULTI_SECTION_VALUE;
+/** Check whether the selection should render bracket sections independently. */
+function shouldRenderMultiSectionView(
+  bracketSections: BracketSection[] | undefined,
+  roundStart: string | null,
+): boolean {
+  return roundStart === MULTI_SECTION_VALUE && bracketSections != null;
 }
 
 /**
@@ -381,18 +396,40 @@ function renderSingleBracketInto(
  */
 function buildAndRenderBracket(
   container: HTMLElement,
-  rows: RawMatchRow[],
-  order: (string | null)[],
-  aggregateTiebreakOrder: AggregateTiebreakCriterion[],
-  targetDate: string | null,
-  lastDate: string,
-  cssFiles: string[],
+  input: SingleBracketRenderInput,
 ): void {
+  const { rows, order, aggregateTiebreakOrder, targetDate, lastDate, cssFiles } = input;
   if (order.length < 2) return;
   const fullRoot = buildBracket(rows, order, aggregateTiebreakOrder);
   const root = (targetDate && targetDate < lastDate)
     ? maskBracketForDate(fullRoot, targetDate) : fullRoot;
   renderSingleBracketInto(container, root, cssFiles);
+}
+
+function createSingleBracketRenderInput(
+  state: Pick<BracketState, 'csvRows' | 'aggregateTiebreakOrder' | 'matchDates' | 'cssFiles'>,
+  order: (string | null)[],
+): SingleBracketRenderInput | null {
+  if (order.length < 2 || state.matchDates.length === 0) return null;
+  return {
+    rows: state.csvRows,
+    order,
+    aggregateTiebreakOrder: state.aggregateTiebreakOrder,
+    targetDate: getTargetDate(),
+    lastDate: state.matchDates[state.matchDates.length - 1],
+    cssFiles: state.cssFiles,
+  };
+}
+
+function createInclusiveBracketRenderInput(
+  state: Pick<
+  BracketState,
+  'csvRows' | 'aggregateTiebreakOrder' | 'matchDates' | 'cssFiles' |
+  'fullRoot' | 'bracketOrder' | 'roundsByDepth' | 'allRounds'
+  >,
+): SingleBracketRenderInput | null {
+  const order = resolveInclusiveBracketOrder(state, controlState.roundStart);
+  return createSingleBracketRenderInput(state, order);
 }
 
 /**
@@ -425,9 +462,6 @@ function renderMultiSections(): void {
     applyScale();
   });
   container.appendChild(toggleBtn);
-
-  const targetDate = getTargetDate();
-  const lastDate = currentState.matchDates[currentState.matchDates.length - 1];
 
   for (const section of currentState.bracketSections) {
     if (section.bracket_order.length < 2) continue;
@@ -464,18 +498,29 @@ function renderMultiSections(): void {
       for (let i = 0; i < order.length; i += 2) {
         const pair = order.slice(i, i + 2);
         if (pair.every(t => t == null)) continue;
-        buildAndRenderBracket(
-          sectionWrapper, rows, pair, currentState.aggregateTiebreakOrder,
-          targetDate, lastDate, currentState.cssFiles,
+        const input = createSingleBracketRenderInput(
+          { ...currentState, csvRows: rows },
+          pair,
         );
+        if (input) buildAndRenderBracket(sectionWrapper, input);
       }
     } else {
-      buildAndRenderBracket(
-        sectionWrapper, rows, section.bracket_order, currentState.aggregateTiebreakOrder,
-        targetDate, lastDate, currentState.cssFiles,
+      const input = createSingleBracketRenderInput(
+        { ...currentState, csvRows: rows },
+        section.bracket_order,
       );
+      if (input) buildAndRenderBracket(sectionWrapper, input);
     }
   }
+}
+
+/** Render the single-tree ("inclusive") bracket view. */
+function renderInclusiveBracket(container: HTMLElement): void {
+  if (!currentState) return;
+  const input = createInclusiveBracketRenderInput(currentState);
+  if (!input) return;
+  container.replaceChildren();
+  buildAndRenderBracket(container, input);
 }
 
 function renderWithDateFilter(): void {
@@ -486,28 +531,14 @@ function renderWithDateFilter(): void {
   // Dismiss any pinned tooltip before re-render (DOM will be replaced)
   unpinTooltip();
 
-  // Multi-section mode: render all sections independently
-  if (isMultiSectionMode() && currentState.bracketSections) {
+  // Multi-section mode: render each section as its own bracket block.
+  if (shouldRenderMultiSectionView(currentState.bracketSections, controlState.roundStart)) {
     renderMultiSections();
     return;
   }
 
-  // Single bracket mode: use effective bracket order + date mask
-  const effectiveOrder = getEffectiveBracketOrder();
-  if (effectiveOrder.length < 2) return;
-  const fullRoot = buildBracket(
-    currentState.csvRows,
-    effectiveOrder,
-    currentState.aggregateTiebreakOrder,
-  );
-  const targetDate = getTargetDate();
-  const lastDate = currentState.matchDates[currentState.matchDates.length - 1];
-  const root = (targetDate && targetDate < lastDate)
-    ? maskBracketForDate(fullRoot, targetDate)
-    : fullRoot;
-
-  container.replaceChildren();
-  renderSingleBracketInto(container, root, currentState.cssFiles);
+  // Inclusive mode: resolve one effective bracket order, then render it as one tree.
+  renderInclusiveBracket(container);
 }
 
 /** Sync controlState.selectedDate from slider position and update display label. */


### PR DESCRIPTION
Refs #210

> このPRは `refactor/issue-209-tournament-view-refactoring` への統合PRです。`main` への統合は親Issue #209 の完了PRで行います。

## Summary
- Tournament View の描画分岐を multi 表示と包括表示として読み取れるように整理
- 包括表示の bracket order 解決を helper 化し、build -> mask -> render の入口をそろえる構造へ調整
- helper テストを追加し、round start と multi-section 判定の挙動を固定

## Changes
| Commit | Description |
|--------|-------------|
| `3427049` | 描画フローの関数分割と helper テスト追加 |

## Test plan
- [x] `npm test -- tournament-app` passed (`frontend/`)
- [x] `npm run typecheck` passed (`frontend/`)
- [x] `npm run build` succeeded (`frontend/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)