### PR TITLE
Unify date slider state handling across views

### DIFF
--- a/frontend/src/__tests__/core/date-slider.test.ts
+++ b/frontend/src/__tests__/core/date-slider.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, test } from 'vitest';
+import {
+  PRESEASON_SENTINEL,
+  findSliderIndex,
+  formatSliderDate,
+  getLastMatchDate,
+  getSliderDate,
+  resolveTargetDate,
+  syncSliderToTargetDate,
+} from '../../core/date-slider';
+
+describe('date-slider helpers', () => {
+  const DATES = [PRESEASON_SENTINEL, '2026/03/08', '2026/03/15', '2026/03/22'];
+
+  describe('findSliderIndex', () => {
+    test('targetDate before first real match -> 0', () => {
+      expect(findSliderIndex(DATES, '2026/01/01')).toBe(0);
+    });
+
+    test('targetDate between two match dates -> last index <= targetDate', () => {
+      expect(findSliderIndex(DATES, '2026/03/10')).toBe(1);
+    });
+
+    test('targetDate after last match -> last index', () => {
+      expect(findSliderIndex(DATES, '2099/12/31')).toBe(3);
+    });
+  });
+
+  describe('formatSliderDate', () => {
+    test('sentinel -> preseason label', () => {
+      expect(formatSliderDate(PRESEASON_SENTINEL, '2026/03/08')).toBe('開幕前');
+    });
+
+    test('real match date -> targetDate', () => {
+      expect(formatSliderDate('2026/03/08', '2026/03/10')).toBe('2026/03/10');
+    });
+  });
+
+  test('getSliderDate returns null for out-of-range index', () => {
+    expect(getSliderDate(DATES, 99)).toBeNull();
+  });
+
+  test('getLastMatchDate returns null for empty matchDates', () => {
+    expect(getLastMatchDate([])).toBeNull();
+  });
+
+  test('resolveTargetDate falls back to the latest match date', () => {
+    expect(resolveTargetDate(DATES, null)).toBe('2026/03/22');
+  });
+
+  test('syncSliderToTargetDate aligns slider to effective target date', () => {
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    syncSliderToTargetDate(slider, DATES, '2026/03/10');
+    expect(slider.max).toBe('3');
+    expect(slider.value).toBe('1');
+  });
+
+  test('syncSliderToTargetDate uses latest date when targetDate is absent', () => {
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    syncSliderToTargetDate(slider, DATES, undefined);
+    expect(slider.value).toBe('3');
+  });
+});

--- a/frontend/src/__tests__/graph/renderer.test.ts
+++ b/frontend/src/__tests__/graph/renderer.test.ts
@@ -6,8 +6,6 @@ import {
   makePointColumn,
   assembleTeamColumn,
   renderBarGraph,
-  findSliderIndex,
-  formatSliderDate,
 } from '../../graph/renderer';
 import { buildTeamColumn } from '../../graph/bar-column';
 import { calculateTeamStats } from '../../ranking/stats-calculator';
@@ -273,57 +271,5 @@ describe('renderBarGraph', () => {
     // Count point_column occurrences: start + insertions + end ≥ 3
     const count = container.querySelectorAll('.point_column').length;
     expect(count).toBeGreaterThanOrEqual(3);
-  });
-});
-
-// ─── findSliderIndex ─────────────────────────────────────────────────────────
-
-describe('findSliderIndex', () => {
-  // Typical matchDates as returned by renderBarGraph (sentinel + real dates).
-  const DATES = ['1970/01/01', '2026/03/08', '2026/03/15', '2026/03/22'];
-
-  test('targetDate before first real match → 0 (sentinel / 開幕前)', () => {
-    expect(findSliderIndex(DATES, '2026/01/01')).toBe(0);
-  });
-
-  test('targetDate equals sentinel → 0', () => {
-    expect(findSliderIndex(DATES, '1970/01/01')).toBe(0);
-  });
-
-  test('targetDate equals first real match → 1', () => {
-    expect(findSliderIndex(DATES, '2026/03/08')).toBe(1);
-  });
-
-  test('targetDate between two match dates → last index ≤ targetDate', () => {
-    expect(findSliderIndex(DATES, '2026/03/10')).toBe(1); // '2026/03/08' ≤ '2026/03/10' < '2026/03/15'
-  });
-
-  test('targetDate equals last match → last index', () => {
-    expect(findSliderIndex(DATES, '2026/03/22')).toBe(3);
-  });
-
-  test('targetDate after last match → last index', () => {
-    expect(findSliderIndex(DATES, '2099/12/31')).toBe(3);
-  });
-
-  test('single-element array (sentinel only) → 0', () => {
-    expect(findSliderIndex(['1970/01/01'], '2026/03/08')).toBe(0);
-  });
-});
-
-// ─── formatSliderDate ────────────────────────────────────────────────────────
-
-describe('formatSliderDate', () => {
-  test('sentinel 1970/01/01 → 開幕前', () => {
-    expect(formatSliderDate('1970/01/01', '2026/03/08')).toBe('開幕前');
-  });
-
-  test('real match date → targetDate (exact user-requested date)', () => {
-    // Slider snapped to '2026/03/08' but user typed '2026/03/10' → show targetDate.
-    expect(formatSliderDate('2026/03/08', '2026/03/10')).toBe('2026/03/10');
-  });
-
-  test('real match date equals targetDate → that date', () => {
-    expect(formatSliderDate('2026/03/08', '2026/03/08')).toBe('2026/03/08');
   });
 });

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -17,6 +17,9 @@ import {
 } from './config/season-map';
 import { parseCsvResults } from './core/csv-parser';
 import { dateFormat } from './core/date-utils';
+import {
+  getLastMatchDate, getSliderDate, syncSliderToTargetDate,
+} from './core/date-slider';
 import { prepareRenderData } from './core/prepare-render';
 import type { MatchSortKey } from './ranking/stats-calculator';
 import {
@@ -25,7 +28,7 @@ import {
 } from './ranking/rank-table';
 import type { GroupRenderResult } from './ranking/rank-table';
 import { getMaxPointsPerGame } from './core/point-calculator';
-import { renderBarGraph, findSliderIndex } from './graph/renderer';
+import { renderBarGraph } from './graph/renderer';
 import { DEFAULT_HEIGHT_UNIT, getHeightUnit, setFutureOpacity, setSpace, setScale } from './graph/css-utils';
 import { findTeamsWithoutColor } from './graph/css-validator';
 import { teamCssClass } from './core/team-utils';
@@ -241,14 +244,11 @@ function resetDateSlider(matchDates: string[], targetDate: string): void {
   state.currentMatchDates = matchDates;
   const slider = document.getElementById('date_slider') as HTMLInputElement | null;
   if (!slider || matchDates.length === 0) return;
-
-  slider.max = String(matchDates.length - 1);
-
-  const idx = findSliderIndex(matchDates, targetDate);
-  slider.value = String(idx);
+  syncSliderToTargetDate(slider, matchDates, targetDate);
 
   const postEl = document.getElementById('post_date_slider');
-  if (postEl) postEl.textContent = matchDates[matchDates.length - 1] ?? '';
+  const lastDate = getLastMatchDate(matchDates);
+  if (postEl && lastDate) postEl.textContent = lastDate;
 }
 
 // ---- Core render pipeline ----------------------------------------------
@@ -564,7 +564,7 @@ async function main(): Promise<void> {
   const dateSlider = document.getElementById('date_slider') as HTMLInputElement | null;
   if (dateSlider) {
     const updateFromSlider = (): void => {
-      const date = state.currentMatchDates[parseInt(dateSlider.value, 10)];
+      const date = getSliderDate(state.currentMatchDates, parseInt(dateSlider.value, 10));
       if (!date) return;
       (document.getElementById('target_date') as HTMLInputElement).value = date.replace(/\//g, '-');
       loadAndRender(seasonMap);
@@ -574,7 +574,7 @@ async function main(): Promise<void> {
 
     // Show date label in real-time while dragging (no graph redraw)
     dateSlider.addEventListener('input', () => {
-      const date = state.currentMatchDates[parseInt(dateSlider.value, 10)];
+      const date = getSliderDate(state.currentMatchDates, parseInt(dateSlider.value, 10));
       if (!date) return;
       (document.getElementById('target_date') as HTMLInputElement).value = date.replace(/\//g, '-');
     });

--- a/frontend/src/core/date-slider.ts
+++ b/frontend/src/core/date-slider.ts
@@ -1,0 +1,59 @@
+import { t } from '../i18n';
+
+export const PRESEASON_SENTINEL = '1970/01/01';
+
+export function getLastMatchDate(matchDates: string[]): string | null {
+  return matchDates.length > 0 ? matchDates[matchDates.length - 1] : null;
+}
+
+/**
+ * Returns the slider index for a given target date within the matchDates array.
+ *
+ * Finds the last index i where matchDates[i] <= targetDate.
+ * If targetDate is before the first real match (or equals the sentinel '1970/01/01'),
+ * returns 0 (the "開幕前" sentinel position).
+ */
+export function findSliderIndex(matchDates: string[], targetDate: string): number {
+  let idx = matchDates.length - 1;
+  for (let i = 0; i < matchDates.length; i++) {
+    if (matchDates[i] > targetDate) {
+      idx = Math.max(0, i - 1);
+      break;
+    }
+  }
+  return idx;
+}
+
+export function getSliderDate(matchDates: string[], sliderValue: number): string | null {
+  return matchDates[sliderValue] ?? null;
+}
+
+export function resolveTargetDate(
+  matchDates: string[],
+  targetDate: string | null | undefined,
+): string | null {
+  return targetDate ?? getLastMatchDate(matchDates);
+}
+
+export function syncSliderToTargetDate(
+  slider: HTMLInputElement | null,
+  matchDates: string[],
+  targetDate: string | null | undefined,
+): void {
+  if (!slider || matchDates.length === 0) return;
+  slider.max = String(matchDates.length - 1);
+  const effectiveTargetDate = resolveTargetDate(matchDates, targetDate);
+  if (!effectiveTargetDate) return;
+  slider.value = String(findSliderIndex(matchDates, effectiveTargetDate));
+}
+
+/**
+ * Returns the display text for a resolved slider date.
+ *
+ * When sliderDate is the sentinel '1970/01/01', returns '開幕前'.
+ * Otherwise returns targetDate (the exact user-requested date,
+ * which may differ from sliderDate when typed between match days).
+ */
+export function formatSliderDate(sliderDate: string, targetDate: string): string {
+  return sliderDate === PRESEASON_SENTINEL ? t('slider.preseason') : targetDate;
+}

--- a/frontend/src/graph/renderer.ts
+++ b/frontend/src/graph/renderer.ts
@@ -5,6 +5,7 @@
 
 import type { TeamData } from '../types/match';
 import type { SeasonInfo } from '../types/season';
+import { PRESEASON_SENTINEL } from '../core/date-slider';
 import { getPointHeightScale } from '../core/point-calculator';
 import { buildTeamColumn } from './bar-column';
 import type { ColumnResult } from './bar-column';
@@ -180,7 +181,7 @@ export function renderBarGraph(
 
   // Sentinel: slider position 0 always maps to "開幕前" (before season start).
   // '1970/01/01' sorts before any J-League date (1993–), so it will be first after sort.
-  matchDateSet.add('1970/01/01');
+  matchDateSet.add(PRESEASON_SENTINEL);
 
   for (const teamName of sortedTeams) {
     const teamData = groupData[teamName];
@@ -217,35 +218,4 @@ export function renderBarGraph(
   fragment.appendChild(pointColumn.cloneNode(true));
 
   return { fragment, matchDates };
-}
-
-// ---- Slider utilities (pure, exported for testing) ----------------------
-
-/**
- * Returns the slider index for a given target date within the matchDates array.
- *
- * Finds the last index i where matchDates[i] <= targetDate.
- * If targetDate is before the first real match (or equals the sentinel '1970/01/01'),
- * returns 0 (the "開幕前" sentinel position).
- */
-export function findSliderIndex(matchDates: string[], targetDate: string): number {
-  let idx = matchDates.length - 1;
-  for (let i = 0; i < matchDates.length; i++) {
-    if (matchDates[i] > targetDate) {
-      idx = Math.max(0, i - 1);
-      break;
-    }
-  }
-  return idx;
-}
-
-/**
- * Returns the display text for a resolved slider date.
- *
- * When sliderDate is the sentinel '1970/01/01', returns '開幕前'.
- * Otherwise returns targetDate (the exact date the user requested,
- * which may differ from sliderDate when typed between match days).
- */
-export function formatSliderDate(sliderDate: string, targetDate: string): string {
-  return sliderDate === '1970/01/01' ? t('slider.preseason') : targetDate;
 }

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -11,10 +11,17 @@ import {
   loadSeasonMap, getCsvFilename, findCompetition, resolveSeasonInfo,
   getCompetitionViewTypes,
 } from './config/season-map';
+import {
+  PRESEASON_SENTINEL,
+  formatSliderDate,
+  getLastMatchDate,
+  getSliderDate,
+  resolveTargetDate,
+  syncSliderToTargetDate,
+} from './core/date-slider';
 import { buildBracket, maskBracketForDate } from './bracket/bracket-data';
 import { normalizeBracketRoundLabel } from './bracket/round-label';
 import { renderBracket, adjustBracketPositions, drawBracketConnectors, unpinTooltip } from './bracket/bracket-renderer';
-import { findSliderIndex, formatSliderDate } from './graph/renderer';
 import { loadPrefs, savePrefs } from './storage/local-storage';
 import { t, applyI18nAttributes, setLocale } from './i18n';
 import type { Locale } from './i18n';
@@ -42,7 +49,7 @@ interface ControlState {
   layout: 'horizontal' | 'vertical';
   scale: number;
   futureOpacity: number;
-  selectedDate: string | null;
+  targetDate: string | null;
   roundStart: string | null;
 }
 
@@ -63,7 +70,7 @@ let controlState: ControlState = {
   layout: 'horizontal',
   scale: 1,
   futureOpacity: 0.2,
-  selectedDate: null,
+  targetDate: null,
   roundStart: null,
 };
 
@@ -79,8 +86,6 @@ function setStatus(msg: string): void {
 }
 
 // ---- Match date collection --------------------------------------------------
-
-const PRESEASON_SENTINEL = '1970/01/01';
 
 function collectMatchDates(rows: RawMatchRow[]): string[] {
   const dates = new Set<string>();
@@ -364,7 +369,7 @@ function resolveInclusiveBracketOrder(
 // ---- Bracket rendering with date filter ------------------------------------
 
 function getTargetDate(): string | null {
-  return controlState.selectedDate;
+  return controlState.targetDate;
 }
 
 /** Check whether the selection should render bracket sections independently. */
@@ -541,23 +546,19 @@ function renderWithDateFilter(): void {
   renderInclusiveBracket(container);
 }
 
-/** Sync controlState.selectedDate from slider position and update display label. */
-function syncSelectedDateFromSlider(): void {
+/** Sync controlState.targetDate from slider position. */
+function syncTargetDateFromSlider(): void {
   if (!currentState) return;
   const slider = document.getElementById('date_slider') as HTMLInputElement | null;
   if (!slider) return;
-  const idx = parseInt(slider.value, 10);
-  const date = currentState.matchDates[idx];
-  controlState.selectedDate = date ?? null;
+  controlState.targetDate = getSliderDate(currentState.matchDates, parseInt(slider.value, 10));
 }
 
 /** Align slider position to the kept target date without overwriting the target itself. */
-function syncSliderFromSelectedDate(): void {
+function syncSliderFromTargetDate(): void {
   if (!currentState) return;
   const slider = document.getElementById('date_slider') as HTMLInputElement | null;
-  if (!slider || currentState.matchDates.length === 0) return;
-  const targetDate = controlState.selectedDate ?? currentState.matchDates[currentState.matchDates.length - 1];
-  slider.value = String(findSliderIndex(currentState.matchDates, targetDate));
+  syncSliderToTargetDate(slider, currentState.matchDates, controlState.targetDate);
 }
 
 /** Update display label from current slider position + kept target date. */
@@ -566,9 +567,8 @@ function updateSliderDisplay(): void {
   const slider = document.getElementById('date_slider') as HTMLInputElement | null;
   const display = document.getElementById('post_date_slider');
   if (!slider || !display) return;
-  const idx = parseInt(slider.value, 10);
-  const sliderDate = currentState.matchDates[idx] ?? '';
-  const targetDate = controlState.selectedDate ?? sliderDate;
+  const sliderDate = getSliderDate(currentState.matchDates, parseInt(slider.value, 10)) ?? '';
+  const targetDate = resolveTargetDate(currentState.matchDates, controlState.targetDate) ?? sliderDate;
   display.textContent = formatSliderDate(sliderDate, targetDate);
 }
 
@@ -714,15 +714,14 @@ function loadAndRender(seasonMap: SeasonMap): void {
         controlState.roundStart = roundSel.value;
       }
 
-      // Set up date slider and sync controlState.selectedDate
+      // Set up date slider and sync controlState.targetDate
       const slider = document.getElementById('date_slider') as HTMLInputElement | null;
       if (slider && matchDates.length > 0) {
         slider.min = '0';
-        slider.max = String(matchDates.length - 1);
-        if (!controlState.selectedDate) {
-          controlState.selectedDate = matchDates[matchDates.length - 1] ?? null;
+        if (!controlState.targetDate) {
+          controlState.targetDate = getLastMatchDate(matchDates);
         }
-        syncSliderFromSelectedDate();
+        syncSliderFromTargetDate();
       }
 
       renderWithDateFilter();
@@ -782,7 +781,7 @@ async function main(): Promise<void> {
     layout: 'horizontal',
     scale: prefs.scale ? parseFloat(prefs.scale) : 1,
     futureOpacity: prefs.futureOpacity ? parseFloat(prefs.futureOpacity) : 0.2,
-    selectedDate: prefs.targetDate ?? null,
+    targetDate: prefs.targetDate ?? null,
     roundStart: prefs.roundStart ?? null,
   };
 
@@ -828,43 +827,43 @@ async function main(): Promise<void> {
   const dateSlider = document.getElementById('date_slider') as HTMLInputElement | null;
   if (dateSlider) {
     dateSlider.addEventListener('input', () => {
-      syncSelectedDateFromSlider();
+      syncTargetDateFromSlider();
       updateSliderDisplay();
     });
     dateSlider.addEventListener('change', () => {
-      syncSelectedDateFromSlider();
+      syncTargetDateFromSlider();
       updateSliderDisplay();
       renderWithDateFilter();
       applyFutureOpacity();
-      savePrefs({ targetDate: controlState.selectedDate ?? undefined });
+      savePrefs({ targetDate: controlState.targetDate ?? undefined });
     });
 
     document.getElementById('date_slider_down')?.addEventListener('click', () => {
       dateSlider.value = String(Math.max(0, parseInt(dateSlider.value, 10) - 1));
-      syncSelectedDateFromSlider();
+      syncTargetDateFromSlider();
       updateSliderDisplay();
       renderWithDateFilter();
       applyFutureOpacity();
-      savePrefs({ targetDate: controlState.selectedDate ?? undefined });
+      savePrefs({ targetDate: controlState.targetDate ?? undefined });
     });
     document.getElementById('date_slider_up')?.addEventListener('click', () => {
       dateSlider.value = String(Math.min(
         parseInt(dateSlider.max, 10), parseInt(dateSlider.value, 10) + 1,
       ));
-      syncSelectedDateFromSlider();
+      syncTargetDateFromSlider();
       updateSliderDisplay();
       renderWithDateFilter();
       applyFutureOpacity();
-      savePrefs({ targetDate: controlState.selectedDate ?? undefined });
+      savePrefs({ targetDate: controlState.targetDate ?? undefined });
     });
     document.getElementById('date_slider_reset')?.addEventListener('click', () => {
       if (!currentState) return;
-      controlState.selectedDate = currentState.matchDates[currentState.matchDates.length - 1] ?? null;
-      syncSliderFromSelectedDate();
+      controlState.targetDate = getLastMatchDate(currentState.matchDates);
+      syncSliderFromTargetDate();
       updateSliderDisplay();
       renderWithDateFilter();
       applyFutureOpacity();
-      savePrefs({ targetDate: controlState.selectedDate ?? undefined });
+      savePrefs({ targetDate: controlState.targetDate ?? undefined });
     });
   }
 


### PR DESCRIPTION
Refs #214

> このPRは `refactor/issue-209-tournament-view-refactoring` への統合PRです。`main` への統合は親Issue #209 の完了PRで行います。

## Summary
- Tournament View の `selectedDate` を `targetDate` に統一し、date persistence と render cutoff の語彙をそろえました
- `frontend/src/core/date-slider.ts` に slider index / latest fallback / label / DOM 同期 helper を抽出し、League / Tournament で共通利用に寄せました
- slider helper の専用テストを追加し、renderer test から責務を分離しました

## Changes
| Commit | Description |
|--------|-------------|
| `49144f2` | date slider helper を抽出し、League/Tournament の日付 state 同期を共通化 |

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)