### PR TITLE
Cache buildBracket and consolidate render pipeline (Phase 4-d)

### DIFF
--- a/frontend/src/__tests__/bracket/bracket-renderer.test.ts
+++ b/frontend/src/__tests__/bracket/bracket-renderer.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect } from 'vitest';
-import { renderBracket } from '../../bracket/bracket-renderer';
+import { renderBracket, renderBracketInto } from '../../bracket/bracket-renderer';
 import { buildBracket } from '../../bracket/bracket-data';
 import type { RawMatchRow } from '../../types/match';
 import type { BracketNode } from '../../bracket/bracket-types';
@@ -299,5 +299,70 @@ describe('renderBracket — DOM structure', () => {
     expect(cards).toHaveLength(1);
     const roundLabel = el.querySelector('.bracket-round-label');
     expect(roundLabel!.textContent).toBe('1回戦');
+  });
+});
+
+describe('renderBracketInto — pipeline integration', () => {
+  function makeContainer(): HTMLElement {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    return el;
+  }
+
+  it('renders bracket into container with horizontal layout', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1', round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const container = makeContainer();
+
+    renderBracketInto(container, root, [], 'horizontal');
+
+    expect(container.querySelector('.bracket')).not.toBeNull();
+    expect(container.querySelector('.bracket')!.classList.contains('vertical')).toBe(false);
+    expect(container.querySelectorAll('.bracket-match')).toHaveLength(1);
+  });
+
+  it('applies vertical class when layout is vertical', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1', round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B']);
+    const container = makeContainer();
+
+    renderBracketInto(container, root, [], 'vertical');
+
+    expect(container.querySelector('.bracket')!.classList.contains('vertical')).toBe(true);
+  });
+
+  it('creates SVG connector elements for multi-match bracket', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1', round: '準決勝',
+      }),
+      makeRow({
+        home_team: 'C', away_team: 'D',
+        home_goal: '1', away_goal: '0', round: '準決勝',
+      }),
+      makeRow({
+        home_team: 'A', away_team: 'C',
+        home_goal: '3', away_goal: '2', round: '決勝',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B', 'C', 'D']);
+    const container = makeContainer();
+
+    renderBracketInto(container, root, [], 'horizontal');
+
+    // SVG overlay should be created (coordinates are 0 in happy-dom but element exists)
+    const svg = container.querySelector('.bracket-svg');
+    expect(svg).not.toBeNull();
   });
 });

--- a/frontend/src/__tests__/tournament/tournament-app.test.ts
+++ b/frontend/src/__tests__/tournament/tournament-app.test.ts
@@ -302,6 +302,96 @@ describe('tournament-app helpers', () => {
 
       expect(order).toEqual(['TeamA', 'TeamX', 'TeamB', null, 'TeamC', 'TeamY', 'TeamD', 'TeamZ']);
     });
+
+    test('returns original order when same as leaf round', () => {
+      const order = __testables.resolveInclusiveBracketOrder({
+        fullRoot,
+        bracketOrder: ['TeamA', 'TeamB', 'TeamC', 'TeamD'],
+        roundsByDepth: ['決勝', '準決勝'],
+        allRounds: ['準決勝', '決勝'],
+        csvRows: [],
+      }, '準決勝');
+
+      expect(order).toEqual(['TeamA', 'TeamB', 'TeamC', 'TeamD']);
+    });
+
+    test('returns original order for null selectedRoundStart', () => {
+      const order = __testables.resolveInclusiveBracketOrder({
+        fullRoot,
+        bracketOrder: ['TeamA', 'TeamB', 'TeamC', 'TeamD'],
+        roundsByDepth: ['決勝', '準決勝'],
+        allRounds: ['準決勝', '決勝'],
+        csvRows: [],
+      }, null);
+
+      expect(order).toEqual(['TeamA', 'TeamB', 'TeamC', 'TeamD']);
+    });
+
+    test('returns original order for unknown round', () => {
+      const order = __testables.resolveInclusiveBracketOrder({
+        fullRoot,
+        bracketOrder: ['TeamA', 'TeamB', 'TeamC', 'TeamD'],
+        roundsByDepth: ['決勝', '準決勝'],
+        allRounds: ['準決勝', '決勝'],
+        csvRows: [],
+      }, '存在しないラウンド');
+
+      expect(order).toEqual(['TeamA', 'TeamB', 'TeamC', 'TeamD']);
+    });
+
+    test('collapses 3-level tree to final winners', () => {
+      const deepRoot = makeNode({
+        round: '決勝',
+        winner: 'A',
+        children: [
+          makeNode({
+            round: '準決勝',
+            winner: 'A',
+            children: [
+              makeNode({ round: '準々決勝', winner: 'A' }),
+              makeNode({ round: '準々決勝', winner: 'C' }),
+            ],
+          }),
+          makeNode({
+            round: '準決勝',
+            winner: 'E',
+            children: [
+              makeNode({ round: '準々決勝', winner: 'E' }),
+              makeNode({ round: '準々決勝', winner: 'G' }),
+            ],
+          }),
+        ],
+      });
+
+      const order = __testables.resolveInclusiveBracketOrder({
+        fullRoot: deepRoot,
+        bracketOrder: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'],
+        roundsByDepth: ['決勝', '準決勝', '準々決勝'],
+        allRounds: ['準々決勝', '準決勝', '決勝'],
+        csvRows: [],
+      }, '準決勝');
+
+      expect(order).toEqual(['A', 'C', 'E', 'G']);
+    });
+  });
+
+  describe('collectRoundsFromCsv', () => {
+    test('returns unique normalized rounds in chronological order', () => {
+      const rows = [
+        makeRow({ round: '1回戦', match_date: '2024/06/01' }),
+        makeRow({ round: '準決勝 第1戦', match_date: '2024/09/01' }),
+        makeRow({ round: '準決勝 第2戦', match_date: '2024/09/15' }),
+        makeRow({ round: '決勝', match_date: '2024/12/01' }),
+      ];
+      const rounds = __testables.collectRoundsFromCsv(rows);
+      expect(rounds).toEqual(['1回戦', '準決勝', '決勝']);
+    });
+
+    test('returns empty array for rows without round', () => {
+      const rows = [makeRow({ round: undefined })];
+      const rounds = __testables.collectRoundsFromCsv(rows);
+      expect(rounds).toEqual([]);
+    });
   });
 
   describe('shouldRenderMultiSectionView', () => {

--- a/frontend/src/bracket/bracket-renderer.ts
+++ b/frontend/src/bracket/bracket-renderer.ts
@@ -750,3 +750,28 @@ export function renderBracket(root: BracketNode, _cssFiles: string[]): DocumentF
   fragment.appendChild(wrapper);
   return fragment;
 }
+
+/**
+ * Full render pipeline: create DOM, apply layout, adjust positions, draw connectors.
+ * The container must already be in the DOM for getBoundingClientRect to work.
+ *
+ * @param container - DOM element to render bracket into.
+ * @param root - Root BracketNode (the final match).
+ * @param cssFiles - CSS file names for team colors.
+ * @param layout - Bracket layout orientation.
+ */
+export function renderBracketInto(
+  container: HTMLElement,
+  root: BracketNode,
+  cssFiles: string[],
+  layout: 'horizontal' | 'vertical',
+): void {
+  container.appendChild(renderBracket(root, cssFiles));
+  const isVertical = layout === 'vertical';
+  for (const el of Array.from(container.querySelectorAll('.bracket'))) {
+    if (isVertical) el.classList.add('vertical');
+    else el.classList.remove('vertical');
+  }
+  adjustBracketPositions(container);
+  drawBracketConnectors(container);
+}

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -27,7 +27,7 @@ import {
 import { buildBracket, maskBracketForDate } from './bracket/bracket-data';
 import { normalizeBracketRoundLabel } from './bracket/round-label';
 import { inferRoundFilter } from './bracket/round-filter-inference';
-import { renderBracket, adjustBracketPositions, drawBracketConnectors, unpinTooltip } from './bracket/bracket-renderer';
+import { renderBracketInto, unpinTooltip } from './bracket/bracket-renderer';
 import { loadPrefs, savePrefs } from './storage/local-storage';
 import type { ViewerPrefs } from './storage/local-storage';
 import { t, applyI18nAttributes, setLocale } from './i18n';
@@ -80,6 +80,9 @@ interface SingleBracketRenderInput {
 const MULTI_SECTION_VALUE = '__multi_section__';
 
 let currentState: BracketState | null = null;
+
+/** Cache buildBracket results to avoid redundant rebuilds on slider/layout changes. */
+let bracketCache = new Map<string, BracketNode>();
 
 let controlState: ControlState = {
   viewer: {
@@ -447,23 +450,8 @@ function shouldRenderMultiSectionView(
 }
 
 /**
- * Render a single bracket into a container, apply layout, adjust, and draw connectors.
- * The container must already be in the DOM for getBoundingClientRect to work.
- */
-function renderSingleBracketInto(
-  sectionContainer: HTMLElement,
-  root: BracketNode,
-  cssFiles: string[],
-): void {
-  sectionContainer.appendChild(renderBracket(root, cssFiles));
-  applyLayoutTo(sectionContainer);
-  adjustBracketPositions(sectionContainer);
-  drawBracketConnectors(sectionContainer);
-}
-
-/**
  * Build and render a bracket tree (with date mask) into a container.
- * Handles the common build → mask → render pipeline for both normal and single-round modes.
+ * Uses cache to avoid redundant buildBracket calls on slider/layout changes.
  */
 function buildAndRenderBracket(
   container: HTMLElement,
@@ -471,10 +459,15 @@ function buildAndRenderBracket(
 ): void {
   const { rows, order, aggregateTiebreakOrder, targetDate, lastDate, cssFiles } = input;
   if (order.length < 2) return;
-  const fullRoot = buildBracket(rows, order, aggregateTiebreakOrder);
+  const cacheKey = JSON.stringify(order);
+  let fullRoot = bracketCache.get(cacheKey);
+  if (!fullRoot) {
+    fullRoot = buildBracket(rows, order, aggregateTiebreakOrder);
+    bracketCache.set(cacheKey, fullRoot);
+  }
   const root = (targetDate && targetDate < lastDate)
     ? maskBracketForDate(fullRoot, targetDate) : fullRoot;
-  renderSingleBracketInto(container, root, cssFiles);
+  renderBracketInto(container, root, cssFiles, controlState.bracket.layout);
 }
 
 function createSingleBracketRenderInput(
@@ -673,15 +666,6 @@ function applyScale(): void {
   if (display) display.textContent = value;
 }
 
-/** Apply layout class to a specific container's bracket element(s). */
-function applyLayoutTo(container: HTMLElement): void {
-  const isVertical = controlState.bracket.layout === 'vertical';
-  for (const bracket of Array.from(container.querySelectorAll('.bracket'))) {
-    if (isVertical) bracket.classList.add('vertical');
-    else bracket.classList.remove('vertical');
-  }
-}
-
 // ---- Render pipeline -------------------------------------------------------
 
 const CACHE_BUST_WINDOW_SEC = 300;
@@ -736,8 +720,10 @@ function loadAndRender(seasonMap: SeasonMap): void {
       const bracketRows = collectBracketSourceRows(results.data, bracketBlocks);
       const matchDates = collectMatchDates(bracketRows);
 
-      // Build full tree to extract round structure
+      // Build full tree to extract round structure and pre-populate cache
       const fullRoot = buildBracket(bracketRows, bracketOrder, aggregateTiebreakOrder);
+      bracketCache = new Map();
+      bracketCache.set(JSON.stringify(bracketOrder), fullRoot);
       const roundsByDepth = collectRoundsByDepth(fullRoot);
       const bracketRounds = collectBracketRounds(fullRoot);
       const allRounds = bracketBlocks


### PR DESCRIPTION
## Summary

Refs #224

- `buildBracket()` の結果を bracket order でキャッシュし、日付スライダー / レイアウト切替時の不要なツリー再構築を排除
- post-render パイプライン (render → layout → adjust → connectors) を `renderBracketInto()` として bracket-renderer 側に集約し、`tournament-app.ts` から `renderSingleBracketInto` / `applyLayoutTo` を削除
- `resolveInclusiveBracketOrder` のエッジケース (同一ラウンド, null, 不明, 3階層) と `renderBracketInto` パイプラインのユニットテストを追加

## Changes

| ファイル | 変更内容 |
| --- | --- |
| `bracket-renderer.ts` | `renderBracketInto()` 追加 (layout 適用 + adjust + connectors を一括実行) |
| `tournament-app.ts` | `bracketCache` 導入、`renderSingleBracketInto` / `applyLayoutTo` 削除 |
| `tournament-app.test.ts` | `resolveInclusiveBracketOrder` 4ケース + `collectRoundsFromCsv` 2ケース追加 |
| `bracket-renderer.test.ts` | `renderBracketInto` 3ケース追加 (horizontal, vertical, SVG生成) |

## Test plan

- [x] vitest 全通過 (484 tests)
- [x] typecheck 通過
- [x] vite build 成功
- [x] E2E 全通過 (76 tests, chromium + webkit)
- [x] ブラウザ目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)