### PR TITLE
Refactor bracket_order default resolution for Issue 220

### DIFF
--- a/docs/json/season_map.json
+++ b/docs/json/season_map.json
@@ -644,10 +644,10 @@
         "seasons": {
           "22-23": [2, 0, 0,
             ["浦和", "東京NB"],
-            {"bracket_order": ["浦和", "東京NB"], "bracket_round_start": "決勝"}],
+            {"bracket_round_start": "決勝"}],
           "23-24": [2, 0, 0,
             ["S広島R", "新潟L"],
-            {"bracket_order": ["S広島R", "新潟L"], "bracket_round_start": "決勝"}],
+            {"bracket_round_start": "決勝"}],
           "24-25": [4, 0, 0,
             ["S広島R", "浦和", "I神戸", "新潟L"],
             {"bracket_round_start": "準決勝"}]

--- a/frontend/src/__tests__/tournament/tournament-app.test.ts
+++ b/frontend/src/__tests__/tournament/tournament-app.test.ts
@@ -35,6 +35,62 @@ function makeNode(overrides: Partial<BracketNode> = {}): BracketNode {
 }
 
 describe('tournament-app helpers', () => {
+  describe('resolveSeasonBracketOrder', () => {
+    test('uses explicit options.bracket_order with highest priority', () => {
+      const order = __testables.resolveSeasonBracketOrder([
+        4,
+        0,
+        0,
+        ['LegacyA', 'LegacyB'],
+        {
+          bracket_order: ['ExplicitA', null, 'ExplicitB'],
+          bracket_sections: [{ label: 'S1', bracket_order: ['SectionA', 'SectionB'] }],
+        },
+      ]);
+
+      expect(order).toEqual(['ExplicitA', null, 'ExplicitB']);
+    });
+
+    test('falls back to legacy entry[3] when explicit bracket_order is absent', () => {
+      const order = __testables.resolveSeasonBracketOrder([
+        4,
+        0,
+        0,
+        ['LegacyA', 'LegacyB', 'LegacyC', 'LegacyD'],
+      ]);
+
+      expect(order).toEqual(['LegacyA', 'LegacyB', 'LegacyC', 'LegacyD']);
+    });
+
+    test('derives default global order from bracket_sections when entry[3] is empty', () => {
+      const order = __testables.resolveSeasonBracketOrder([
+        4,
+        0,
+        0,
+        [],
+        {
+          bracket_sections: [
+            { label: 'A', bracket_order: ['A1', 'A2'] },
+            { label: 'B', bracket_order: ['B1', null, 'B2'] },
+          ],
+        },
+      ]);
+
+      expect(order).toEqual(['A1', 'A2', 'B1', null, 'B2']);
+    });
+
+    test('returns undefined when no source bracket order exists', () => {
+      const order = __testables.resolveSeasonBracketOrder([
+        4,
+        0,
+        0,
+        [],
+      ]);
+
+      expect(order).toBeUndefined();
+    });
+  });
+
   describe('createControlStateFromPrefs', () => {
     test('separates viewer-common prefs from bracket-specific prefs', () => {
       const state = __testables.createControlStateFromPrefs({

--- a/frontend/src/bracket/round-filter-inference.ts
+++ b/frontend/src/bracket/round-filter-inference.ts
@@ -64,6 +64,13 @@ export function inferRoundFilter(
   }
 
   // Normal: expected bracket depth K = ceil(log2(leaf positions))
+  // TODO: K can over-estimate for mid-join blocks (e.g. 2011 JLeagueCup where
+  // block winners merge into a shared QF). Possible refinements:
+  //   - Detect bye positions to derive effective pair count
+  //   - Account for seeded-team single-side placement
+  //   - Use section pair count instead of full leaf count
+  // Currently all sections infer correctly without these, but edge cases in
+  // future tournaments may benefit from a more precise K calculation.
   const K = Math.max(1, Math.ceil(Math.log2(bracketOrder.length)));
 
   // bracket_start = first of the chronologically last K rounds

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -6,7 +6,12 @@
 
 import Papa from 'papaparse';
 import type { RawMatchRow } from './types/match';
-import type { SeasonMap, BracketSection, AggregateTiebreakCriterion } from './types/season';
+import type {
+  SeasonMap,
+  BracketSection,
+  AggregateTiebreakCriterion,
+  RawSeasonEntry,
+} from './types/season';
 import {
   loadSeasonMap, getCsvFilename, findCompetition, resolveSeasonInfo,
   getCompetitionViewTypes,
@@ -33,7 +38,7 @@ import type { BracketNode } from './bracket/bracket-types';
 
 interface BracketState {
   csvRows: RawMatchRow[];
-  bracketOrder: string[];
+  bracketOrder: (string | null)[];
   aggregateTiebreakOrder: AggregateTiebreakCriterion[];
   fullRoot: BracketNode;        // full tree built from bracketOrder
   roundsByDepth: string[];      // round labels root-to-leaf (e.g. ['決勝戦','準決勝','準々決勝','ラウンド16'])
@@ -124,6 +129,25 @@ function collectMatchDates(rows: RawMatchRow[]): string[] {
   // Prepend sentinel so slider index 0 = "before any match"
   sorted.unshift(PRESEASON_SENTINEL);
   return sorted;
+}
+
+function resolveSeasonBracketOrder(entry: RawSeasonEntry): (string | null)[] | undefined {
+  const explicitOrder = entry[4]?.bracket_order;
+  if (explicitOrder != null && explicitOrder.length > 0) {
+    return explicitOrder;
+  }
+
+  const legacyOrder = entry[3];
+  if (legacyOrder.length > 0) {
+    return legacyOrder;
+  }
+
+  const sectionOrder = entry[4]?.bracket_sections?.flatMap((section) => section.bracket_order);
+  if (sectionOrder != null && sectionOrder.length > 0) {
+    return sectionOrder;
+  }
+
+  return undefined;
 }
 
 // ---- Dropdown population ---------------------------------------------------
@@ -292,6 +316,7 @@ function collectRoundsFromCsv(rows: RawMatchRow[]): string[] {
 
 export const __testables = {
   createControlStateFromPrefs,
+  resolveSeasonBracketOrder,
   filterRowsByRounds,
   resolveSectionRoundFilters,
   inferMissingSectionRoundFilters,
@@ -676,7 +701,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
     found.group, found.competition, found.competition.seasons[season], found.groupKey,
   );
   const entry = found.competition.seasons[season];
-  const bracketOrder = entry[4]?.bracket_order ?? entry[3];
+  const bracketOrder = resolveSeasonBracketOrder(entry);
   if (!bracketOrder || bracketOrder.length === 0) {
     setStatus('No bracket data for this season.');
     return;

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -71,7 +71,7 @@ export interface SeasonEntryOptions {
   data_source?: DataSource;
   promotion_label?: string;
   aggregate_tiebreak_order?: AggregateTiebreakCriterion[];
-  bracket_order?: string[];
+  bracket_order?: (string | null)[];
   bracket_round_start?: string;
   round_start_options?: string[];
   default_round_filter?: string[];


### PR DESCRIPTION
## 概要
Issue #220 の 3-b として、season 全体 `bracket_order` の省略デフォルト化を進めました。

## 変更内容
| 区分 | 内容 |
| --- | --- |
| resolver | `resolveSeasonBracketOrder()` を追加し、`options.bracket_order > entry[3] > bracket_sections連結` の優先順で解決 |
| 型 | `SeasonEntryOptions.bracket_order` を `(string | null)[]` に拡張 |
| test | 優先順と fallback のユニットテストを追加 |
| season_map | WE Cup KO `22-23` / `23-24` の冗長 `bracket_order` を削除 |

## テスト
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npx vitest run src/__tests__/tournament/tournament-app.test.ts`
- [x] `cd frontend && npm run build`
- [x] `uv run pytest tests/test_match_utils.py`

Refs #220
