### PR TITLE
Wrap multi-group bar graph into block rows when row team count exceeds threshold

### DIFF
--- a/docs/j_points.css
+++ b/docs/j_points.css
@@ -89,6 +89,26 @@ p {
   align-self: flex-start;
 }
 
+/* Multi-group: stack block rows vertically; each row is a horizontal flex row.
+   Single-group keeps the default #box_container row layout above. */
+#box_container.blockrows {
+  flex-direction: column;
+  align-items: flex-start;
+  /* Stacked block rows scale from the top: the overridden box height matches the
+     scaled content top-down, so bottom-origin (used for the single-row layout)
+     would push content below the box and leave a gap above. */
+  transform-origin: left top;
+}
+.group_block_row {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+}
+/* Leave room below each row for the group labels (positioned at bottom: -25px). */
+#box_container.blockrows .group_block_row {
+  margin-bottom: 35px;
+}
+
 .group_wrapper {
   display: flex;
   flex-direction: row;

--- a/frontend/e2e/multi-group.spec.ts
+++ b/frontend/e2e/multi-group.spec.ts
@@ -10,6 +10,9 @@ test.describe('T6: Multi-Group Rendering', () => {
     const groups = page.locator('#box_container .group_wrapper');
     expect(await groups.count()).toBe(3);
 
+    // 3 small groups stay within the default 16-team row threshold → single block row.
+    expect(await page.locator('#box_container .group_block_row').count()).toBe(1);
+
     // Group labels present with prefix
     const labels = page.locator('#box_container .group_label');
     expect(await labels.count()).toBe(3);
@@ -41,6 +44,10 @@ test.describe('T6: Multi-Group Rendering', () => {
     const groups = page.locator('#box_container .group_wrapper');
     expect(await groups.count()).toBe(0);
 
+    // Single-group never wraps into block rows.
+    expect(await page.locator('#box_container .group_block_row').count()).toBe(0);
+    expect(await page.locator('#box_container.blockrows').count()).toBe(0);
+
     await assertInvariants(page);
   });
 
@@ -51,6 +58,13 @@ test.describe('T6: Multi-Group Rendering', () => {
     // 12 groups (A..L).
     const groups = page.locator('#box_container .group_wrapper');
     expect(await groups.count()).toBe(12);
+
+    // 12 groups × 4 teams wrap at the default 16-team threshold → 3 block rows of 4.
+    const blockRows = page.locator('#box_container .group_block_row');
+    expect(await blockRows.count()).toBe(3);
+    for (let i = 0; i < 3; i++) {
+      expect(await blockRows.nth(i).locator('.group_wrapper').count()).toBe(4);
+    }
 
     // interior_point_columns: false → each group keeps only the two edge
     // point columns, no mid-table axis splitting the 4 teams.

--- a/frontend/src/__tests__/config/season-map.test.ts
+++ b/frontend/src/__tests__/config/season-map.test.ts
@@ -403,6 +403,29 @@ describe('resolveLeagueSeasonInfo', () => {
     );
   });
 
+  test('maxRowTeams defaults to 16 when not set at any level', () => {
+    const entry: RawSeasonEntry = { team_count: 20, promotion_count: 3, relegation_count: 3, teams: [] };
+    const info = resolveLeagueSeasonInfo(sampleFamily, sampleFamily.competitions.J1, entry);
+
+    expect(info.maxRowTeams).toBe(16);
+  });
+
+  test('cascade: max_row_teams from competition level', () => {
+    const comp: CompetitionEntry = { max_row_teams: 20, seasons: {} };
+    const entry: RawSeasonEntry = { team_count: 4, promotion_count: 0, relegation_count: 0, teams: [] };
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
+
+    expect(info.maxRowTeams).toBe(20);
+  });
+
+  test('cascade: max_row_teams from season overrides competition', () => {
+    const comp: CompetitionEntry = { max_row_teams: 20, seasons: {} };
+    const entry: RawSeasonEntry = { team_count: 4, promotion_count: 0, relegation_count: 0, teams: [], max_row_teams: 12 };
+    const info = resolveLeagueSeasonInfo(sampleFamily, comp, entry);
+
+    expect(info.maxRowTeams).toBe(12);
+  });
+
   test('cascade: notes append family, competition, season, and generated rule notes', () => {
     const family: CompetitionFamilyEntry = {
       display_name: 'Test',

--- a/frontend/src/__tests__/fixtures/match-data.ts
+++ b/frontend/src/__tests__/fixtures/match-data.ts
@@ -49,6 +49,7 @@ export function makeLeagueSeasonInfo(
     tiebreakOrder: ['goal_diff', 'goal_get'],
     seasonStartMonth: 7,
     interiorPointColumns: true,
+    maxRowTeams: 16,
     notes: [],
     promotionLabel: '昇格',
     viewTypes: ['league'],

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -318,7 +318,17 @@ function renderFromCache(
   const globalMatchDateSet = new Set<string>();
   const allTeamCssClasses: string[] = [];
   const boxCon = document.getElementById('box_container') as HTMLElement | null;
-  if (boxCon) boxCon.replaceChildren();
+  if (boxCon) {
+    boxCon.replaceChildren();
+    // Multi-group graphs are laid out as stacked block rows (column); single-group
+    // keeps the original single horizontal row.
+    boxCon.classList.toggle('blockrows', isMultiGroup);
+  }
+
+  // Block-row wrapping state (multi-group only): accumulate team counts and wrap to
+  // a new .group_block_row once the next group would exceed maxRowTeams.
+  let currentBlockRow: HTMLElement | null = null;
+  let currentRowTeams = 0;
 
   // Prepare ranking table container.
   const sortableDiv = document.querySelector('#ranktable_section .sortable-table') as HTMLElement | null;
@@ -361,7 +371,20 @@ function renderFromCache(
         label.textContent = t('graph.group', { key: groupKey });
         wrapper.appendChild(label);
         wrapper.appendChild(fragment);
-        boxCon.appendChild(wrapper);
+
+        // Start a new block row when the current one would overflow maxRowTeams.
+        // Use the actual rendered column count (sortedTeams.length), not the config
+        // team count. Wrapping happens only at group boundaries (a group is never split).
+        const rowTeams = sortedTeams.length;
+        if (currentBlockRow === null
+            || (currentRowTeams > 0 && currentRowTeams + rowTeams > seasonInfo.maxRowTeams)) {
+          currentBlockRow = document.createElement('div');
+          currentBlockRow.classList.add('group_block_row');
+          boxCon.appendChild(currentBlockRow);
+          currentRowTeams = 0;
+        }
+        currentBlockRow.appendChild(wrapper);
+        currentRowTeams += rowTeams;
       } else {
         boxCon.appendChild(fragment);
       }

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -251,6 +251,13 @@ export function resolveLeagueSeasonInfo(
     true,
   )!;
 
+  const maxRowTeams = pickCascade(
+    entry.max_row_teams,
+    comp.max_row_teams,
+    family.max_row_teams,
+    16,
+  )!;
+
   // group_team_count currently cascades only competition -> season.
   const compGroupTeamCount = expandScalarDefault(comp.group_team_count, shownGroups, 'group_team_count');
   const entryGroupTeamCount = expandScalarDefault(entry.group_team_count, shownGroups, 'group_team_count');
@@ -302,6 +309,7 @@ export function resolveLeagueSeasonInfo(
     shownGroups,
     crossGroupStanding,
     interiorPointColumns,
+    maxRowTeams,
     groupTeamCount,
     dataSource: base.dataSource,
     notes,

--- a/frontend/src/graph/css-utils.ts
+++ b/frontend/src/graph/css-utils.ts
@@ -94,19 +94,39 @@ export function setSpace(value: string, updateColorPicker = true): void {
   }
 }
 
+// Vertical gap below each block row; keep in sync with the
+// `.group_block_row` margin-bottom in docs/j_points.css.
+const BLOCK_ROW_GAP = 35;
+
+/** Largest .point_column clientHeight within a root element (0 if none). */
+function maxPointColumnHeight(root: ParentNode): number {
+  let maxHeight = 0;
+  for (const pCol of Array.from(root.querySelectorAll('.point_column'))) {
+    maxHeight = Math.max(maxHeight, (pCol as HTMLElement).clientHeight);
+  }
+  return maxHeight;
+}
+
 /**
  * Applies CSS transform scale to boxCon and adjusts its height.
- * Height is set to .point_column clientHeight × scale to prevent overflow.
+ * Height is set to the unscaled content height × scale to prevent overflow.
+ * Single row → max .point_column height. Multi-group block rows (.group_block_row)
+ * → sum of each row's max height plus the inter-row gaps.
  * updateSlider=true (default) → also updates #scale_slider value and #current_scale display.
  */
 export function setScale(boxCon: HTMLElement, value: string, updateSlider = true): void {
   boxCon.style.transform = `scale(${value})`;
-  let maxHeight = 0;
-  for (const pCol of Array.from(boxCon.querySelectorAll('.point_column'))) {
-    maxHeight = Math.max(maxHeight, (pCol as HTMLElement).clientHeight);
+  const blockRows = Array.from(boxCon.querySelectorAll('.group_block_row'));
+  let contentHeight = 0;
+  if (blockRows.length > 0) {
+    for (const row of blockRows) {
+      contentHeight += maxPointColumnHeight(row) + BLOCK_ROW_GAP;
+    }
+  } else {
+    contentHeight = maxPointColumnHeight(boxCon);
   }
-  if (maxHeight > 0) {
-    boxCon.style.height = `${maxHeight * parseFloat(value)}px`;
+  if (contentHeight > 0) {
+    boxCon.style.height = `${contentHeight * parseFloat(value)}px`;
   }
   if (updateSlider) {
     const slider = document.getElementById('scale_slider') as HTMLInputElement | null;

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -71,6 +71,10 @@ export interface SeasonEntryOptions {
   // columns. Edge point columns are always shown. Default true. Set false for
   // small grouped competitions (e.g. World Cup 4-team groups) to avoid clutter.
   interior_point_columns?: boolean;
+  // Max team count placed in one horizontal block row before wrapping multi-group
+  // bar graphs to the next row. Wrapping happens only at group boundaries (a group
+  // is never split). Default 16. Single-group leagues never wrap.
+  max_row_teams?: number;
   group_team_count?: number | Record<string, number>;
   note?: string | string[];
   data_source?: DataSource;
@@ -139,6 +143,7 @@ export interface LeagueSeasonInfo extends BaseSeasonInfo {
   shownGroups?: string[];
   crossGroupStanding?: CrossGroupStanding;
   interiorPointColumns: boolean;
+  maxRowTeams: number;
   groupTeamCount?: Record<string, number>;
   promotionLabel: string;
 }

--- a/src/match_utils.py
+++ b/src/match_utils.py
@@ -126,7 +126,7 @@ class SeasonEntry:
         'league_display', 'point_system', 'css_files',
         'team_rename_map', 'tiebreak_order', 'season_start_month',
         'shown_groups', 'cross_group_standing', 'interior_point_columns',
-        'group_team_count',
+        'group_team_count', 'max_row_teams',
         'note', 'data_source', 'promotion_label',
         'aggregate_tiebreak_order',
         'bracket_order', 'bracket_round_start', 'round_start_options',


### PR DESCRIPTION
## 概要

W杯グループステージ (`WC_GS 2026`、12グループ/48チーム) のように多グループを横一列に並べると破綻するため、1行に並ぶチーム数が閾値を超えたら次のグループからブロック行へ折り返すレイアウトを導入する。単一グループのリーグ戦は従来どおり折り返さない。

## 変更内容

| 変更 | 内容 |
| --- | --- |
| cascade オプション | `max_row_teams` (camelCase `maxRowTeams`、デフォルト 16) を追加。Python `OPTIONAL_KEYS` / TS `SeasonEntryOptions`・`LeagueSeasonInfo` / `resolveLeagueSeasonInfo` カスケード |
| バーグラフ描画 | 実描画列数 (`sortedTeams.length`) を累積し、閾値超過で `.group_block_row` を改行 (グループ境界でのみ折り返し) |
| CSS | `.group_block_row` 追加、複数行時 `#box_container.blockrows` を縦積み。縮小時は `transform-origin: left top` |
| `setScale()` | 高さをブロック行ごとの最大高の和 × scale に修正 |

## テスト計画

- [x] vitest 511 passed (cascade テスト3件追加)
- [x] pytest 110 passed
- [x] `check_type_sync.py` 通過
- [x] `npm run typecheck` 通過
- [x] `npm run build` 成功
- [x] e2e multi-group 6 passed (WC_GS=3行×4 / WE Cup=1行 / 単一=ブロック行なし)
- [x] ブラウザ目視: 縮小時の余白・重なり解消を確認

Fixes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)