### PR TITLE
Add tournament season info resolver

### DIFF
--- a/frontend/src/__tests__/config/season-map.test.ts
+++ b/frontend/src/__tests__/config/season-map.test.ts
@@ -6,6 +6,7 @@ import {
   getCsvFilename,
   findCompetition,
   resolveSeasonInfo,
+  resolveTournamentSeasonInfo,
 } from '../../config/season-map';
 
 // ---- Test fixtures --------------------------------------------------------
@@ -532,5 +533,54 @@ describe('resolveSeasonInfo', () => {
     expect(() => resolveSeasonInfo(sampleFamily, comp, entry)).toThrow(
       'Missing required season_map field: team_count',
     );
+  });
+});
+
+describe('resolveTournamentSeasonInfo', () => {
+  test('aggregateTiebreakOrder defaults to ["penalties"] when not set anywhere', () => {
+    const family: CompetitionFamilyEntry = { display_name: 'Test', competitions: {} };
+    const comp: CompetitionEntry = { seasons: {} };
+    const entry: RawSeasonEntry = {};
+
+    const info = resolveTournamentSeasonInfo(family, comp, entry);
+
+    expect(info.aggregateTiebreakOrder).toEqual(['penalties']);
+  });
+
+  test('aggregateTiebreakOrder cascades from competition level', () => {
+    const family: CompetitionFamilyEntry = { display_name: 'Test', competitions: {} };
+    const comp: CompetitionEntry = {
+      aggregate_tiebreak_order: ['away_goals', 'penalties'],
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = {};
+
+    const info = resolveTournamentSeasonInfo(family, comp, entry);
+
+    expect(info.aggregateTiebreakOrder).toEqual(['away_goals', 'penalties']);
+  });
+
+  test('defaultRoundStart is normalized', () => {
+    const entry: RawSeasonEntry = { bracket_round_start: '準決勝 第1戦' };
+
+    const info = resolveTournamentSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+
+    expect(info.defaultRoundStart).toBe('準決勝');
+  });
+
+  test('roundStartOptions are normalized while preserving multi section sentinel', () => {
+    const entry: RawSeasonEntry = {
+      round_start_options: ['準決勝 第1戦', '__multi_section__'],
+    };
+
+    const info = resolveTournamentSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+
+    expect(info.roundStartOptions).toEqual(['準決勝', '__multi_section__']);
+  });
+
+  test('defaultRoundStart stays undefined when bracket_round_start is absent', () => {
+    const info = resolveTournamentSeasonInfo(sampleFamily, sampleFamily.competitions.J1, {});
+
+    expect(info.defaultRoundStart).toBeUndefined();
   });
 });

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -4,10 +4,11 @@ import yaml from 'js-yaml';
 import type { PointSystem } from '../types/config';
 import type {
   SeasonMap, CompetitionFamilyEntry, CompetitionEntry, RawSeasonEntry, SeasonInfo,
-  CrossGroupStanding, DataSource, ViewType,
+  CrossGroupStanding, DataSource, ViewType, AggregateTiebreakCriterion,
 } from '../types/season';
 import { generateRuleNotes } from './rule-notes';
 import { t } from '../i18n';
+import { normalizeBracketRoundLabel } from '../bracket/round-label';
 
 /**
  * Returns the CSV filename for a given competition and season.
@@ -108,6 +109,30 @@ function hasEntries(value: Record<string, unknown>): boolean {
   return Object.keys(value).length > 0;
 }
 
+const MULTI_SECTION_VALUE = '__multi_section__';
+
+interface ResolvedBaseFields {
+  cssFiles: string[];
+  leagueDisplay: string;
+  pointSystem: PointSystem;
+  tiebreakOrder: string[];
+  aggregateTiebreakOrder: AggregateTiebreakCriterion[];
+  dataSource?: DataSource;
+  rawNotes: string[];
+  viewTypes: ViewType[];
+}
+
+export interface TournamentSeasonInfo {
+  cssFiles: string[];
+  leagueDisplay: string;
+  notes: string[];
+  viewTypes: ViewType[];
+  dataSource?: DataSource;
+  aggregateTiebreakOrder: AggregateTiebreakCriterion[];
+  defaultRoundStart?: string;
+  roundStartOptions?: string[];
+}
+
 /**
  * Expands a scalar value into a Record using the given index keys.
  * If the value is already a Record, returns it as-is.
@@ -130,28 +155,13 @@ function expandScalarDefault<T>(
   return Object.fromEntries(indexKeys.map((key) => [key, value as T]));
 }
 
-/**
- * Resolves a SeasonInfo by applying the property cascade:
- * family → competition → season entry options.
- *
- * Cascade rules:
- * - Scalar (string): lower level overrides upper
- * - Array (css_files): union (deduplicated)
- * - Object (team_rename_map): merge (lower keys override)
- */
-export function resolveSeasonInfo(
+function resolveBaseFields(
   family: CompetitionFamilyEntry,
   comp: CompetitionEntry,
   entry: RawSeasonEntry,
   familyKey: string = '',
-): SeasonInfo {
+): ResolvedBaseFields {
   const cssFiles = mergeUniqueArrays(family.css_files, comp.css_files, entry.css_files);
-
-  // team_rename_map currently cascades only competition -> season.
-  const teamRenameMap = mergeObjects<Record<string, string>>(
-    comp.team_rename_map,
-    entry.team_rename_map,
-  );
 
   const leagueDisplay = pickCascade(
     entry.league_display,
@@ -176,8 +186,57 @@ export function resolveSeasonInfo(
     entry.aggregate_tiebreak_order,
     comp.aggregate_tiebreak_order,
     family.aggregate_tiebreak_order,
-    [],
+    ['penalties'] as AggregateTiebreakCriterion[],
   )!;
+
+  const dataSource: DataSource | undefined = pickCascade(
+    entry.data_source,
+    comp.data_source,
+    family.data_source,
+  );
+
+  const rawNotes = [
+    ...toArray(family.note),
+    ...toArray(comp.note),
+    ...toArray(entry.note),
+  ];
+
+  const viewTypes = mergeUniqueArrays(family.view_type, comp.view_type, entry.view_type);
+
+  return {
+    cssFiles,
+    leagueDisplay,
+    pointSystem,
+    tiebreakOrder,
+    aggregateTiebreakOrder,
+    dataSource,
+    rawNotes,
+    viewTypes: viewTypes.length > 0 ? viewTypes : ['league'],
+  };
+}
+
+/**
+ * Resolves a SeasonInfo by applying the property cascade:
+ * family → competition → season entry options.
+ *
+ * Cascade rules:
+ * - Scalar (string): lower level overrides upper
+ * - Array (css_files): union (deduplicated)
+ * - Object (team_rename_map): merge (lower keys override)
+ */
+export function resolveSeasonInfo(
+  family: CompetitionFamilyEntry,
+  comp: CompetitionEntry,
+  entry: RawSeasonEntry,
+  familyKey: string = '',
+): SeasonInfo {
+  const base = resolveBaseFields(family, comp, entry, familyKey);
+
+  // team_rename_map currently cascades only competition -> season.
+  const teamRenameMap = mergeObjects<Record<string, string>>(
+    comp.team_rename_map,
+    entry.team_rename_map,
+  );
 
   const seasonStartMonth = pickCascade(
     entry.season_start_month,
@@ -205,12 +264,6 @@ export function resolveSeasonInfo(
   );
   const groupTeamCount = hasEntries(groupTeamCountRaw) ? groupTeamCountRaw : undefined;
 
-  const dataSource: DataSource | undefined = pickCascade(
-    entry.data_source,
-    comp.data_source,
-    family.data_source,
-  );
-
   const promotionLabel = pickCascade(
     entry.promotion_label,
     comp.promotion_label,
@@ -219,14 +272,11 @@ export function resolveSeasonInfo(
   )!;
 
   const notes = [
-    ...toArray(family.note),
-    ...toArray(comp.note),
-    ...toArray(entry.note),
-    ...generateRuleNotes(pointSystem, tiebreakOrder, aggregateTiebreakOrder),
+    ...base.rawNotes,
+    ...generateRuleNotes(base.pointSystem, base.tiebreakOrder, base.aggregateTiebreakOrder),
   ];
 
-  const viewTypes = mergeUniqueArrays(family.view_type, comp.view_type, entry.view_type);
-  const bracketDefaultCount = viewTypes.includes('bracket') ? 0 : undefined;
+  const bracketDefaultCount = base.viewTypes.includes('bracket') ? 0 : undefined;
   const inferredTeamCount = entry.teams && entry.teams.length > 0 ? entry.teams.length : undefined;
   const teamCount = requireCascade('team_count', entry.team_count, comp.team_count, inferredTeamCount);
   const promotionCount = requireCascade(
@@ -250,18 +300,42 @@ export function resolveSeasonInfo(
     rankClass: entry.rank_properties ?? {},
     groupDisplay: entry.group_display,
     urlCategory: entry.url_category,
-    leagueDisplay,
-    pointSystem,
-    cssFiles,
+    leagueDisplay: base.leagueDisplay,
+    pointSystem: base.pointSystem,
+    cssFiles: base.cssFiles,
     teamRenameMap,
-    tiebreakOrder,
+    tiebreakOrder: base.tiebreakOrder,
     seasonStartMonth,
     shownGroups,
     crossGroupStanding,
     groupTeamCount,
-    dataSource,
+    dataSource: base.dataSource,
     notes,
     promotionLabel,
-    viewTypes: viewTypes.length > 0 ? viewTypes : ['league'],
+    viewTypes: base.viewTypes,
+  };
+}
+
+export function resolveTournamentSeasonInfo(
+  family: CompetitionFamilyEntry,
+  comp: CompetitionEntry,
+  entry: RawSeasonEntry,
+  familyKey: string = '',
+): TournamentSeasonInfo {
+  const base = resolveBaseFields(family, comp, entry, familyKey);
+
+  return {
+    cssFiles: base.cssFiles,
+    leagueDisplay: base.leagueDisplay,
+    notes: base.rawNotes,
+    viewTypes: base.viewTypes,
+    dataSource: base.dataSource,
+    aggregateTiebreakOrder: base.aggregateTiebreakOrder,
+    defaultRoundStart: entry.bracket_round_start
+      ? normalizeBracketRoundLabel(entry.bracket_round_start)
+      : undefined,
+    roundStartOptions: entry.round_start_options?.map((option) => (
+      option === MULTI_SECTION_VALUE ? option : normalizeBracketRoundLabel(option)
+    )),
   };
 }

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -13,7 +13,7 @@ import type {
   RawSeasonEntry,
 } from './types/season';
 import {
-  loadSeasonMap, getCsvFilename, findCompetition, resolveSeasonInfo,
+  loadSeasonMap, getCsvFilename, findCompetition, resolveTournamentSeasonInfo,
   getCompetitionViewTypes,
 } from './config/season-map';
 import {
@@ -726,13 +726,13 @@ function loadAndRender(seasonMap: SeasonMap): void {
       const rawSections = entry.bracket_blocks
         ? resolveSectionBracketOrders(entry.bracket_blocks, seasonTeams)
         : undefined;
-      const resolvedEntry: RawSeasonEntry = {
+      const resolvedEntry = {
         ...entry,
         teams: seasonTeams,
         team_count: entry.team_count ?? (seasonTeams.length > 0 ? seasonTeams.length : undefined),
         bracket_blocks: rawSections,
       };
-      const seasonInfo = resolveSeasonInfo(
+      const tournamentSeasonInfo = resolveTournamentSeasonInfo(
         found.family, found.competition, resolvedEntry, found.familyKey,
       );
       const bracketOrder = resolveSeasonBracketOrder(entry, inferredOrder);
@@ -740,13 +740,6 @@ function loadAndRender(seasonMap: SeasonMap): void {
         setStatus('No bracket data for this season.');
         return;
       }
-      const defaultRoundStart = entry.bracket_round_start
-        ? normalizeBracketRoundLabel(entry.bracket_round_start)
-        : undefined;
-      const roundStartOptions = entry.round_start_options?.map((option) => (
-        option === MULTI_SECTION_VALUE ? option : normalizeBracketRoundLabel(option)
-      ));
-      const aggregateTiebreakOrder = entry.aggregate_tiebreak_order ?? ['penalties'];
       const resolved = rawSections
         ? resolveSectionRoundFilters(rawSections, entry.default_round_filter)
         : undefined;
@@ -757,7 +750,11 @@ function loadAndRender(seasonMap: SeasonMap): void {
       const matchDates = collectMatchDates(bracketRows);
 
       // Build full tree to extract round structure and pre-populate cache
-      const fullRoot = buildBracket(bracketRows, bracketOrder, aggregateTiebreakOrder);
+      const fullRoot = buildBracket(
+        bracketRows,
+        bracketOrder,
+        tournamentSeasonInfo.aggregateTiebreakOrder,
+      );
       bracketCache = new Map();
       bracketCache.set(JSON.stringify(bracketOrder), fullRoot);
       const roundsByDepth = collectRoundsByDepth(fullRoot);
@@ -769,25 +766,25 @@ function loadAndRender(seasonMap: SeasonMap): void {
       currentState = {
         csvRows: bracketRows,
         bracketOrder,
-        aggregateTiebreakOrder,
+        aggregateTiebreakOrder: tournamentSeasonInfo.aggregateTiebreakOrder,
         fullRoot,
         roundsByDepth,
         allRounds,
-        defaultRoundStart,
-        roundStartOptions,
+        defaultRoundStart: tournamentSeasonInfo.defaultRoundStart,
+        roundStartOptions: tournamentSeasonInfo.roundStartOptions,
         bracketBlocks,
         matchDates,
-        cssFiles: seasonInfo.cssFiles,
-        leagueDisplay: seasonInfo.leagueDisplay,
+        cssFiles: tournamentSeasonInfo.cssFiles,
+        leagueDisplay: tournamentSeasonInfo.leagueDisplay,
         season,
       };
 
       // Populate round start dropdown (with multi-section option if sections exist)
       populateRoundStartPulldown(
         allRounds,
-        defaultRoundStart,
+        tournamentSeasonInfo.defaultRoundStart,
         bracketBlocks != null,
-        roundStartOptions,
+        tournamentSeasonInfo.roundStartOptions,
       );
 
       // Sync round start: restore from controlState or pick up dropdown default
@@ -829,7 +826,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
           t('bracketNote.etIncluded'),
           t('bracketNote.pkAnnotation'),
         ];
-        for (const text of [...seasonInfo.notes, ...bracketNotes]) {
+        for (const text of [...tournamentSeasonInfo.notes, ...bracketNotes]) {
           const li = document.createElement('li');
           li.textContent = text;
           notesEl.appendChild(li);
@@ -837,7 +834,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
       }
 
       setStatus(t('status.loaded', {
-        league: seasonInfo.leagueDisplay, season, rows: bracketRows.length,
+        league: tournamentSeasonInfo.leagueDisplay, season, rows: bracketRows.length,
       }));
     },
     error: (err: unknown) => {


### PR DESCRIPTION
Refs #238

> このPRは `refactor/issue-237-seasoninfo-type-split` への統合PRです。`main` への統合は親Issue #237 の完了PRで行います。

## Summary
- bracket view 向けに `resolveTournamentSeasonInfo()` を追加し、`resolveBaseFields()` で共通 cascade 解決を集約
- `tournament-app.ts` の bracket 固有 ad-hoc 解決を削除し、competition / family レベルの `aggregate_tiebreak_order` を tournament view に反映
- `aggregateTiebreakOrder` のデフォルトを `['penalties']` に統一し、対応テストを追加

## Changes
| Commit | Description |
|--------|-------------|
| `6fcbda1` | Tournament 用 season info resolver を追加し、bracket 側の ad-hoc 解決を集約 |

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)