### PR TITLE
Split season info types and consolidate resolvers

### DIFF
--- a/frontend/src/__tests__/config/season-map.test.ts
+++ b/frontend/src/__tests__/config/season-map.test.ts
@@ -5,7 +5,7 @@ import type {
 import {
   getCsvFilename,
   findCompetition,
-  resolveSeasonInfo,
+  resolveLeagueSeasonInfo,
   resolveTournamentSeasonInfo,
 } from '../../config/season-map';
 
@@ -96,12 +96,12 @@ describe('findCompetition', () => {
   });
 });
 
-// ---- resolveSeasonInfo ----------------------------------------------------
+// ---- resolveLeagueSeasonInfo ----------------------------------------------
 
-describe('resolveSeasonInfo', () => {
+describe('resolveLeagueSeasonInfo', () => {
   test('basic J1 season without extra options', () => {
     const entry: RawSeasonEntry = { team_count: 20, promotion_count: 3, relegation_count: 3, teams: ['神戸', '広島'] };
-    const info = resolveSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
 
     expect(info.teamCount).toBe(20);
     expect(info.promotionCount).toBe(3);
@@ -124,21 +124,21 @@ describe('resolveSeasonInfo', () => {
       relegation_count: 0,
       teams: ['A', 'B', 'C', 'D'],
     };
-    const info = resolveSeasonInfo(family, comp, entry);
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
 
     expect(info.teamCount).toBe(4);
   });
 
   test('season with rank_properties', () => {
     const entry: RawSeasonEntry = { team_count: 20, promotion_count: 3, relegation_count: 3, teams: [], rank_properties: { '3': 'promoted_playoff' } };
-    const info = resolveSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
 
     expect(info.rankClass).toEqual({ '3': 'promoted_playoff' });
   });
 
   test('season with group_display and url_category', () => {
     const entry: RawSeasonEntry = { team_count: 10, promotion_count: 0, relegation_count: 0, teams: [], group_display: 'EAST-A', url_category: 'j2j3' };
-    const info = resolveSeasonInfo(sampleFamily, sampleFamily.competitions.J2, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, sampleFamily.competitions.J2, entry);
 
     expect(info.groupDisplay).toBe('EAST-A');
     expect(info.urlCategory).toBe('j2j3');
@@ -147,14 +147,14 @@ describe('resolveSeasonInfo', () => {
 
   test('cascade: league_display in season overrides competition', () => {
     const entry: RawSeasonEntry = { team_count: 10, promotion_count: 0, relegation_count: 0, teams: [], league_display: 'Jリーグ 1993' };
-    const info = resolveSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
 
     expect(info.leagueDisplay).toBe('Jリーグ 1993');
   });
 
   test('cascade: point_system from season overrides default', () => {
     const entry: RawSeasonEntry = { team_count: 10, promotion_count: 0, relegation_count: 0, teams: [], point_system: 'victory-count' };
-    const info = resolveSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
 
     expect(info.pointSystem).toBe('victory-count');
   });
@@ -171,7 +171,7 @@ describe('resolveSeasonInfo', () => {
       competitions: {},
     };
     const entry: RawSeasonEntry = { team_count: 10, promotion_count: 0, relegation_count: 0, teams: [], css_files: ['season.css'] };
-    const info = resolveSeasonInfo(familyWithCss, compWithCss, entry);
+    const info = resolveLeagueSeasonInfo(familyWithCss, compWithCss, entry);
 
     expect(info.cssFiles).toEqual(['team_style.css', 'extra.css', 'season.css']);
   });
@@ -183,7 +183,7 @@ describe('resolveSeasonInfo', () => {
       seasons: {},
     };
     const entry: RawSeasonEntry = { team_count: 32, promotion_count: 0, relegation_count: 0, teams: [], team_rename_map: { 'アメリカ': 'USA' } };
-    const info = resolveSeasonInfo(nationalFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(nationalFamily, comp, entry);
 
     expect(info.teamRenameMap).toEqual({ 'オーストラリア': '豪州', 'アメリカ': 'USA' });
   });
@@ -200,14 +200,14 @@ describe('resolveSeasonInfo', () => {
       seasons: {},
     };
     const entry: RawSeasonEntry = { team_count: 32, promotion_count: 0, relegation_count: 0, teams: [] };
-    const info = resolveSeasonInfo(family, comp, entry);
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
 
     expect(info.teamRenameMap).toEqual({ 'オーストラリア': '豪州' });
   });
 
   test('national family inherits national CSS', () => {
     const entry: RawSeasonEntry = { team_count: 32, promotion_count: 0, relegation_count: 0, teams: [] };
-    const info = resolveSeasonInfo(nationalFamily, nationalFamily.competitions.WC_GS, entry);
+    const info = resolveLeagueSeasonInfo(nationalFamily, nationalFamily.competitions.WC_GS, entry);
 
     expect(info.cssFiles).toEqual(['national_team_style.css']);
     expect(info.leagueDisplay).toBe('FIFAワールドカップ グループステージ');
@@ -218,7 +218,7 @@ describe('resolveSeasonInfo', () => {
     const comp: CompetitionEntry = { seasons: {} };
     const family: CompetitionFamilyEntry = { display_name: 'Test Group', competitions: {} };
     const entry: RawSeasonEntry = { team_count: 10, promotion_count: 0, relegation_count: 0, teams: [] };
-    const info = resolveSeasonInfo(family, comp, entry);
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
 
     expect(info.leagueDisplay).toBe('Test Group');
   });
@@ -227,14 +227,14 @@ describe('resolveSeasonInfo', () => {
     const comp: CompetitionEntry = { seasons: {} };
     const family: CompetitionFamilyEntry = { competitions: {} };
     const entry: RawSeasonEntry = { team_count: 10, promotion_count: 0, relegation_count: 0, teams: [] };
-    const info = resolveSeasonInfo(family, comp, entry, 'my_family');
+    const info = resolveLeagueSeasonInfo(family, comp, entry, 'my_family');
 
     expect(info.leagueDisplay).toBe('my_family');
   });
 
   test('tiebreakOrder defaults to ["goal_diff", "goal_get"]', () => {
     const entry: RawSeasonEntry = { team_count: 20, promotion_count: 3, relegation_count: 3, teams: [] };
-    const info = resolveSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
 
     expect(info.tiebreakOrder).toEqual(['goal_diff', 'goal_get']);
   });
@@ -246,7 +246,7 @@ describe('resolveSeasonInfo', () => {
       seasons: {},
     };
     const entry: RawSeasonEntry = { team_count: 8, promotion_count: 0, relegation_count: 0, teams: [] };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.tiebreakOrder).toEqual(['head_to_head', 'goal_diff', 'goal_get']);
   });
@@ -258,7 +258,7 @@ describe('resolveSeasonInfo', () => {
       seasons: {},
     };
     const entry: RawSeasonEntry = { team_count: 8, promotion_count: 0, relegation_count: 0, teams: [], tiebreak_order: ['goal_diff', 'wins'] };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.tiebreakOrder).toEqual(['goal_diff', 'wins']);
   });
@@ -267,7 +267,7 @@ describe('resolveSeasonInfo', () => {
     const family: CompetitionFamilyEntry = { display_name: 'Test', competitions: {} };
     const comp: CompetitionEntry = { seasons: {} };
     const entry: RawSeasonEntry = { team_count: 10, promotion_count: 0, relegation_count: 0, teams: [] };
-    const info = resolveSeasonInfo(family, comp, entry);
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
 
     expect(info.seasonStartMonth).toBe(7);
   });
@@ -280,7 +280,7 @@ describe('resolveSeasonInfo', () => {
     };
     const comp: CompetitionEntry = { seasons: {} };
     const entry: RawSeasonEntry = { team_count: 20, promotion_count: 3, relegation_count: 3, teams: [] };
-    const info = resolveSeasonInfo(family, comp, entry);
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
 
     expect(info.seasonStartMonth).toBe(1);
   });
@@ -293,7 +293,7 @@ describe('resolveSeasonInfo', () => {
     };
     const comp: CompetitionEntry = { season_start_month: 8, seasons: {} };
     const entry: RawSeasonEntry = { team_count: 10, promotion_count: 0, relegation_count: 0, teams: [] };
-    const info = resolveSeasonInfo(family, comp, entry);
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
 
     expect(info.seasonStartMonth).toBe(8);
   });
@@ -301,14 +301,14 @@ describe('resolveSeasonInfo', () => {
   test('cascade: season_start_month from season overrides competition', () => {
     const comp: CompetitionEntry = { season_start_month: 1, seasons: {} };
     const entry: RawSeasonEntry = { team_count: 10, promotion_count: 0, relegation_count: 0, teams: [], season_start_month: 7 };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.seasonStartMonth).toBe(7);
   });
 
   test('shownGroups undefined when not set at any level', () => {
     const entry: RawSeasonEntry = { team_count: 20, promotion_count: 3, relegation_count: 3, teams: [] };
-    const info = resolveSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
 
     expect(info.shownGroups).toBeUndefined();
   });
@@ -320,7 +320,7 @@ describe('resolveSeasonInfo', () => {
       seasons: {},
     };
     const entry: RawSeasonEntry = { team_count: 16, promotion_count: 0, relegation_count: 0, teams: [] };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.shownGroups).toEqual(['A', 'B']);
   });
@@ -332,7 +332,7 @@ describe('resolveSeasonInfo', () => {
       seasons: {},
     };
     const entry: RawSeasonEntry = { team_count: 6, promotion_count: 0, relegation_count: 0, teams: [], shown_groups: ['C'] };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.shownGroups).toEqual(['C']);
   });
@@ -348,7 +348,7 @@ describe('resolveSeasonInfo', () => {
       group_team_count: { B: 4, C: 4 },
     };
     const entry: RawSeasonEntry = { team_count: 16, promotion_count: 0, relegation_count: 0, teams: [], group_team_count: { C: 3, D: 4 } };
-    const info = resolveSeasonInfo(family, comp, entry);
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
 
     expect(info.groupTeamCount).toEqual({ B: 4, C: 3, D: 4 });
   });
@@ -365,7 +365,7 @@ describe('resolveSeasonInfo', () => {
       teams: [],
       group_team_count: 4,
     };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.groupTeamCount).toEqual({ A: 4, B: 4 });
   });
@@ -383,7 +383,7 @@ describe('resolveSeasonInfo', () => {
       teams: [],
       group_team_count: { B: 3 },
     };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.groupTeamCount).toEqual({ A: 4, B: 3 });
   });
@@ -398,7 +398,7 @@ describe('resolveSeasonInfo', () => {
       group_team_count: 4,
     };
 
-    expect(() => resolveSeasonInfo(sampleFamily, comp, entry)).toThrow(
+    expect(() => resolveLeagueSeasonInfo(sampleFamily, comp, entry)).toThrow(
       'group_team_count scalar form requires index keys to expand',
     );
   });
@@ -416,7 +416,7 @@ describe('resolveSeasonInfo', () => {
       point_system: 'victory-count',
     };
     const entry: RawSeasonEntry = { team_count: 4, promotion_count: 0, relegation_count: 0, teams: [], note: 'season note' };
-    const info = resolveSeasonInfo(family, comp, entry);
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
 
     expect(info.notes.slice(0, 3)).toEqual(['family note', 'competition note', 'season note']);
     expect(info.notes.some((note) => note.includes('勝敗数のみカウント'))).toBe(true);
@@ -434,14 +434,14 @@ describe('resolveSeasonInfo', () => {
       view_type: ['bracket'],
     };
     const entry: RawSeasonEntry = { team_count: 8, promotion_count: 0, relegation_count: 0, teams: [], view_type: ['league', 'bracket'] };
-    const info = resolveSeasonInfo(family, comp, entry);
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
 
     expect(info.viewTypes).toEqual(['league', 'bracket']);
   });
 
   test('promotionLabel defaults to "昇格" when not set', () => {
     const entry: RawSeasonEntry = { team_count: 20, promotion_count: 3, relegation_count: 3, teams: [] };
-    const info = resolveSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
 
     expect(info.promotionLabel).toBe('昇格');
   });
@@ -453,7 +453,7 @@ describe('resolveSeasonInfo', () => {
       seasons: {},
     };
     const entry: RawSeasonEntry = { team_count: 20, promotion_count: 3, relegation_count: 3, teams: [] };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.promotionLabel).toBe('昇格<br/>ACL');
   });
@@ -465,7 +465,7 @@ describe('resolveSeasonInfo', () => {
       seasons: {},
     };
     const entry: RawSeasonEntry = { team_count: 20, promotion_count: 3, relegation_count: 3, teams: [], promotion_label: 'W杯本選' };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.promotionLabel).toBe('W杯本選');
   });
@@ -479,14 +479,14 @@ describe('resolveSeasonInfo', () => {
       seasons: {},
     };
     const entry: RawSeasonEntry = { teams: ['A', 'B'] };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.teamCount).toBe(8);
     expect(info.promotionCount).toBe(0);
     expect(info.relegationCount).toBe(0);
   });
 
-  test('bracket view seasons can omit promotion and relegation counts', () => {
+  test('league resolver throws when promotion and relegation counts are missing', () => {
     const comp: CompetitionEntry = {
       league_display: 'JLeagueCup',
       view_type: ['bracket'],
@@ -495,11 +495,10 @@ describe('resolveSeasonInfo', () => {
     const entry: RawSeasonEntry = {
       teams: ['A', 'B', 'C', 'D'],
     };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
 
-    expect(info.teamCount).toBe(4);
-    expect(info.promotionCount).toBe(0);
-    expect(info.relegationCount).toBe(0);
+    expect(() => resolveLeagueSeasonInfo(sampleFamily, comp, entry)).toThrow(
+      'Missing required season_map field: promotion_count',
+    );
   });
 
   test('season count fields override competition defaults', () => {
@@ -516,7 +515,7 @@ describe('resolveSeasonInfo', () => {
       relegation_count: 3,
       teams: [],
     };
-    const info = resolveSeasonInfo(sampleFamily, comp, entry);
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
 
     expect(info.teamCount).toBe(20);
     expect(info.promotionCount).toBe(3);
@@ -530,7 +529,7 @@ describe('resolveSeasonInfo', () => {
     };
     const entry: RawSeasonEntry = { teams: [] };
 
-    expect(() => resolveSeasonInfo(sampleFamily, comp, entry)).toThrow(
+    expect(() => resolveLeagueSeasonInfo(sampleFamily, comp, entry)).toThrow(
       'Missing required season_map field: team_count',
     );
   });

--- a/frontend/src/__tests__/config/season-map.test.ts
+++ b/frontend/src/__tests__/config/season-map.test.ts
@@ -6,6 +6,7 @@ import {
   getCsvFilename,
   findCompetition,
   resolveSeasonInfo,
+  resolveTournamentSeasonInfo,
 } from '../../config/season-map';
 
 // ---- Test fixtures --------------------------------------------------------
@@ -532,5 +533,54 @@ describe('resolveSeasonInfo', () => {
     expect(() => resolveSeasonInfo(sampleFamily, comp, entry)).toThrow(
       'Missing required season_map field: team_count',
     );
+  });
+});
+
+describe('resolveTournamentSeasonInfo', () => {
+  test('aggregateTiebreakOrder defaults to ["penalties"] when not set anywhere', () => {
+    const family: CompetitionFamilyEntry = { display_name: 'Test', competitions: {} };
+    const comp: CompetitionEntry = { seasons: {} };
+    const entry: RawSeasonEntry = {};
+
+    const info = resolveTournamentSeasonInfo(family, comp, entry);
+
+    expect(info.aggregateTiebreakOrder).toEqual(['penalties']);
+  });
+
+  test('aggregateTiebreakOrder cascades from competition level', () => {
+    const family: CompetitionFamilyEntry = { display_name: 'Test', competitions: {} };
+    const comp: CompetitionEntry = {
+      aggregate_tiebreak_order: ['away_goals', 'penalties'],
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = {};
+
+    const info = resolveTournamentSeasonInfo(family, comp, entry);
+
+    expect(info.aggregateTiebreakOrder).toEqual(['away_goals', 'penalties']);
+  });
+
+  test('defaultRoundStart is normalized', () => {
+    const entry: RawSeasonEntry = { bracket_round_start: '準決勝 第1戦' };
+
+    const info = resolveTournamentSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+
+    expect(info.defaultRoundStart).toBe('準決勝');
+  });
+
+  test('roundStartOptions are normalized while preserving multi section sentinel', () => {
+    const entry: RawSeasonEntry = {
+      round_start_options: ['準決勝 第1戦', '__multi_section__'],
+    };
+
+    const info = resolveTournamentSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+
+    expect(info.roundStartOptions).toEqual(['準決勝', '__multi_section__']);
+  });
+
+  test('defaultRoundStart stays undefined when bracket_round_start is absent', () => {
+    const info = resolveTournamentSeasonInfo(sampleFamily, sampleFamily.competitions.J1, {});
+
+    expect(info.defaultRoundStart).toBeUndefined();
   });
 });

--- a/frontend/src/__tests__/core/prepare-render.test.ts
+++ b/frontend/src/__tests__/core/prepare-render.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import { prepareRenderData } from '../../core/prepare-render';
 import type { PrepareRenderInput } from '../../core/prepare-render';
-import { makeMatch, makeTeamData, makeSeasonInfo } from '../fixtures/match-data';
+import { makeMatch, makeTeamData, makeLeagueSeasonInfo } from '../fixtures/match-data';
 
 function makeTestInput(overrides: Partial<PrepareRenderInput> = {}): PrepareRenderInput {
   return {
@@ -19,7 +19,7 @@ function makeTestInput(overrides: Partial<PrepareRenderInput> = {}): PrepareRend
         makeMatch({ opponent: 'TeamB', point: 1, match_date: '2025/03/08', section_no: 2, goal_get: 1, goal_lose: 1, is_home: false }),
       ]),
     },
-    seasonInfo: makeSeasonInfo({ teamCount: 3, teams: ['TeamA', 'TeamB', 'TeamC'] }),
+    seasonInfo: makeLeagueSeasonInfo({ teamCount: 3, teams: ['TeamA', 'TeamB', 'TeamC'] }),
     targetDate: '2025/12/31',
     sortKey: 'point',
     matchSortKey: 'section_no',
@@ -79,7 +79,7 @@ describe('prepareRenderData', () => {
   test('works with empty team list', () => {
     const input = makeTestInput({
       groupData: {},
-      seasonInfo: makeSeasonInfo({ teamCount: 0, teams: [] }),
+      seasonInfo: makeLeagueSeasonInfo({ teamCount: 0, teams: [] }),
     });
     const result = prepareRenderData(input);
     expect(result.groupData).toEqual({});
@@ -113,7 +113,7 @@ describe('prepareRenderData with tiebreakOrder', () => {
           makeMatch({ opponent: 'TeamB', point: 0, goal_get: 0, goal_lose: 3, match_date: '2025/03/08', section_no: 2, is_home: false }),
         ]),
       },
-      seasonInfo: makeSeasonInfo({
+      seasonInfo: makeLeagueSeasonInfo({
         teamCount: 3,
         teams: ['TeamA', 'TeamB', 'TeamC'],
         tiebreakOrder,
@@ -177,7 +177,7 @@ describe('prepareRenderData with tiebreakOrder', () => {
           makeMatch({ opponent: 'TeamY', point: 0, goal_get: 0, goal_lose: 3, match_date: '2025/03/08', section_no: 2, is_home: false }),
         ]),
       },
-      seasonInfo: makeSeasonInfo({
+      seasonInfo: makeLeagueSeasonInfo({
         teamCount: 3, teams: ['TeamX', 'TeamY', 'TeamZ'],
         tiebreakOrder: ['head_to_head', 'goal_diff'],
       }),
@@ -219,7 +219,7 @@ describe('prepareRenderData with disp sort keys and targetDate', () => {
           makeMatch({ opponent: 'TeamB', point: 3, goal_get: 2, goal_lose: 0, match_date: '2025/04/01', section_no: 2 }),
         ]),
       },
-      seasonInfo: makeSeasonInfo({ teamCount: 3, teams: ['TeamA', 'TeamB', 'TeamC'] }),
+      seasonInfo: makeLeagueSeasonInfo({ teamCount: 3, teams: ['TeamA', 'TeamB', 'TeamC'] }),
       targetDate,
       sortKey,
       matchSortKey: 'section_no',
@@ -310,7 +310,7 @@ describe('prepareRenderData sort stability with many teams', () => {
 
     const input: PrepareRenderInput = {
       groupData,
-      seasonInfo: makeSeasonInfo({ teamCount: 20, teams: teamNames }),
+      seasonInfo: makeLeagueSeasonInfo({ teamCount: 20, teams: teamNames }),
       targetDate: '2025/12/31',
       sortKey: 'point',
       matchSortKey: 'section_no',
@@ -356,7 +356,7 @@ describe('prepareRenderData sort stability with many teams', () => {
 
     const input: PrepareRenderInput = {
       groupData,
-      seasonInfo: makeSeasonInfo({ teamCount: 20, teams: teamNames }),
+      seasonInfo: makeLeagueSeasonInfo({ teamCount: 20, teams: teamNames }),
       targetDate: '2025/12/31',
       sortKey: 'point',
       matchSortKey: 'section_no',

--- a/frontend/src/__tests__/fixtures/match-data.ts
+++ b/frontend/src/__tests__/fixtures/match-data.ts
@@ -2,7 +2,7 @@
 
 import type { TeamData, TeamMatch } from '../../types/match';
 import { TeamStats } from '../../types/match';
-import type { SeasonInfo } from '../../types/season';
+import type { LeagueSeasonInfo } from '../../types/season';
 
 /** Creates a TeamMatch with sensible defaults; override any field as needed. */
 export function makeMatch(overrides: Partial<TeamMatch> = {}): TeamMatch {
@@ -32,8 +32,10 @@ export function makeTeamData(matches: TeamMatch[] = []): TeamData {
   return { df: matches, latestStats: new TeamStats(), displayStats: new TeamStats() };
 }
 
-/** Creates a SeasonInfo for a 4-team season with 1 promotion and 1 relegation slot. */
-export function makeSeasonInfo(overrides: Partial<SeasonInfo> = {}): SeasonInfo {
+/** Creates a LeagueSeasonInfo for a 4-team season with 1 promotion and 1 relegation slot. */
+export function makeLeagueSeasonInfo(
+  overrides: Partial<LeagueSeasonInfo> = {},
+): LeagueSeasonInfo {
   return {
     teamCount: 4,
     promotionCount: 1,

--- a/frontend/src/__tests__/graph/renderer.test.ts
+++ b/frontend/src/__tests__/graph/renderer.test.ts
@@ -9,39 +9,39 @@ import {
 } from '../../graph/renderer';
 import { buildTeamColumn } from '../../graph/bar-column';
 import { calculateTeamStats } from '../../ranking/stats-calculator';
-import { makeMatch, makeTeamData, makeSeasonInfo } from '../fixtures/match-data';
+import { makeMatch, makeTeamData, makeLeagueSeasonInfo } from '../fixtures/match-data';
 import type { ColumnResult } from '../../graph/bar-column';
 
 // ─── getScaleColumnPositions ──────────────────────────────────────────────────────
 
 describe('getScaleColumnPositions', () => {
   test('promotion=0, relegation=0 → mid only', () => {
-    const info = makeSeasonInfo({ teamCount: 10, promotionCount: 0, relegationCount: 0 });
+    const info = makeLeagueSeasonInfo({ teamCount: 10, promotionCount: 0, relegationCount: 0 });
     expect(getScaleColumnPositions(info)).toEqual([5]);
   });
 
   test('teamCount=4 with promotion=1, relegation=1 → [1, 2, 3]', () => {
-    const info = makeSeasonInfo({ teamCount: 4, promotionCount: 1, relegationCount: 1 });
+    const info = makeLeagueSeasonInfo({ teamCount: 4, promotionCount: 1, relegationCount: 1 });
     expect(getScaleColumnPositions(info)).toEqual([1, 2, 3]);
   });
 
   test('teamCount=20, promotion=3, relegation=4 → [3, 10, 16]', () => {
-    const info = makeSeasonInfo({ teamCount: 20, promotionCount: 3, relegationCount: 4 });
+    const info = makeLeagueSeasonInfo({ teamCount: 20, promotionCount: 3, relegationCount: 4 });
     expect(getScaleColumnPositions(info)).toEqual([3, 10, 16]);
   });
 
   test('promotion only (relegation=0) → [promotionCount, mid]', () => {
-    const info = makeSeasonInfo({ teamCount: 10, promotionCount: 3, relegationCount: 0 });
+    const info = makeLeagueSeasonInfo({ teamCount: 10, promotionCount: 3, relegationCount: 0 });
     expect(getScaleColumnPositions(info)).toEqual([3, 5]);
   });
 
   test('relegation only (promotion=0) → [mid, relegationCutoff]', () => {
-    const info = makeSeasonInfo({ teamCount: 10, promotionCount: 0, relegationCount: 2 });
+    const info = makeLeagueSeasonInfo({ teamCount: 10, promotionCount: 0, relegationCount: 2 });
     expect(getScaleColumnPositions(info)).toEqual([5, 8]);
   });
 
   test('odd teamCount uses floor: teamCount=11 → mid=5', () => {
-    const info = makeSeasonInfo({ teamCount: 11, promotionCount: 0, relegationCount: 0 });
+    const info = makeLeagueSeasonInfo({ teamCount: 11, promotionCount: 0, relegationCount: 0 });
     expect(getScaleColumnPositions(info)).toEqual([5]);
   });
 });
@@ -116,7 +116,7 @@ function buildCol(
 }
 
 describe('assembleTeamColumn', () => {
-  const info = makeSeasonInfo({ teamCount: 4, promotionCount: 1, relegationCount: 1 });
+  const info = makeLeagueSeasonInfo({ teamCount: 4, promotionCount: 1, relegationCount: 1 });
 
   test('space box added when avlbl_pt < maxAvblPt', () => {
     const col = buildCol('TeamA', [makeMatch({ point: 3, has_result: true })]);
@@ -180,7 +180,7 @@ describe('assembleTeamColumn', () => {
 
 describe('renderBarGraph', () => {
   const TARGET = '2025/12/31';
-  const info = makeSeasonInfo({ teamCount: 3, promotionCount: 1, relegationCount: 1 });
+  const info = makeLeagueSeasonInfo({ teamCount: 3, promotionCount: 1, relegationCount: 1 });
 
   function buildGroupData(): Record<string, ReturnType<typeof makeTeamData>> {
     const teams = {

--- a/frontend/src/__tests__/graph/tooltip.test.ts
+++ b/frontend/src/__tests__/graph/tooltip.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../graph/tooltip';
 import { getBright } from '../../graph/css-utils';
 import { calculateTeamStats } from '../../ranking/stats-calculator';
-import { makeMatch, makeTeamData, makeSeasonInfo } from '../fixtures/match-data';
+import { makeMatch, makeTeamData, makeLeagueSeasonInfo } from '../fixtures/match-data';
 
 // ─── makeBoxBody (height-based box content) ─────────────────────────────────
 
@@ -246,7 +246,7 @@ describe('joinLossBox', () => {
 
 describe('getRankClass', () => {
   // 4 teams, promotion 1, relegation 1 → relegationRank = 3 (rank 4 relegated)
-  const info = makeSeasonInfo({ teamCount: 4, promotionCount: 1, relegationCount: 1 });
+  const info = makeLeagueSeasonInfo({ teamCount: 4, promotionCount: 1, relegationCount: 1 });
 
   test('rank within promotion zone → "promoted"', () => {
     expect(getRankClass(1, info)).toBe('promoted');
@@ -262,7 +262,7 @@ describe('getRankClass', () => {
   });
 
   test('custom rankClass takes priority over promotion/relegation', () => {
-    const custom = makeSeasonInfo({
+    const custom = makeLeagueSeasonInfo({
       teamCount: 4, promotionCount: 1, relegationCount: 1,
       rankClass: { '1': 'champion', '3': 'promoted_playoff' },
     });

--- a/frontend/src/__tests__/ranking/rank-table.test.ts
+++ b/frontend/src/__tests__/ranking/rank-table.test.ts
@@ -3,7 +3,7 @@ import { describe, test, expect, beforeAll, vi } from 'vitest';
 import { makeRankData, makeRankTable } from '../../ranking/rank-table';
 import type { TeamData } from '../../types/match';
 import { TeamStats } from '../../types/match';
-import { makeSeasonInfo } from '../fixtures/match-data';
+import { makeLeagueSeasonInfo } from '../fixtures/match-data';
 
 // Mock the CDN-loaded SortableTable global required by makeRankTable.
 beforeAll(() => {
@@ -105,7 +105,7 @@ function makeStatsTeam(opts: {
 // ─── Scenario 1: season finished ──────────────────────────────────────────────
 // All teams have rest_games={}, so getAllRestGame()===0 → allGameFinished branch.
 describe('makeRankData – season finished', () => {
-  const seasonInfo = makeSeasonInfo({ teamCount: 4, promotionCount: 1, relegationCount: 1 });
+  const seasonInfo = makeLeagueSeasonInfo({ teamCount: 4, promotionCount: 1, relegationCount: 1 });
   // relegationRank = 4 - 1 = 3
 
   const groupData: Record<string, TeamData> = {
@@ -178,7 +178,7 @@ describe('makeRankData – confirmed champion, others eliminated', () => {
   // TeamB: avlbl_pt=21 < silverLine=25 → 'なし'
   // TeamC: avlbl_pt=18 < 25 → 'なし'
   // TeamD: avlbl_pt=8  < 25 → 'なし'
-  const seasonInfo = makeSeasonInfo({ teamCount: 4, promotionCount: 0, relegationCount: 0 });
+  const seasonInfo = makeLeagueSeasonInfo({ teamCount: 4, promotionCount: 0, relegationCount: 0 });
 
   const groupData: Record<string, TeamData> = {
     TeamA: makeStatsTeam({ point: 25, avlbl_pt: 25, all_game: 10, rest_games: {} }),
@@ -239,7 +239,7 @@ describe('makeRankData – confirmed champion, others eliminated', () => {
 //   TeamC: silver = 8 - 18 = -10 < 0 → 'なし'
 //   TeamD: silver = 9 - 18 = -9  < 0 → 'なし'
 describe('makeRankData – all four champion states in one table', () => {
-  const seasonInfo = makeSeasonInfo({ teamCount: 4, promotionCount: 0, relegationCount: 0 });
+  const seasonInfo = makeLeagueSeasonInfo({ teamCount: 4, promotionCount: 0, relegationCount: 0 });
 
   const groupData: Record<string, TeamData> = {
     TeamA: makeStatsTeam({ point: 18, avlbl_pt: 21, all_game: 8, rest_games: { TeamC: 1 } }),
@@ -274,7 +274,7 @@ describe('makeRankData – all four champion states in one table', () => {
 // ─── Scenario 4: disp=true uses displayStats ──────────────────────────────────
 // Verify that when disp=true, the row fields reflect displayStats values, not latest values.
 describe('makeRankData – disp=true uses display-time stats', () => {
-  const seasonInfo = makeSeasonInfo({ teamCount: 2, promotionCount: 0, relegationCount: 0 });
+  const seasonInfo = makeLeagueSeasonInfo({ teamCount: 2, promotionCount: 0, relegationCount: 0 });
 
   const groupData: Record<string, TeamData> = {
     TeamA: makeStatsTeam({
@@ -319,7 +319,7 @@ describe('makeRankData – disp=true uses display-time stats', () => {
 
 // ─── Scenario 5: no promotion/relegation ──────────────────────────────────────
 describe('makeRankData – no promotion or relegation counts', () => {
-  const seasonInfo = makeSeasonInfo({ teamCount: 4, promotionCount: 0, relegationCount: 0 });
+  const seasonInfo = makeLeagueSeasonInfo({ teamCount: 4, promotionCount: 0, relegationCount: 0 });
 
   const groupData: Record<string, TeamData> = {
     TeamA: makeStatsTeam({ point: 9, avlbl_pt: 9, all_game: 3, rest_games: {} }),
@@ -382,7 +382,7 @@ describe('makeRankData – no promotion or relegation counts', () => {
 //
 // TeamD/E/F: remaining = avlbl_pt - 18 < 0 → 'なし'
 describe('makeRankData – all four promotion states in one table', () => {
-  const seasonInfo = makeSeasonInfo({ teamCount: 6, promotionCount: 2, relegationCount: 0 });
+  const seasonInfo = makeLeagueSeasonInfo({ teamCount: 6, promotionCount: 2, relegationCount: 0 });
 
   const groupData: Record<string, ReturnType<typeof makeStatsTeam>> = {
     TeamA: makeStatsTeam({ point: 22, avlbl_pt: 22, all_game: 10, rest_games: { TeamB: 1 } }),
@@ -476,7 +476,7 @@ describe('makeRankData – all four promotion states in one table', () => {
 // TeamF: keepLeague = 4-21 = -17 < 0
 //        relegation = 7-14 = -7 < 0 → '降格'
 describe('makeRankData – all four relegation states in one table', () => {
-  const seasonInfo = makeSeasonInfo({ teamCount: 6, promotionCount: 0, relegationCount: 3 });
+  const seasonInfo = makeLeagueSeasonInfo({ teamCount: 6, promotionCount: 0, relegationCount: 3 });
 
   const groupData: Record<string, ReturnType<typeof makeStatsTeam>> = {
     TeamA: makeStatsTeam({ point: 25, avlbl_pt: 25, all_game: 10, rest_games: {} }),
@@ -521,7 +521,7 @@ describe('makeRankData – all four relegation states in one table', () => {
 
 // ─── Scenario 6: row shape ─────────────────────────────────────────────────────
 describe('makeRankData – row shape', () => {
-  const seasonInfo = makeSeasonInfo({ teamCount: 2, promotionCount: 0, relegationCount: 0 });
+  const seasonInfo = makeLeagueSeasonInfo({ teamCount: 2, promotionCount: 0, relegationCount: 0 });
 
   const groupData: Record<string, TeamData> = {
     TeamA: makeStatsTeam({

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -10,9 +10,9 @@
 
 import Papa from 'papaparse';
 import type { RawMatchRow, TeamMap } from './types/match';
-import type { SeasonMap, SeasonInfo } from './types/season';
+import type { SeasonMap, LeagueSeasonInfo } from './types/season';
 import {
-  loadSeasonMap, getCsvFilename, findCompetition, resolveSeasonInfo,
+  loadSeasonMap, getCsvFilename, findCompetition, resolveLeagueSeasonInfo,
   getCompetitionViewTypes,
 } from './config/season-map';
 import { parseCsvResults } from './core/csv-parser';
@@ -305,7 +305,7 @@ function renderFromCache(
   if (!found) return;
   const entry = found.competition.seasons[season];
   if (!entry) return;
-  const seasonInfo = resolveSeasonInfo(found.family, found.competition, entry, found.familyKey);
+  const seasonInfo = resolveLeagueSeasonInfo(found.family, found.competition, entry, found.familyKey);
   const { hasPk, hasEx } = cache;
 
   // Determine which groups to render and in what order.
@@ -335,7 +335,7 @@ function renderFromCache(
     // promotionCount is kept as-is (group-stage competitions advance a fixed number per group).
     // relegationCount is zeroed because relegation is never decided per-group.
     const groupTeamCount = seasonInfo.groupTeamCount?.[groupKey] ?? seasonInfo.teamCount;
-    const perGroupInfo: SeasonInfo = isMultiGroup
+    const perGroupInfo: LeagueSeasonInfo = isMultiGroup
       ? { ...seasonInfo, teamCount: groupTeamCount, relegationCount: 0 }
       : seasonInfo;
 
@@ -458,7 +458,12 @@ function loadAndRender(seasonMap: SeasonMap): void {
     return;
   }
 
-  const leagueDisplay = resolveSeasonInfo(found.family, found.competition, found.competition.seasons[season], found.familyKey).leagueDisplay;
+  const leagueDisplay = resolveLeagueSeasonInfo(
+    found.family,
+    found.competition,
+    found.competition.seasons[season],
+    found.familyKey,
+  ).leagueDisplay;
 
   writeUrlParams(competition, season);
   savePrefs({
@@ -486,7 +491,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
     download: true,
     complete: (results) => {
       const entry = found.competition.seasons[season];
-      const seasonInfo = resolveSeasonInfo(found.family, found.competition, entry, found.familyKey);
+      const seasonInfo = resolveLeagueSeasonInfo(found.family, found.competition, entry, found.familyKey);
       const teamMap = parseCsvResults(
         results.data,
         results.meta.fields ?? [],

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -3,8 +3,8 @@
 import yaml from 'js-yaml';
 import type { PointSystem } from '../types/config';
 import type {
-  SeasonMap, CompetitionFamilyEntry, CompetitionEntry, RawSeasonEntry, SeasonInfo,
-  CrossGroupStanding, DataSource, ViewType, AggregateTiebreakCriterion,
+  SeasonMap, CompetitionFamilyEntry, CompetitionEntry, RawSeasonEntry, LeagueSeasonInfo,
+  TournamentSeasonInfo, CrossGroupStanding, DataSource, ViewType, AggregateTiebreakCriterion,
 } from '../types/season';
 import { generateRuleNotes } from './rule-notes';
 import { t } from '../i18n';
@@ -122,17 +122,6 @@ interface ResolvedBaseFields {
   viewTypes: ViewType[];
 }
 
-export interface TournamentSeasonInfo {
-  cssFiles: string[];
-  leagueDisplay: string;
-  notes: string[];
-  viewTypes: ViewType[];
-  dataSource?: DataSource;
-  aggregateTiebreakOrder: AggregateTiebreakCriterion[];
-  defaultRoundStart?: string;
-  roundStartOptions?: string[];
-}
-
 /**
  * Expands a scalar value into a Record using the given index keys.
  * If the value is already a Record, returns it as-is.
@@ -216,7 +205,7 @@ function resolveBaseFields(
 }
 
 /**
- * Resolves a SeasonInfo by applying the property cascade:
+ * Resolves league season info by applying the property cascade:
  * family → competition → season entry options.
  *
  * Cascade rules:
@@ -224,12 +213,12 @@ function resolveBaseFields(
  * - Array (css_files): union (deduplicated)
  * - Object (team_rename_map): merge (lower keys override)
  */
-export function resolveSeasonInfo(
+export function resolveLeagueSeasonInfo(
   family: CompetitionFamilyEntry,
   comp: CompetitionEntry,
   entry: RawSeasonEntry,
   familyKey: string = '',
-): SeasonInfo {
+): LeagueSeasonInfo {
   const base = resolveBaseFields(family, comp, entry, familyKey);
 
   // team_rename_map currently cascades only competition -> season.
@@ -276,20 +265,17 @@ export function resolveSeasonInfo(
     ...generateRuleNotes(base.pointSystem, base.tiebreakOrder, base.aggregateTiebreakOrder),
   ];
 
-  const bracketDefaultCount = base.viewTypes.includes('bracket') ? 0 : undefined;
   const inferredTeamCount = entry.teams && entry.teams.length > 0 ? entry.teams.length : undefined;
   const teamCount = requireCascade('team_count', entry.team_count, comp.team_count, inferredTeamCount);
   const promotionCount = requireCascade(
     'promotion_count',
     entry.promotion_count,
     comp.promotion_count,
-    bracketDefaultCount,
   );
   const relegationCount = requireCascade(
     'relegation_count',
     entry.relegation_count,
     comp.relegation_count,
-    bracketDefaultCount,
   );
 
   return {

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -4,10 +4,11 @@ import yaml from 'js-yaml';
 import type { PointSystem } from '../types/config';
 import type {
   SeasonMap, CompetitionFamilyEntry, CompetitionEntry, RawSeasonEntry, SeasonInfo,
-  CrossGroupStanding, DataSource, ViewType,
+  CrossGroupStanding, DataSource, ViewType, AggregateTiebreakCriterion,
 } from '../types/season';
 import { generateRuleNotes } from './rule-notes';
 import { t } from '../i18n';
+import { normalizeBracketRoundLabel } from '../bracket/round-label';
 
 /**
  * Returns the CSV filename for a given competition and season.
@@ -108,6 +109,30 @@ function hasEntries(value: Record<string, unknown>): boolean {
   return Object.keys(value).length > 0;
 }
 
+const MULTI_SECTION_VALUE = '__multi_section__';
+
+interface ResolvedBaseFields {
+  cssFiles: string[];
+  leagueDisplay: string;
+  pointSystem: PointSystem;
+  tiebreakOrder: string[];
+  aggregateTiebreakOrder: AggregateTiebreakCriterion[];
+  dataSource?: DataSource;
+  rawNotes: string[];
+  viewTypes: ViewType[];
+}
+
+export interface TournamentSeasonInfo {
+  cssFiles: string[];
+  leagueDisplay: string;
+  notes: string[];
+  viewTypes: ViewType[];
+  dataSource?: DataSource;
+  aggregateTiebreakOrder: AggregateTiebreakCriterion[];
+  defaultRoundStart?: string;
+  roundStartOptions?: string[];
+}
+
 /**
  * Expands a scalar value into a Record using the given index keys.
  * If the value is already a Record, returns it as-is.
@@ -130,28 +155,13 @@ function expandScalarDefault<T>(
   return Object.fromEntries(indexKeys.map((key) => [key, value as T]));
 }
 
-/**
- * Resolves a SeasonInfo by applying the property cascade:
- * family → competition → season entry options.
- *
- * Cascade rules:
- * - Scalar (string): lower level overrides upper
- * - Array (css_files): union (deduplicated)
- * - Object (team_rename_map): merge (lower keys override)
- */
-export function resolveSeasonInfo(
+function resolveBaseFields(
   family: CompetitionFamilyEntry,
   comp: CompetitionEntry,
   entry: RawSeasonEntry,
   familyKey: string = '',
-): SeasonInfo {
+): ResolvedBaseFields {
   const cssFiles = mergeUniqueArrays(family.css_files, comp.css_files, entry.css_files);
-
-  // team_rename_map currently cascades only competition -> season.
-  const teamRenameMap = mergeObjects<Record<string, string>>(
-    comp.team_rename_map,
-    entry.team_rename_map,
-  );
 
   const leagueDisplay = pickCascade(
     entry.league_display,
@@ -176,8 +186,57 @@ export function resolveSeasonInfo(
     entry.aggregate_tiebreak_order,
     comp.aggregate_tiebreak_order,
     family.aggregate_tiebreak_order,
-    [],
+    ['penalties'] as AggregateTiebreakCriterion[],
   )!;
+
+  const dataSource: DataSource | undefined = pickCascade(
+    entry.data_source,
+    comp.data_source,
+    family.data_source,
+  );
+
+  const rawNotes = [
+    ...toArray(family.note),
+    ...toArray(comp.note),
+    ...toArray(entry.note),
+  ];
+
+  const viewTypes = mergeUniqueArrays(family.view_type, comp.view_type, entry.view_type);
+
+  return {
+    cssFiles,
+    leagueDisplay,
+    pointSystem,
+    tiebreakOrder,
+    aggregateTiebreakOrder,
+    dataSource,
+    rawNotes,
+    viewTypes: viewTypes.length > 0 ? viewTypes : ['league'],
+  };
+}
+
+/**
+ * Resolves a SeasonInfo by applying the property cascade:
+ * family → competition → season entry options.
+ *
+ * Cascade rules:
+ * - Scalar (string): lower level overrides upper
+ * - Array (css_files): union (deduplicated)
+ * - Object (team_rename_map): merge (lower keys override)
+ */
+export function resolveSeasonInfo(
+  family: CompetitionFamilyEntry,
+  comp: CompetitionEntry,
+  entry: RawSeasonEntry,
+  familyKey: string = '',
+): SeasonInfo {
+  const base = resolveBaseFields(family, comp, entry, familyKey);
+
+  // team_rename_map currently cascades only competition -> season.
+  const teamRenameMap = mergeObjects<Record<string, string>>(
+    comp.team_rename_map,
+    entry.team_rename_map,
+  );
 
   const seasonStartMonth = pickCascade(
     entry.season_start_month,
@@ -205,12 +264,6 @@ export function resolveSeasonInfo(
   );
   const groupTeamCount = hasEntries(groupTeamCountRaw) ? groupTeamCountRaw : undefined;
 
-  const dataSource: DataSource | undefined = pickCascade(
-    entry.data_source,
-    comp.data_source,
-    family.data_source,
-  );
-
   const promotionLabel = pickCascade(
     entry.promotion_label,
     comp.promotion_label,
@@ -219,14 +272,11 @@ export function resolveSeasonInfo(
   )!;
 
   const notes = [
-    ...toArray(family.note),
-    ...toArray(comp.note),
-    ...toArray(entry.note),
-    ...generateRuleNotes(pointSystem, tiebreakOrder, aggregateTiebreakOrder),
+    ...base.rawNotes,
+    ...generateRuleNotes(base.pointSystem, base.tiebreakOrder, base.aggregateTiebreakOrder),
   ];
 
-  const viewTypes = mergeUniqueArrays(family.view_type, comp.view_type, entry.view_type);
-  const bracketDefaultCount = viewTypes.includes('bracket') ? 0 : undefined;
+  const bracketDefaultCount = base.viewTypes.includes('bracket') ? 0 : undefined;
   const inferredTeamCount = entry.teams && entry.teams.length > 0 ? entry.teams.length : undefined;
   const teamCount = requireCascade('team_count', entry.team_count, comp.team_count, inferredTeamCount);
   const promotionCount = requireCascade(
@@ -250,18 +300,42 @@ export function resolveSeasonInfo(
     rankClass: entry.rank_properties ?? {},
     groupDisplay: entry.group_display,
     urlCategory: entry.url_category,
-    leagueDisplay,
-    pointSystem,
-    cssFiles,
+    leagueDisplay: base.leagueDisplay,
+    pointSystem: base.pointSystem,
+    cssFiles: base.cssFiles,
     teamRenameMap,
-    tiebreakOrder,
+    tiebreakOrder: base.tiebreakOrder,
     seasonStartMonth,
     shownGroups,
     crossGroupStanding,
     groupTeamCount,
-    dataSource,
+    dataSource: base.dataSource,
     notes,
     promotionLabel,
-    viewTypes: viewTypes.length > 0 ? viewTypes : ['league'],
+    viewTypes: base.viewTypes,
+  };
+}
+
+export function resolveTournamentSeasonInfo(
+  family: CompetitionFamilyEntry,
+  comp: CompetitionEntry,
+  entry: RawSeasonEntry,
+  familyKey: string = '',
+): TournamentSeasonInfo {
+  const base = resolveBaseFields(family, comp, entry, familyKey);
+
+  return {
+    cssFiles: base.cssFiles,
+    leagueDisplay: base.leagueDisplay,
+    notes: base.rawNotes,
+    viewTypes: base.viewTypes,
+    dataSource: base.dataSource,
+    aggregateTiebreakOrder: base.aggregateTiebreakOrder,
+    defaultRoundStart: entry.bracket_round_start
+      ? normalizeBracketRoundLabel(entry.bracket_round_start)
+      : undefined,
+    roundStartOptions: entry.round_start_options?.map((option) => (
+      option === MULTI_SECTION_VALUE ? option : normalizeBracketRoundLabel(option)
+    )),
   };
 }

--- a/frontend/src/core/prepare-render.ts
+++ b/frontend/src/core/prepare-render.ts
@@ -4,7 +4,7 @@
 // making it testable without any DOM dependency.
 
 import type { TeamData } from '../types/match';
-import type { SeasonInfo } from '../types/season';
+import type { LeagueSeasonInfo } from '../types/season';
 import { calculateTeamStats } from '../ranking/stats-calculator';
 import type { MatchSortKey } from '../ranking/stats-calculator';
 import { getSortedTeamList } from './sorter';
@@ -13,8 +13,8 @@ import { getSortedTeamList } from './sorter';
 export interface PrepareRenderInput {
   /** Raw group data from the CSV cache (will be deep-copied, not mutated). */
   groupData: Record<string, TeamData>;
-  /** Fully resolved season info (from resolveSeasonInfo). */
-  seasonInfo: SeasonInfo;
+  /** Fully resolved season info (from resolveLeagueSeasonInfo). */
+  seasonInfo: LeagueSeasonInfo;
   /** Display cutoff date in 'YYYY/MM/DD' format. */
   targetDate: string;
   /** Team sort key (e.g. 'point', 'disp_avlbl_pt'). */

--- a/frontend/src/graph/renderer.ts
+++ b/frontend/src/graph/renderer.ts
@@ -4,7 +4,7 @@
 // is responsible for inserting the returned fragment into the DOM.
 
 import type { TeamData } from '../types/match';
-import type { SeasonInfo } from '../types/season';
+import type { LeagueSeasonInfo } from '../types/season';
 import { PRESEASON_SENTINEL } from '../core/date-slider';
 import { getPointHeightScale } from '../core/point-calculator';
 import { buildTeamColumn } from './bar-column';
@@ -29,7 +29,7 @@ export interface RenderResult {
  *
  * Example: teamCount=20, promotion=3, relegation=4 → [3, 10, 16]
  */
-export function getScaleColumnPositions(seasonInfo: SeasonInfo): number[] {
+export function getScaleColumnPositions(seasonInfo: LeagueSeasonInfo): number[] {
   const columns: number[] = [Math.floor(seasonInfo.teamCount / 2)];
   if (seasonInfo.promotionCount !== 0) columns.unshift(seasonInfo.promotionCount);
   if (seasonInfo.relegationCount !== 0) columns.push(seasonInfo.teamCount - seasonInfo.relegationCount);
@@ -88,7 +88,7 @@ export function assembleTeamColumn(
   maxAvblPt: number,
   heightUnit: number,
   bottomFirst: boolean,
-  seasonInfo: SeasonInfo,
+  seasonInfo: LeagueSeasonInfo,
 ): HTMLDivElement {
   // Clone arrays so we don't mutate the original ColumnResult.
   const graph = [...col.graph];
@@ -166,7 +166,7 @@ export function assembleTeamColumn(
 export function renderBarGraph(
   groupData: Record<string, TeamData>,
   sortedTeams: string[],
-  seasonInfo: SeasonInfo,
+  seasonInfo: LeagueSeasonInfo,
   targetDate: string,
   disp: boolean,
   bottomFirst: boolean,

--- a/frontend/src/graph/tooltip.ts
+++ b/frontend/src/graph/tooltip.ts
@@ -2,7 +2,7 @@
 // None of these functions access the DOM or global state.
 
 import type { TeamMatch, TeamStats } from '../types/match';
-import type { SeasonInfo } from '../types/season';
+import type { LeagueSeasonInfo } from '../types/season';
 import { dateOnly, timeFormat } from '../core/date-utils';
 import { t } from '../i18n';
 
@@ -81,7 +81,7 @@ export function joinLossBox(lossBox: string[]): string {
  * Returns the CSS class name for a given rank within a season.
  * Priority: custom rankClass entry → 'promoted' → 'relegated' → '' (no class).
  */
-export function getRankClass(rank: number, seasonInfo: SeasonInfo): string {
+export function getRankClass(rank: number, seasonInfo: LeagueSeasonInfo): string {
   const custom = seasonInfo.rankClass[String(rank)];
   if (custom) return custom;
   if (rank <= seasonInfo.promotionCount) return 'promoted';

--- a/frontend/src/ranking/rank-table.ts
+++ b/frontend/src/ranking/rank-table.ts
@@ -1,7 +1,7 @@
 // Ranking table data builder and renderer: port of make_rankdata / make_ranktable.
 
 import type { TeamData, TeamMatch } from '../types/match';
-import type { SeasonInfo, CrossGroupStanding } from '../types/season';
+import type { LeagueSeasonInfo, CrossGroupStanding } from '../types/season';
 import {
   getStats,
   getSafetyLine,
@@ -108,7 +108,7 @@ function getAllRestGame(teams: Record<string, TeamData>): number {
 export function makeRankData(
   groupData: Record<string, TeamData>,
   teamList: string[],
-  seasonInfo: SeasonInfo,
+  seasonInfo: LeagueSeasonInfo,
   disp: boolean,
   hasPk: boolean = false,
   hasEx: boolean = false,

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -11,6 +11,7 @@ import type {
   BracketBlock,
   AggregateTiebreakCriterion,
   RawSeasonEntry,
+  TournamentSeasonInfo,
 } from './types/season';
 import {
   loadSeasonMap, getCsvFilename, findCompetition, resolveTournamentSeasonInfo,
@@ -40,16 +41,12 @@ import type { BracketNode } from './bracket/bracket-types';
 interface BracketState {
   csvRows: RawMatchRow[];
   bracketOrder: (string | null)[];
-  aggregateTiebreakOrder: AggregateTiebreakCriterion[];
+  seasonInfo: TournamentSeasonInfo;
   fullRoot: BracketNode;        // full tree built from bracketOrder
   roundsByDepth: string[];      // round labels root-to-leaf (e.g. ['決勝戦','準決勝','準々決勝','ラウンド16'])
   allRounds: string[];          // all CSV rounds in chronological order
-  defaultRoundStart?: string;   // from season_map bracket_round_start
-  roundStartOptions?: string[];
   bracketBlocks?: BracketBlock[];  // multi-section definitions from season_map
   matchDates: string[];         // sorted unique dates from CSV
-  cssFiles: string[];
-  leagueDisplay: string;
   season: string;
 }
 
@@ -494,24 +491,24 @@ function buildAndRenderBracket(
 }
 
 function createSingleBracketRenderInput(
-  state: Pick<BracketState, 'csvRows' | 'aggregateTiebreakOrder' | 'matchDates' | 'cssFiles'>,
+  state: Pick<BracketState, 'csvRows' | 'seasonInfo' | 'matchDates'>,
   order: (string | null)[],
 ): SingleBracketRenderInput | null {
   if (order.length < 2 || state.matchDates.length === 0) return null;
   return {
     rows: state.csvRows,
     order,
-    aggregateTiebreakOrder: state.aggregateTiebreakOrder,
+    aggregateTiebreakOrder: state.seasonInfo.aggregateTiebreakOrder,
     targetDate: getTargetDate(),
     lastDate: state.matchDates[state.matchDates.length - 1],
-    cssFiles: state.cssFiles,
+    cssFiles: state.seasonInfo.cssFiles,
   };
 }
 
 function createInclusiveBracketRenderInput(
   state: Pick<
   BracketState,
-  'csvRows' | 'aggregateTiebreakOrder' | 'matchDates' | 'cssFiles' |
+  'csvRows' | 'seasonInfo' | 'matchDates' |
   'fullRoot' | 'bracketOrder' | 'roundsByDepth' | 'allRounds'
   >,
 ): SingleBracketRenderInput | null {
@@ -766,16 +763,12 @@ function loadAndRender(seasonMap: SeasonMap): void {
       currentState = {
         csvRows: bracketRows,
         bracketOrder,
-        aggregateTiebreakOrder: tournamentSeasonInfo.aggregateTiebreakOrder,
+        seasonInfo: tournamentSeasonInfo,
         fullRoot,
         roundsByDepth,
         allRounds,
-        defaultRoundStart: tournamentSeasonInfo.defaultRoundStart,
-        roundStartOptions: tournamentSeasonInfo.roundStartOptions,
         bracketBlocks,
         matchDates,
-        cssFiles: tournamentSeasonInfo.cssFiles,
-        leagueDisplay: tournamentSeasonInfo.leagueDisplay,
         season,
       };
 

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -13,7 +13,7 @@ import type {
   RawSeasonEntry,
 } from './types/season';
 import {
-  loadSeasonMap, getCsvFilename, findCompetition, resolveSeasonInfo,
+  loadSeasonMap, getCsvFilename, findCompetition, resolveTournamentSeasonInfo,
   getCompetitionViewTypes,
 } from './config/season-map';
 import {
@@ -726,13 +726,13 @@ function loadAndRender(seasonMap: SeasonMap): void {
       const rawSections = entry.bracket_blocks
         ? resolveSectionBracketOrders(entry.bracket_blocks, seasonTeams)
         : undefined;
-      const resolvedEntry: RawSeasonEntry = {
+      const resolvedEntry = {
         ...entry,
         teams: seasonTeams,
         team_count: entry.team_count ?? (seasonTeams.length > 0 ? seasonTeams.length : undefined),
         bracket_blocks: rawSections,
       };
-      const seasonInfo = resolveSeasonInfo(
+      const tournamentSeasonInfo = resolveTournamentSeasonInfo(
         found.family, found.competition, resolvedEntry, found.familyKey,
       );
       const bracketOrder = resolveSeasonBracketOrder(entry, inferredOrder);
@@ -740,13 +740,6 @@ function loadAndRender(seasonMap: SeasonMap): void {
         setStatus('No bracket data for this season.');
         return;
       }
-      const defaultRoundStart = entry.bracket_round_start
-        ? normalizeBracketRoundLabel(entry.bracket_round_start)
-        : undefined;
-      const roundStartOptions = entry.round_start_options?.map((option) => (
-        option === MULTI_SECTION_VALUE ? option : normalizeBracketRoundLabel(option)
-      ));
-      const aggregateTiebreakOrder = entry.aggregate_tiebreak_order ?? ['penalties'];
       const resolved = rawSections
         ? resolveSectionRoundFilters(rawSections, entry.default_round_filter)
         : undefined;
@@ -757,7 +750,11 @@ function loadAndRender(seasonMap: SeasonMap): void {
       const matchDates = collectMatchDates(bracketRows);
 
       // Build full tree to extract round structure and pre-populate cache
-      const fullRoot = buildBracket(bracketRows, bracketOrder, aggregateTiebreakOrder);
+      const fullRoot = buildBracket(
+        bracketRows,
+        bracketOrder,
+        tournamentSeasonInfo.aggregateTiebreakOrder,
+      );
       bracketCache = new Map();
       bracketCache.set(JSON.stringify(bracketOrder), fullRoot);
       const roundsByDepth = collectRoundsByDepth(fullRoot);
@@ -769,25 +766,25 @@ function loadAndRender(seasonMap: SeasonMap): void {
       currentState = {
         csvRows: bracketRows,
         bracketOrder,
-        aggregateTiebreakOrder,
+        aggregateTiebreakOrder: tournamentSeasonInfo.aggregateTiebreakOrder,
         fullRoot,
         roundsByDepth,
         allRounds,
-        defaultRoundStart,
-        roundStartOptions,
+        defaultRoundStart: tournamentSeasonInfo.defaultRoundStart,
+        roundStartOptions: tournamentSeasonInfo.roundStartOptions,
         bracketBlocks,
         matchDates,
-        cssFiles: seasonInfo.cssFiles,
-        leagueDisplay: seasonInfo.leagueDisplay,
+        cssFiles: tournamentSeasonInfo.cssFiles,
+        leagueDisplay: tournamentSeasonInfo.leagueDisplay,
         season,
       };
 
       // Populate round start dropdown (with multi-section option if sections exist)
       populateRoundStartPulldown(
         allRounds,
-        defaultRoundStart,
+        tournamentSeasonInfo.defaultRoundStart,
         bracketBlocks != null,
-        roundStartOptions,
+        tournamentSeasonInfo.roundStartOptions,
       );
 
       // Sync round start: restore from controlState or pick up dropdown default
@@ -829,7 +826,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
           t('bracketNote.etIncluded'),
           t('bracketNote.pkAnnotation'),
         ];
-        for (const text of [...seasonInfo.notes, ...bracketNotes]) {
+        for (const text of [...tournamentSeasonInfo.notes, ...bracketNotes]) {
           const li = document.createElement('li');
           li.textContent = text;
           notesEl.appendChild(li);
@@ -837,7 +834,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
       }
 
       setStatus(t('status.loaded', {
-        league: seasonInfo.leagueDisplay, season, rows: bracketRows.length,
+        league: tournamentSeasonInfo.leagueDisplay, season, rows: bracketRows.length,
       }));
     },
     error: (err: unknown) => {

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -109,9 +109,18 @@ export interface CompetitionFamilyEntry extends SeasonEntryOptions {
 // The entire season_map.yaml: family key → CompetitionFamilyEntry.
 export type SeasonMap = Record<string, CompetitionFamilyEntry>;
 
-// Object form of a fully resolved season entry.
-// Use resolveSeasonInfo() (in season-map.ts) for cascade resolution.
-export interface SeasonInfo {
+// Fields shared by league and tournament season resolution.
+export interface BaseSeasonInfo {
+  leagueDisplay: string;
+  cssFiles: string[];
+  dataSource?: DataSource;
+  notes: string[];
+  viewTypes: ViewType[];
+}
+
+// Object form of a fully resolved league season entry.
+// Use resolveLeagueSeasonInfo() (in season-map.ts) for cascade resolution.
+export interface LeagueSeasonInfo extends BaseSeasonInfo {
   teamCount: number;
   promotionCount: number;
   relegationCount: number;
@@ -119,17 +128,20 @@ export interface SeasonInfo {
   rankClass: RankClassMap;
   groupDisplay?: string;
   urlCategory?: string;
-  leagueDisplay: string;
   pointSystem: PointSystem;
-  cssFiles: string[];
   teamRenameMap: Record<string, string>;
   tiebreakOrder: string[];
   seasonStartMonth: number;
   shownGroups?: string[];
   crossGroupStanding?: CrossGroupStanding;
   groupTeamCount?: Record<string, number>;
-  dataSource?: DataSource;
-  notes: string[];
   promotionLabel: string;
-  viewTypes: ViewType[];
+}
+
+// Object form of a fully resolved tournament season entry.
+// Use resolveTournamentSeasonInfo() (in season-map.ts) for cascade resolution.
+export interface TournamentSeasonInfo extends BaseSeasonInfo {
+  aggregateTiebreakOrder: AggregateTiebreakCriterion[];
+  defaultRoundStart?: string;
+  roundStartOptions?: string[];
 }


### PR DESCRIPTION
Fixes #237

## Summary
- tournament 向けの `resolveTournamentSeasonInfo()` を導入し、`tournament-app.ts` の ad-hoc な season 情報解決を `season-map.ts` 側へ集約しました
- `SeasonInfo` を `BaseSeasonInfo` / `LeagueSeasonInfo` / `TournamentSeasonInfo` に分割し、league / tournament で必要な型責務を分離しました
- `BracketState` は `seasonInfo: TournamentSeasonInfo` を保持する形へ整理し、bracket 描画入力もその object から必要値を参照するよう統一しました

## Changes
| Commit | Description |
|--------|-------------|
| `6fcbda1` | `resolveTournamentSeasonInfo()` を追加し、tournament 向けの season cascade 解決を正式化 |
| `bac8538` | `SeasonInfo` を `BaseSeasonInfo` / `LeagueSeasonInfo` / `TournamentSeasonInfo` へ分割 |
| `9994462` | `BracketState` と bracket render input を `TournamentSeasonInfo` 中心の shape に整理 |

## Test plan
- [x] `npm run typecheck` passed (`frontend/`)
- [x] `npm test` passed (`frontend/`)
- [x] `npm run build` succeeded (`frontend/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)