### PR TITLE
Keep rank table team names on a single line

### DIFF
--- a/docs/j_points.css
+++ b/docs/j_points.css
@@ -219,6 +219,9 @@ table.ranktable td {
 table.ranktable td div {
   text-align: center;
 }
+table.ranktable [data-rank-team-name] {
+  white-space: nowrap;
+}
 table.ranktable th {
   border-bottom: solid 2px #222;
 }

--- a/frontend/e2e/rank-table.spec.ts
+++ b/frontend/e2e/rank-table.spec.ts
@@ -19,6 +19,15 @@ test.describe('T5: Rank Table', () => {
     expect(headers).toContain('loss');
   });
 
+  test('team names do not wrap', async ({ page }) => {
+    await page.goto('/j_points.html?competition=J1&season=2024');
+    await waitForRender(page);
+
+    const teamNames = page.locator('table.ranktable [data-rank-team-name]');
+    await expect(teamNames.first()).toBeVisible();
+    await expect(teamNames.first()).toHaveCSS('white-space', 'nowrap');
+  });
+
   test('sortable header click changes row order', async ({ page }) => {
     await page.goto('/j_points.html?competition=J1&season=2024');
     await waitForRender(page);

--- a/frontend/src/__tests__/ranking/rank-table.test.ts
+++ b/frontend/src/__tests__/ranking/rank-table.test.ts
@@ -534,9 +534,9 @@ describe('makeRankData – row shape', () => {
     }),
   };
 
-  test('name is wrapped in a div with the team name as class and text', () => {
+  test('name is wrapped in a non-wrapping target div with the team name as class and text', () => {
     const rows = makeRankData(groupData, ['TeamA', 'TeamB'], seasonInfo, false);
-    expect(rows[0].name).toBe('<div class="TeamA">TeamA</div>');
+    expect(rows[0].name).toBe('<div class="TeamA" data-rank-team-name>TeamA</div>');
   });
 
   test('avrg_pt is formatted to 2 decimal places', () => {

--- a/frontend/src/ranking/rank-table.ts
+++ b/frontend/src/ranking/rank-table.ts
@@ -141,7 +141,7 @@ export function makeRankData(
 
     const row: RankRow = {
       rank,
-      name: `<div class="${teamCssClass(teamName)}">${teamName}</div>`,
+      name: `<div class="${teamCssClass(teamName)}" data-rank-team-name>${teamName}</div>`,
       win:         rc.win,
       ...(hasPk ? {
         pk_win:    rc.pk_win,
@@ -379,7 +379,7 @@ export function buildCrossGroupRows(
 
     rows.push({
       rank: groupKey,
-      name: `<div class="${teamCssClass(teamName)}">${teamName}</div>`,
+      name: `<div class="${teamCssClass(teamName)}" data-rank-team-name>${teamName}</div>`,
       all_game: stats.all_game,
       point: stats.point,
       avrg_pt: stats.avrg_pt.toFixed(2),


### PR DESCRIPTION
## 概要

順位表のチーム名が列幅に応じて複数行に折り返される問題を修正する。チーム名 div にマーカー属性 `data-rank-team-name` を付与し、`white-space: nowrap` を適用して常に1行で表示する。通常の順位表とグループ間比較表 (cross-group) の両方に適用。表示列の切り替えコントロールは追加せず、常時 nowrap とする (列切り替えは #257 で別途)。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `frontend/src/ranking/rank-table.ts` | `makeRankData` / `buildCrossGroupRows` のチーム名 div に `data-rank-team-name` 付与 |
| `docs/j_points.css` | `table.ranktable [data-rank-team-name] { white-space: nowrap; }` 追加 |
| `frontend/src/__tests__/ranking/rank-table.test.ts` | div 生成の期待値を更新 |
| `frontend/e2e/rank-table.spec.ts` | チーム名セルの computed style が `nowrap` であることを検証する E2E 追加 |

## テスト計画

- [x] `npm test` 全通過 (512 tests)
- [x] `npm run typecheck` 通過
- [x] `npm run build` 成功

Fixes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
