### PR TITLE
Allow competition defaults and scalar group counts in season_map

### DIFF
--- a/docs/yaml/season_map.yaml
+++ b/docs/yaml/season_map.yaml
@@ -794,24 +794,22 @@ jleague:
     JLeagueCup:
       league_display: Jリーグカップ
       view_type: [bracket]
+      team_count: 8
+      promotion_count: 0
+      relegation_count: 0
       seasons:
         '1992':
           team_count: 4
-          promotion_count: 0
-          relegation_count: 0
           teams: [Ｖ川崎, 鹿島, 清水, 名古屋]
           bracket_round_start: 準決勝
           bracket_blocks:
           - label: 決勝トーナメント
             bracket_order: [Ｖ川崎, 鹿島, 清水, 名古屋]
           shown_groups: [A]
-          group_team_count:
-            A: 10
+          group_team_count: 10
           note: 予選は単一リーグ。
         '1993':
           team_count: 4
-          promotion_count: 0
-          relegation_count: 0
           teams: [Ｖ川崎, 横浜Ｆ, Ｇ大阪, 清水]
           bracket_round_start: 準決勝
           bracket_blocks:
@@ -824,99 +822,63 @@ jleague:
           note: 'Wikipedia group labels: A=Ｖ川崎/Ｇ大阪/鹿島/柏/市原/平塚/広島, B=清水/横浜Ｆ/磐田/名古屋/横浜M/浦和.'
         '1994':
           team_count: 14
-          promotion_count: 0
-          relegation_count: 0
           teams: [Ｖ川崎, 名古屋, 市原, Ｇ大阪, 広島, 鹿島, 浦和, 清水, 柏, 横浜M, 横浜Ｆ, Ｃ大阪, 磐田, 平塚]
           bracket_order: [Ｖ川崎, ~, 名古屋, 市原, Ｇ大阪, 広島, 鹿島, 浦和, 清水, ~, 柏, 横浜M, 横浜Ｆ, Ｃ大阪, 磐田, 平塚]
           bracket_round_start: 1回戦
         '1996':
           team_count: 4
-          promotion_count: 0
-          relegation_count: 0
           teams: [柏, Ｖ川崎, 清水, 平塚]
           bracket_round_start: 準決勝
           bracket_blocks:
           - label: 決勝トーナメント
             bracket_order: [柏, Ｖ川崎, 清水, 平塚]
           shown_groups: [A, B]
-          group_team_count:
-            A: 8
-            B: 8
+          group_team_count: 8
           note: 'Wikipedia group labels: A=柏/平塚/広島/横浜M/磐田/Ｇ大阪/浦和/京都, B=清水/Ｖ川崎/横浜Ｆ/市原/鹿島/Ｃ大阪/名古屋/福岡.'
         '1997':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [市原, 名古屋, 鹿島, 札幌, 磐田, 浦和, 柏, 横浜Ｆ]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
             bracket_order: [市原, 名古屋, 鹿島, 札幌, 磐田, 浦和, 柏, 横浜Ｆ]
           shown_groups: [A, B, C, D, E]
-          group_team_count:
-            A: 4
-            B: 4
-            C: 4
-            D: 4
-            E: 4
+          group_team_count: 4
           note: 'Wikipedia group labels: A=市原/清水/平塚/B仙台, B=札幌/Ｖ川崎/Ｇ大阪/横浜M, C=鹿島/浦和/Ｃ大阪/鳥栖, D=柏/名古屋/広島/神戸, E=横浜Ｆ/磐田/京都/福岡.'
         '1998':
           team_count: 4
-          promotion_count: 0
-          relegation_count: 0
           teams: [清水, 磐田, 市原, 鹿島]
           bracket_round_start: 準決勝
           bracket_blocks:
           - label: 決勝トーナメント
             bracket_order: [清水, 磐田, 市原, 鹿島]
           shown_groups: [A, B, C, D]
-          group_team_count:
-            A: 5
-            B: 5
-            C: 5
-            D: 5
+          group_team_count: 5
           note: 'Wikipedia group labels: A=磐田/浦和/Ｖ川崎/広島/B仙台, B=鹿島/柏/福岡/横浜M/Ｃ大阪, C=清水/川崎Ｆ/Ｇ大阪/横浜Ｆ/札幌, D=市原/名古屋/平塚/神戸/京都.'
         '1999':
           team_count: 26
-          promotion_count: 0
-          relegation_count: 0
           teams: [磐田, 福岡, 札幌, 柏, 新潟, Ｃ大阪, 鳥栖, 清水, 京都, 山形, 名古屋, Ｖ川崎, 甲府, 市原, 神戸, Ｆ東京, 横浜FM, 大宮, 広島, 仙台, 鹿島, Ｇ大阪, 川崎Ｆ, 浦和, 平塚, 大分]
           bracket_order: [磐田, ~, 福岡, 札幌, 柏, 新潟, Ｃ大阪, 鳥栖, 清水, ~, 京都, 山形, 名古屋, ~, Ｖ川崎, 甲府, 市原, ~, 神戸, Ｆ東京, 横浜FM, 大宮, 広島, 仙台, 鹿島, ~, Ｇ大阪, 川崎Ｆ, 浦和, ~, 平塚, 大分]
           bracket_round_start: 1回戦
         '2000':
           team_count: 27
-          promotion_count: 0
-          relegation_count: 0
           teams: [柏, 浦和, 川崎Ｆ, Ｖ川崎, 鳥栖, 仙台, Ｃ大阪, Ｆ東京, 京都, 新潟, 磐田, 札幌, Ｇ大阪, 鹿島, 福岡, 湘南, 広島, 山形, 横浜FM, 甲府, 名古屋, 市原, 大分, 水戸, 清水, 神戸, 大宮]
           bracket_order: [柏, ~, 浦和, 川崎Ｆ, Ｖ川崎, 鳥栖, 仙台, Ｃ大阪, Ｆ東京, ~, 京都, 新潟, 磐田, ~, 札幌, Ｇ大阪, 鹿島, ~, 福岡, 湘南, 広島, 山形, 横浜FM, 甲府, 名古屋, ~, 市原, 大分, 水戸, 清水, 神戸, 大宮]
           bracket_round_start: 1回戦
         '2001':
           team_count: 28
-          promotion_count: 0
-          relegation_count: 0
           teams: [鹿島, 柏, 湘南, 浦和, 山形, Ｇ大阪, 京都, 清水, 市原, 大宮, 札幌, 大分, Ｃ大阪, 磐田, 川崎Ｆ, 東京Ｖ, 横浜FC, 横浜FM, 水戸, 福岡, 仙台, 名古屋, 神戸, 鳥栖, 甲府, Ｆ東京, 広島, 新潟]
           bracket_order: [鹿島, ~, 柏, 湘南, 浦和, 山形, Ｇ大阪, 京都, 清水, ~, 市原, 大宮, 札幌, 大分, Ｃ大阪, 磐田, 川崎Ｆ, ~, 東京Ｖ, 横浜FC, 横浜FM, 水戸, 福岡, 仙台, 名古屋, ~, 神戸, 鳥栖, 甲府, Ｆ東京, 広島, 新潟]
           bracket_round_start: 1回戦
         '2002':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [磐田, 鹿島, 市原, 清水, Ｆ東京, Ｇ大阪, 浦和, 柏]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
             bracket_order: [磐田, 鹿島, 市原, 清水, Ｆ東京, Ｇ大阪, 浦和, 柏]
           shown_groups: [A, B, C, D]
-          group_team_count:
-            A: 4
-            B: 4
-            C: 4
-            D: 4
+          group_team_count: 4
           note: 'Wikipedia group labels: A=磐田/柏/仙台/札幌, B=Ｆ東京/清水/東京Ｖ/神戸, C=市原/Ｇ大阪/横浜FM/京都, D=浦和/鹿島/名古屋/広島.'
         '2003':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [磐田, 横浜FM, 名古屋, 鹿島, Ｆ東京, 浦和, Ｇ大阪, 清水]
           bracket_round_start: 準々決勝
           bracket_blocks:
@@ -930,41 +892,24 @@ jleague:
             D: 3
           note: 'Wikipedia group labels: A=磐田/浦和/東京Ｖ/神戸, B=Ｆ東京/横浜FM/仙台/柏, C=Ｇ大阪/Ｃ大阪/市原, D=名古屋/京都/大分. 鹿島と清水はACL出場のため準々決勝から参加.'
         '2004':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [Ｆ東京, Ｇ大阪, 東京Ｖ, 清水, 名古屋, 鹿島, 浦和, 横浜FM]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
             bracket_order: [Ｆ東京, Ｇ大阪, 東京Ｖ, 清水, 名古屋, 鹿島, 浦和, 横浜FM]
           shown_groups: [A, B, C, D]
-          group_team_count:
-            A: 4
-            B: 4
-            C: 4
-            D: 4
+          group_team_count: 4
           note: 'Wikipedia group labels: A=東京Ｖ/横浜FM/広島/Ｃ大阪, B=名古屋/Ｇ大阪/新潟/磐田, C=浦和/清水/市原/大分, D=Ｆ東京/鹿島/柏/神戸.'
         '2005':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [磐田, 千葉, 浦和, 清水, 横浜FM, 大宮, Ｇ大阪, Ｃ大阪]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
             bracket_order: [磐田, 千葉, 浦和, 清水, 横浜FM, 大宮, Ｇ大阪, Ｃ大阪]
           shown_groups: [A, B, C, D]
-          group_team_count:
-            A: 4
-            B: 4
-            C: 4
-            D: 4
+          group_team_count: 4
           note: 公式トーナメント図で順序確認。ACL出場の磐田、横浜FMは準々決勝から参加.
         '2006':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [磐田, 横浜FM, Ｇ大阪, 鹿島, 千葉, Ｃ大阪, 川崎Ｆ, 浦和]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -979,9 +924,6 @@ jleague:
             D: 5
           note: 公式トーナメント図で順序確認。ACL出場のＧ大阪は準々決勝から参加。GS通過はA1=浦和, A2=横浜FM, B1=川崎Ｆ, B2=鹿島, C1=千葉, D1=Ｃ大阪, D2=磐田.
         '2007':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [Ｇ大阪, 浦和, 川崎Ｆ, 甲府, Ｆ東京, 横浜FM, 鹿島, 広島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -994,16 +936,9 @@ jleague:
             bracket_order: [川崎Ｆ, 横浜FM, 鹿島, Ｇ大阪]
             bracket_round_start: 準決勝
           shown_groups: [A, B, C, D]
-          group_team_count:
-            A: 4
-            B: 4
-            C: 4
-            D: 4
+          group_team_count: 4
           note: 公式トーナメント図で順序確認。ACL出場のＧ大阪、浦和は準々決勝から参加。準決勝は準々決勝後の組み替えに合わせて別セクション化.
         '2008':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [大分, Ｆ東京, 名古屋, 千葉, 横浜FM, Ｇ大阪, 清水, 鹿島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1011,16 +946,9 @@ jleague:
           - label: 決勝トーナメント
             bracket_order: [大分, Ｆ東京, 名古屋, 千葉, 横浜FM, Ｇ大阪, 清水, 鹿島]
           shown_groups: [A, B, C, D]
-          group_team_count:
-            A: 4
-            B: 4
-            C: 4
-            D: 4
+          group_team_count: 4
           note: 公式トーナメント図で順序確認。ACL出場の横浜FM、清水は準々決勝から参加.
         '2009':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [名古屋, Ｆ東京, 清水, 浦和, 横浜FM, Ｇ大阪, 川崎Ｆ, 鹿島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1028,14 +956,9 @@ jleague:
           - label: 決勝トーナメント
             bracket_order: [名古屋, Ｆ東京, 清水, 浦和, 横浜FM, Ｇ大阪, 川崎Ｆ, 鹿島]
           shown_groups: [A, B]
-          group_team_count:
-            A: 7
-            B: 7
+          group_team_count: 7
           note: 公式トーナメント図で順序確認。ACL出場の鹿島、川崎Ｆ、Ｇ大阪、名古屋は準々決勝から参加.
         '2010':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [川崎Ｆ, 鹿島, 仙台, 磐田, Ｇ大阪, 広島, 清水, Ｆ東京]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1043,14 +966,9 @@ jleague:
           - label: 決勝トーナメント
             bracket_order: [川崎Ｆ, 鹿島, 仙台, 磐田, Ｇ大阪, 広島, 清水, Ｆ東京]
           shown_groups: [A, B]
-          group_team_count:
-            A: 7
-            B: 7
+          group_team_count: 7
           note: 公式トーナメント図で順序確認。ACL出場の鹿島、川崎Ｆ、清水、Ｇ大阪は準々決勝から参加.
         '2011':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [Ｃ大阪, 浦和, Ｇ大阪, 磐田, 名古屋, 新潟, 鹿島, 横浜FM]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1068,9 +986,6 @@ jleague:
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2011年は純粋KOで、1回戦・2回戦はH&A、準々決勝以降は単試合。途中合流シードを表すため、準々決勝進出決定ブロックと決勝トーナメントを分離している.
         '2012':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [名古屋, 清水, Ｆ東京, 仙台, 柏, Ｇ大阪, Ｃ大阪, 鹿島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1079,9 +994,6 @@ jleague:
             bracket_order: [名古屋, 清水, Ｆ東京, 仙台, 柏, Ｇ大阪, Ｃ大阪, 鹿島]
           note: 公式トーナメント図で順序確認。準々決勝・準決勝はH&A、決勝は単試合。清水, 仙台, Ｃ大阪, 鹿島はGL上位通過チームのため図中に順位注記あり.
         '2013':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [浦和, Ｃ大阪, 仙台, 川崎Ｆ, 横浜FM, 鹿島, 柏, 広島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1090,9 +1002,6 @@ jleague:
             bracket_order: [浦和, Ｃ大阪, 仙台, 川崎Ｆ, 横浜FM, 鹿島, 柏, 広島]
           note: 公式トーナメント図で順序確認。準々決勝・準決勝はH&A、決勝は単試合.
         '2014':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [浦和, 広島, 柏, 横浜FM, 川崎Ｆ, Ｃ大阪, Ｇ大阪, 神戸]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1101,9 +1010,6 @@ jleague:
             bracket_order: [浦和, 広島, 柏, 横浜FM, 川崎Ｆ, Ｃ大阪, Ｇ大阪, 神戸]
           note: 公式トーナメント図で順序確認。準々決勝・準決勝はH&A、決勝は単試合。浦和, 柏, Ｇ大阪, 神戸は図中にGL順位注記あり.
         '2015':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [鹿島, FC東京, 神戸, 柏, 名古屋, Ｇ大阪, 浦和, 新潟]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1112,9 +1018,6 @@ jleague:
             bracket_order: [鹿島, FC東京, 神戸, 柏, 名古屋, Ｇ大阪, 浦和, 新潟]
           note: 公式トーナメント図で順序確認。2015年もH&Aはアウェイゴール適用。名古屋-Ｇ大阪は2戦合計得点・アウェイゴール数ともに並んだため延長・PK決着。鹿島, 神戸, 名古屋, 新潟は図中にGL順位注記あり.
         '2016':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [横浜FM, 大宮, Ｇ大阪, 広島, 浦和, 神戸, 福岡, FC東京]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1123,9 +1026,6 @@ jleague:
             bracket_order: [横浜FM, 大宮, Ｇ大阪, 広島, 浦和, 神戸, 福岡, FC東京]
           note: 公式トーナメント図で順序確認。準々決勝・準決勝はH&A、決勝は単試合。横浜FM, 大宮, 神戸, 福岡は図中にGL順位注記あり.
         '2017':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [Ｇ大阪, 神戸, 浦和, Ｃ大阪, FC東京, 川崎Ｆ, 鹿島, 仙台]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1138,9 +1038,6 @@ jleague:
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2017年はプレーオフステージ後にノックアウトステージへ進む構造。準々決勝・準決勝はH&A、決勝は単試合。図中注記はACL=Ｇ大阪/浦和/川崎Ｆ/鹿島, A1=仙台, A2=FC東京, A3=札幌, B1=神戸, B2=Ｃ大阪, B3=広島.
         '2018':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [Ｃ大阪, 湘南, 柏, 甲府, 横浜FM, Ｇ大阪, 川崎Ｆ, 鹿島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1153,9 +1050,6 @@ jleague:
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2018年は4組×4GS後に4ペアのプレーオフステージを実施。準々決勝・準決勝はH&A、決勝は単試合。図中注記はACL=Ｃ大阪/柏/川崎Ｆ/鹿島, A1=仙台, A2=横浜FM, B1=磐田, B2=甲府, C1=浦和, C2=Ｇ大阪, D1=神戸, D2=湘南.
         '2019':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [広島, 札幌, FC東京, Ｇ大阪, 鹿島, 浦和, 名古屋, 川崎Ｆ]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1168,9 +1062,6 @@ jleague:
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2019年は4組×4GS後に4ペアのプレーオフステージを実施。準々決勝・準決勝はH&A、決勝は単試合。図中注記はACL=広島/鹿島/川崎Ｆ, A1=札幌, A2=長崎, B1=仙台, B2=FC東京, C1=Ｃ大阪, C2=名古屋, D1=Ｇ大阪, D2=磐田.
         '2020':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [札幌, 横浜FM, Ｃ大阪, 柏, 神戸, 川崎Ｆ, FC東京, 名古屋]
           bracket_round_start: 準々決勝
           bracket_blocks:
@@ -1178,9 +1069,6 @@ jleague:
             bracket_order: [札幌, 横浜FM, Ｃ大阪, 柏, 神戸, 川崎Ｆ, FC東京, 名古屋]
           note: 公式トーナメント図で順序確認。2020年は短縮開催のためプライムステージの準々決勝・準決勝・決勝をすべて単試合で実施。図中注記はC1=札幌, ACL=横浜FM/神戸/FC東京, B1=Ｃ大阪, D1=柏, A1=川崎Ｆ, A2=名古屋.
         '2021':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [FC東京, 札幌, 鹿島, 名古屋, Ｇ大阪, Ｃ大阪, 川崎Ｆ, 浦和]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1193,9 +1081,6 @@ jleague:
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2021年は4組×4GS後に4ペアのプレーオフステージを実施。プライムステージの準々決勝・準決勝はH&A、決勝は単試合。図中注記はA1=鹿島, A2=札幌, B1=FC東京, B2=神戸, C1=浦和, C2=湘南, D1=横浜FM, D2=清水, ACL=名古屋/Ｇ大阪/Ｃ大阪/川崎Ｆ.
         '2022':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [浦和, 名古屋, 川崎Ｆ, Ｃ大阪, 横浜FM, 広島, 福岡, 神戸]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
@@ -1208,9 +1093,6 @@ jleague:
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2022年は4組×4GS後に4ペアのプレーオフステージを実施。プライムステージの準々決勝・準決勝はH&A、決勝は単試合。図中注記はACL=浦和/川崎Ｆ/横浜FM/神戸, A1=鹿島, A2=Ｃ大阪, B1=広島, B2=名古屋, C1=京都, C2=札幌, D1=湘南, D2=福岡.
         '2023':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [鹿島, 名古屋, 福岡, FC東京, 浦和, Ｇ大阪, 横浜FM, 札幌]
           bracket_round_start: 準々決勝
           bracket_blocks:
@@ -1218,9 +1100,6 @@ jleague:
             bracket_order: [鹿島, 名古屋, 福岡, FC東京, 浦和, Ｇ大阪, 横浜FM, 札幌]
           note: 公式トーナメント図で順序確認。2023年は5組×4GS後にプライムステージの準々決勝・準決勝をH&A、決勝を単試合で実施。図中注記はD2=鹿島, C1=名古屋, D1=福岡, E2=FC東京, B1=浦和, E1=Ｇ大阪, A1=横浜FM, A2=札幌.
         '2024':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [新潟, 町田, 川崎Ｆ, 甲府, 名古屋, 広島, 横浜FM, 札幌]
           aggregate_tiebreak_order: [wins, penalties]
           bracket_round_start: 準々決勝
@@ -1252,9 +1131,6 @@ jleague:
             bracket_order: [広島, 名古屋, 札幌, 横浜FM, 甲府, 川崎Ｆ, 町田, 新潟]
           note: 公式トーナメント図と 2024 entry spec で順序確認。2024年は1stラウンド10ブロック、プレーオフラウンド5ペア、プライムラウンドで構成。H&A 判定は勝利数→得失点差→延長→PK を使用する.
         '2025':
-          team_count: 8
-          promotion_count: 0
-          relegation_count: 0
           teams: [横浜FC, 神戸, 湘南, 広島, 浦和, 川崎Ｆ, 横浜FM, 柏]
           aggregate_tiebreak_order: [wins, penalties]
           bracket_round_start: 準々決勝
@@ -1383,8 +1259,7 @@ acl:
           promotion_count: 1
           relegation_count: 0
           teams: []
-          group_team_count:
-            J: 3
+          group_team_count: 3
           cross_group_standing:
             position: 2
             exclude_from_rank: 4

--- a/frontend/src/__tests__/config/season-map.test.ts
+++ b/frontend/src/__tests__/config/season-map.test.ts
@@ -339,6 +339,56 @@ describe('resolveSeasonInfo', () => {
     expect(info.groupTeamCount).toEqual({ B: 4, C: 3, D: 4 });
   });
 
+  test('group_team_count scalar form expands using shown_groups', () => {
+    const comp: CompetitionEntry = {
+      shown_groups: ['A', 'B'],
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = {
+      team_count: 16,
+      promotion_count: 0,
+      relegation_count: 0,
+      teams: [],
+      group_team_count: 4,
+    };
+    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+
+    expect(info.groupTeamCount).toEqual({ A: 4, B: 4 });
+  });
+
+  test('group_team_count scalar form can be overridden by season dict entries', () => {
+    const comp: CompetitionEntry = {
+      shown_groups: ['A', 'B'],
+      group_team_count: 4,
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = {
+      team_count: 16,
+      promotion_count: 0,
+      relegation_count: 0,
+      teams: [],
+      group_team_count: { B: 3 },
+    };
+    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+
+    expect(info.groupTeamCount).toEqual({ A: 4, B: 3 });
+  });
+
+  test('group_team_count scalar form throws without shown_groups', () => {
+    const comp: CompetitionEntry = { seasons: {} };
+    const entry: RawSeasonEntry = {
+      team_count: 16,
+      promotion_count: 0,
+      relegation_count: 0,
+      teams: [],
+      group_team_count: 4,
+    };
+
+    expect(() => resolveSeasonInfo(sampleFamily, comp, entry)).toThrow(
+      'group_team_count scalar form requires index keys to expand',
+    );
+  });
+
   test('cascade: notes append family, competition, season, and generated rule notes', () => {
     const family: CompetitionFamilyEntry = {
       display_name: 'Test',
@@ -404,5 +454,54 @@ describe('resolveSeasonInfo', () => {
     const info = resolveSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.promotionLabel).toBe('W杯本選');
+  });
+
+  test('required count fields can default from competition level', () => {
+    const comp: CompetitionEntry = {
+      league_display: 'JLeagueCup',
+      team_count: 8,
+      promotion_count: 0,
+      relegation_count: 0,
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = { teams: ['A', 'B'] };
+    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+
+    expect(info.teamCount).toBe(8);
+    expect(info.promotionCount).toBe(0);
+    expect(info.relegationCount).toBe(0);
+  });
+
+  test('season count fields override competition defaults', () => {
+    const comp: CompetitionEntry = {
+      league_display: 'J1リーグ',
+      team_count: 18,
+      promotion_count: 2,
+      relegation_count: 2,
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = {
+      team_count: 20,
+      promotion_count: 3,
+      relegation_count: 3,
+      teams: [],
+    };
+    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+
+    expect(info.teamCount).toBe(20);
+    expect(info.promotionCount).toBe(3);
+    expect(info.relegationCount).toBe(3);
+  });
+
+  test('throws when required count fields are missing at both season and competition level', () => {
+    const comp: CompetitionEntry = {
+      league_display: 'Broken',
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = { teams: [] };
+
+    expect(() => resolveSeasonInfo(sampleFamily, comp, entry)).toThrow(
+      'Missing required season_map field: team_count',
+    );
   });
 });

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -67,6 +67,17 @@ function pickCascade<T>(...values: (T | undefined)[]): T | undefined {
   return values.find((value) => value !== undefined);
 }
 
+function requireCascade<T>(
+  label: string,
+  ...values: (T | undefined)[]
+): T {
+  const resolved = pickCascade(...values);
+  if (resolved === undefined) {
+    throw new Error(`Missing required season_map field: ${label}`);
+  }
+  return resolved;
+}
+
 function mergeObjects<T extends Record<string, unknown>>(...values: (T | undefined)[]): T {
   return Object.assign({}, ...values) as T;
 }
@@ -95,6 +106,28 @@ function toArray<T>(value: T | readonly T[] | undefined): T[] {
 
 function hasEntries(value: Record<string, unknown>): boolean {
   return Object.keys(value).length > 0;
+}
+
+/**
+ * Expands a scalar value into a Record using the given index keys.
+ * If the value is already a Record, returns it as-is.
+ * This enables YAML shorthand: `group_team_count: 4` instead of `{A: 4, B: 4, ...}`.
+ */
+function expandScalarDefault<T>(
+  value: T | Record<string, T> | undefined,
+  indexKeys: string[] | undefined,
+  fieldName: string,
+): Record<string, T> | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, T>;
+  }
+  if (!indexKeys || indexKeys.length === 0) {
+    throw new Error(
+      `${fieldName} scalar form requires index keys to expand`,
+    );
+  }
+  return Object.fromEntries(indexKeys.map((key) => [key, value as T]));
 }
 
 /**
@@ -164,9 +197,11 @@ export function resolveSeasonInfo(
   );
 
   // group_team_count currently cascades only competition -> season.
+  const compGroupTeamCount = expandScalarDefault(comp.group_team_count, shownGroups, 'group_team_count');
+  const entryGroupTeamCount = expandScalarDefault(entry.group_team_count, shownGroups, 'group_team_count');
   const groupTeamCountRaw = mergeObjects<Record<string, number>>(
-    comp.group_team_count,
-    entry.group_team_count,
+    compGroupTeamCount,
+    entryGroupTeamCount,
   );
   const groupTeamCount = hasEntries(groupTeamCountRaw) ? groupTeamCountRaw : undefined;
 
@@ -191,11 +226,22 @@ export function resolveSeasonInfo(
   ];
 
   const viewTypes = mergeUniqueArrays(family.view_type, comp.view_type, entry.view_type);
+  const teamCount = requireCascade('team_count', entry.team_count, comp.team_count);
+  const promotionCount = requireCascade(
+    'promotion_count',
+    entry.promotion_count,
+    comp.promotion_count,
+  );
+  const relegationCount = requireCascade(
+    'relegation_count',
+    entry.relegation_count,
+    comp.relegation_count,
+  );
 
   return {
-    teamCount: entry.team_count,
-    promotionCount: entry.promotion_count,
-    relegationCount: entry.relegation_count,
+    teamCount,
+    promotionCount,
+    relegationCount,
     teams: entry.teams,
     rankClass: entry.rank_properties ?? {},
     groupDisplay: entry.group_display,

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -66,7 +66,7 @@ export interface SeasonEntryOptions {
   season_start_month?: number;
   shown_groups?: string[];
   cross_group_standing?: CrossGroupStanding;
-  group_team_count?: Record<string, number>;
+  group_team_count?: number | Record<string, number>;
   note?: string | string[];
   data_source?: DataSource;
   promotion_label?: string;
@@ -83,15 +83,18 @@ export interface SeasonEntryOptions {
 // Object format as loaded from season_map.yaml.
 // Required fields + optional cascade properties (flattened).
 export interface RawSeasonEntry extends SeasonEntryOptions {
-  team_count: number;
-  promotion_count: number;
-  relegation_count: number;
+  team_count?: number;
+  promotion_count?: number;
+  relegation_count?: number;
   teams: string[];
 }
 
 // A single competition within a family (e.g., J1 within jleague).
 // Extends SeasonEntryOptions because cascade allows any option at this level.
 export interface CompetitionEntry extends SeasonEntryOptions {
+  team_count?: number;
+  promotion_count?: number;
+  relegation_count?: number;
   seasons: Record<string, RawSeasonEntry>;
 }
 

--- a/scripts/check_type_sync.py
+++ b/scripts/check_type_sync.py
@@ -117,6 +117,41 @@ def check_season_entry_options() -> list[str]:
     return errors
 
 
+def check_required_count_cascade_fields() -> list[str]:
+    """Check count field optionality/defaultability across Python and TS types."""
+    errors: list[str] = []
+    ts_content = SEASON_TS.read_text(encoding='utf-8')
+    raw_fields = _parse_interface_fields(ts_content, 'RawSeasonEntry')
+    comp_fields = _parse_interface_fields(ts_content, 'CompetitionEntry')
+
+    expected = SeasonEntry.COMPETITION_DEFAULTABLE_KEYS
+
+    missing_in_raw = expected - set(raw_fields.keys())
+    if missing_in_raw:
+        errors.append(
+            f"Competition-defaultable count fields missing in TS RawSeasonEntry: "
+            f"{sorted(missing_in_raw)}")
+
+    raw_required = sorted(key for key in expected if raw_fields.get(key) != 'optional')
+    if raw_required:
+        errors.append(
+            f"TS RawSeasonEntry fields should be optional for competition defaults: "
+            f"{raw_required}")
+
+    missing_in_comp = expected - set(comp_fields.keys())
+    if missing_in_comp:
+        errors.append(
+            f"Competition-defaultable count fields missing in TS CompetitionEntry: "
+            f"{sorted(missing_in_comp)}")
+
+    comp_required = sorted(key for key in expected if comp_fields.get(key) != 'optional')
+    if comp_required:
+        errors.append(
+            f"TS CompetitionEntry fields should be optional: {comp_required}")
+
+    return errors
+
+
 def check_point_system_values() -> list[str]:
     """Check POINT_SYSTEM_VALUES against POINT_MAPS keys."""
     errors: list[str] = []
@@ -172,6 +207,7 @@ def main() -> int:
     checks = [
         ('CSV columns', check_csv_columns),
         ('SeasonEntryOptions', check_season_entry_options),
+        ('count cascade fields', check_required_count_cascade_fields),
         ('PointSystem values', check_point_system_values),
         ('view_type consistency', check_view_type_consistency),
     ]

--- a/src/match_utils.py
+++ b/src/match_utils.py
@@ -114,8 +114,10 @@ class SeasonEntry:
         }
     """
 
-    REQUIRED_KEYS: set[str] = {
-        'team_count', 'promotion_count', 'relegation_count', 'teams',
+    REQUIRED_KEYS: set[str] = {'teams'}
+
+    COMPETITION_DEFAULTABLE_KEYS: set[str] = {
+        'team_count', 'promotion_count', 'relegation_count',
     }
 
     OPTIONAL_KEYS: set[str] = {
@@ -131,14 +133,20 @@ class SeasonEntry:
         'view_type',
     }
 
-    KNOWN_KEYS: set[str] = REQUIRED_KEYS | OPTIONAL_KEYS
+    KNOWN_KEYS: set[str] = REQUIRED_KEYS | COMPETITION_DEFAULTABLE_KEYS | OPTIONAL_KEYS
 
-    def __init__(self, season_key: str, raw: dict):
+    def __init__(
+            self,
+            season_key: str,
+            raw: dict,
+            competition_defaults: dict[str, Any] | None = None):
         """Parse and validate a raw season entry object.
 
         Args:
             season_key: Season name (for error messages, e.g. '2026East').
             raw: Raw object from season_map.yaml.
+            competition_defaults:
+                Optional competition-level fallback values for required counts.
 
         Raises:
             ValueError: If required keys are missing.
@@ -148,28 +156,60 @@ class SeasonEntry:
             raise TypeError(
                 f"Season '{season_key}': expected dict, got {type(raw).__name__}")
 
+        competition_defaults = competition_defaults or {}
+
         missing = self.REQUIRED_KEYS - set(raw.keys())
         if missing:
             raise ValueError(
                 f"Season '{season_key}': missing required keys: {missing}")
 
-        for key in ('team_count', 'promotion_count', 'relegation_count'):
-            if not isinstance(raw[key], int):
+        missing_counts = {
+            key for key in self.COMPETITION_DEFAULTABLE_KEYS
+            if key not in raw and key not in competition_defaults
+        }
+        if missing_counts:
+            raise ValueError(
+                f"Season '{season_key}': missing required keys after competition fallback: "
+                f"{missing_counts}")
+
+        resolved_counts = {}
+        for key in self.COMPETITION_DEFAULTABLE_KEYS:
+            value = raw.get(key, competition_defaults.get(key))
+            if not isinstance(value, int):
                 raise TypeError(
                     f"Season '{season_key}': {key} must be int, "
-                    f"got {type(raw[key]).__name__}")
+                    f"got {type(value).__name__}")
+            resolved_counts[key] = value
 
         if not isinstance(raw['teams'], list):
             raise TypeError(
                 f"Season '{season_key}': teams must be list, "
                 f"got {type(raw['teams']).__name__}")
 
-        self.team_count: int = raw['team_count']
-        self.promotion_count: int = raw['promotion_count']
-        self.relegation_count: int = raw['relegation_count']
+        group_team_count = raw.get('group_team_count')
+        if group_team_count is not None:
+            if isinstance(group_team_count, int):
+                pass
+            elif isinstance(group_team_count, dict):
+                invalid = [
+                    key for key, value in group_team_count.items()
+                    if not isinstance(key, str) or not isinstance(value, int)
+                ]
+                if invalid:
+                    raise TypeError(
+                        f"Season '{season_key}': group_team_count dict must be str -> int")
+            else:
+                raise TypeError(
+                    f"Season '{season_key}': group_team_count must be int or dict, "
+                    f"got {type(group_team_count).__name__}")
+
+        self.team_count: int = resolved_counts['team_count']
+        self.promotion_count: int = resolved_counts['promotion_count']
+        self.relegation_count: int = resolved_counts['relegation_count']
         self.teams: list[str] = raw['teams']
         self.options: dict[str, Any] = {
-            k: v for k, v in raw.items() if k not in self.REQUIRED_KEYS
+            k: v for k, v in raw.items()
+            if k not in self.REQUIRED_KEYS | self.COMPETITION_DEFAULTABLE_KEYS
         }
 
         unknown = set(self.options.keys()) - self.OPTIONAL_KEYS
@@ -238,10 +278,19 @@ class MatchUtils:
         family = raw.get(family_key, {}).get('competitions', {})
         return {
             comp_key: {
-                sk: SeasonEntry(sk, entry)
+                sk: SeasonEntry(sk, entry, self._get_competition_count_defaults(comp))
                 for sk, entry in comp.get('seasons', {}).items()
             }
             for comp_key, comp in family.items()
+        }
+
+    @staticmethod
+    def _get_competition_count_defaults(comp: dict[str, Any]) -> dict[str, Any]:
+        """Extract count defaults that may cascade from competition to season."""
+        return {
+            key: comp.get(key)
+            for key in SeasonEntry.COMPETITION_DEFAULTABLE_KEYS
+            if key in comp
         }
 
     def get_sub_seasons(self, competition: str, family_key: str = None) -> list[dict] | None:
@@ -351,9 +400,10 @@ class MatchUtils:
         season_str = str(self.config.season)
         for comp in family.get('competitions', {}).values():
             comp_val = comp.get('season_start_month', family_val)
+            comp_defaults = self._get_competition_count_defaults(comp)
             for sk, raw_entry in comp.get('seasons', {}).items():
                 if sk.startswith(season_str):
-                    entry = SeasonEntry(sk, raw_entry)
+                    entry = SeasonEntry(sk, raw_entry, comp_defaults)
                     return entry.options.get('season_start_month', comp_val)
         return family_val
 

--- a/tests/test_2026_special_season.py
+++ b/tests/test_2026_special_season.py
@@ -14,7 +14,7 @@ import pandas as pd
 import yaml
 from bs4 import BeautifulSoup
 
-from match_utils import mu, get_season_from_date
+from match_utils import SeasonEntry, mu, get_season_from_date
 from read_jleague_matches import (
     read_match_from_web,
     _team_count_to_section_range,
@@ -228,6 +228,71 @@ class TestGetSubSeasons(unittest.TestCase):
             self.assertEqual(s['url_category'], 'j2j3')
         displays = [s['group_display'] for s in subs]
         self.assertEqual(displays, ['EAST-A', 'EAST-B', 'WEST-A', 'WEST-B'])
+
+
+class TestSeasonEntryCompetitionDefaults(unittest.TestCase):
+    """Test SeasonEntry resolves required counts from competition defaults."""
+
+    def test_uses_competition_defaults_for_missing_counts(self):
+        entry = SeasonEntry(
+            '2025',
+            {'teams': ['A', 'B']},
+            {'team_count': 8, 'promotion_count': 0, 'relegation_count': 0},
+        )
+
+        self.assertEqual(entry.team_count, 8)
+        self.assertEqual(entry.promotion_count, 0)
+        self.assertEqual(entry.relegation_count, 0)
+        self.assertEqual(entry.teams, ['A', 'B'])
+
+    def test_season_values_override_competition_defaults(self):
+        entry = SeasonEntry(
+            '2025',
+            {
+                'team_count': 10,
+                'promotion_count': 1,
+                'relegation_count': 1,
+                'teams': ['A', 'B'],
+            },
+            {'team_count': 8, 'promotion_count': 0, 'relegation_count': 0},
+        )
+
+        self.assertEqual(entry.team_count, 10)
+        self.assertEqual(entry.promotion_count, 1)
+        self.assertEqual(entry.relegation_count, 1)
+
+    def test_errors_when_counts_missing_at_both_levels(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                'missing required keys after competition fallback'):
+            SeasonEntry('2025', {'teams': ['A', 'B']})
+
+    def test_group_team_count_scalar_form_is_allowed(self):
+        entry = SeasonEntry(
+            '2025',
+            {
+                'team_count': 10,
+                'promotion_count': 1,
+                'relegation_count': 0,
+                'teams': ['A', 'B'],
+                'group_team_count': 4,
+            },
+        )
+
+        self.assertEqual(entry.options['group_team_count'], 4)
+
+    def test_group_team_count_dict_requires_int_values(self):
+        with self.assertRaisesRegex(TypeError, 'group_team_count dict must be str -> int'):
+            SeasonEntry(
+                '2025',
+                {
+                    'team_count': 10,
+                    'promotion_count': 1,
+                    'relegation_count': 0,
+                    'teams': ['A', 'B'],
+                    'group_team_count': {'A': '4'},
+                },
+            )
 
 
 class TestTeamCountToSectionRange(unittest.TestCase):


### PR DESCRIPTION
Fixes #233

## Summary
- season_map の `team_count` / `promotion_count` / `relegation_count` を competition 階層から解決できるようにし、TS / Python / type sync を一貫して更新
- `group_team_count` にスカラー短縮形を追加し、frontend resolver で正規化する構成へ整理
- JLeagueCup と ACL の YAML 重複を削減し、関連テストと検証コマンドを更新

## Changes
| Commit | Description |
|--------|-------------|
| `85ba232` | Competition defaults と `group_team_count` shorthand 対応を実装し、YAML と検証を更新 |

## Test plan
- [x] `uv run pytest`
- [x] `npm run typecheck` (`frontend/`)
- [x] `npm run build` (`frontend/`)
- [x] `uv run python scripts/check_type_sync.py`
- [x] `uv run python scripts/check_point_system_csv.py`
- [x] `npx playwright test --grep-invert @full-render` (`frontend/`) を実行
- [x] WebKit で timeout した `e2e/date-slider.spec.ts` の単体再実行が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
