### PR TITLE
Show per-competition data source links (WC/Olympic/Prince)

### DIFF
--- a/docs/yaml/season_map.yaml
+++ b/docs/yaml/season_map.yaml
@@ -1006,11 +1006,17 @@ national:
           promotion_count: 0
           relegation_count: 0
           teams: []
+          data_source:
+            label: 'JFA公式: FIFAワールドカップ22'
+            url: https://www.jfa.jp/national_team/samuraiblue/worldcup_2022/
         '2026':
           team_count: 48
           promotion_count: 2
           relegation_count: 0
           teams: []
+          data_source:
+            label: 'JFA公式: FIFAワールドカップ26'
+            url: https://www.jfa.jp/national_team/samuraiblue/worldcup_2026/
           shown_groups: [A, B, C, D, E, F, G, H, I, J, K, L]
           interior_point_columns: false
           rank_properties:
@@ -1059,6 +1065,9 @@ national:
           promotion_count: 2
           relegation_count: 0
           teams: []
+          data_source:
+            label: 'JFA公式: W杯アジア最終予選26'
+            url: https://www.jfa.jp/national_team/samuraiblue/worldcup_2026/final_q_2026/
           shown_groups: [A, B, C]
     Olympic_GS:
       league_display: オリンピック GS
@@ -1079,11 +1088,17 @@ national:
           promotion_count: 2
           relegation_count: 0
           teams: []
+          data_source:
+            label: 'JFA公式: 東京オリンピック'
+            url: https://www.jfa.jp/national_team/u24_2021/tokyo_olympic_2020/
         '2024':
           team_count: 4
           promotion_count: 2
           relegation_count: 0
           teams: []
+          data_source:
+            label: 'JFA公式: パリオリンピック'
+            url: https://www.jfa.jp/national_team/u23_2024/paris_olympic_2024_men/
 acl:
   display_name: ACL
   css_files: [team_style.css]
@@ -1194,6 +1209,9 @@ prince:
           promotion_count: 0
           relegation_count: 0
           teams: []
+          data_source:
+            label: 'JFA公式: 高円宮杯U-18プレミアEAST'
+            url: https://www.jfa.jp/match/takamado_jfa_u18_premier2026/east/
     PrincePremierW:
       league_display: プレミアリーグWEST
       seasons:
@@ -1227,6 +1245,9 @@ prince:
           promotion_count: 0
           relegation_count: 0
           teams: []
+          data_source:
+            label: 'JFA公式: 高円宮杯U-18プレミアWEST'
+            url: https://www.jfa.jp/match/takamado_jfa_u18_premier2026/west/
     PrinceKanto:
       league_display: プリンスリーグ関東
       team_rename_map:
@@ -1263,6 +1284,9 @@ prince:
           promotion_count: 0
           relegation_count: 0
           teams: []
+          data_source:
+            label: 'JFA公式: 高円宮杯U-18プリンス関東'
+            url: https://jfa.jp/match_47fa/103_kanto/takamado_jfa_u18_prince2026/
 we:
   display_name: WEリーグ
   css_files: [team_style.css]

--- a/frontend/src/__tests__/config/season-map.test.ts
+++ b/frontend/src/__tests__/config/season-map.test.ts
@@ -263,6 +263,54 @@ describe('resolveLeagueSeasonInfo', () => {
     expect(info.tiebreakOrder).toEqual(['goal_diff', 'wins']);
   });
 
+  test('cascade: data_source from family level (inherited)', () => {
+    const family: CompetitionFamilyEntry = {
+      display_name: 'Test',
+      data_source: { label: 'Family Src', url: 'https://family.example/' },
+      competitions: {},
+    };
+    const comp: CompetitionEntry = { seasons: {} };
+    const entry: RawSeasonEntry = { team_count: 10, promotion_count: 0, relegation_count: 0, teams: [] };
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
+
+    expect(info.dataSource).toEqual({ label: 'Family Src', url: 'https://family.example/' });
+  });
+
+  test('cascade: data_source from competition overrides family', () => {
+    const family: CompetitionFamilyEntry = {
+      display_name: 'Test',
+      data_source: { label: 'Family Src', url: 'https://family.example/' },
+      competitions: {},
+    };
+    const comp: CompetitionEntry = {
+      data_source: { label: 'Comp Src', url: 'https://comp.example/' },
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = { team_count: 10, promotion_count: 0, relegation_count: 0, teams: [] };
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
+
+    expect(info.dataSource).toEqual({ label: 'Comp Src', url: 'https://comp.example/' });
+  });
+
+  test('cascade: data_source from season overrides competition and family', () => {
+    const family: CompetitionFamilyEntry = {
+      display_name: 'Test',
+      data_source: { label: 'Family Src', url: 'https://family.example/' },
+      competitions: {},
+    };
+    const comp: CompetitionEntry = {
+      data_source: { label: 'Comp Src', url: 'https://comp.example/' },
+      seasons: {},
+    };
+    const entry: RawSeasonEntry = {
+      team_count: 10, promotion_count: 0, relegation_count: 0, teams: [],
+      data_source: { label: 'Season Src', url: 'https://season.example/' },
+    };
+    const info = resolveLeagueSeasonInfo(family, comp, entry);
+
+    expect(info.dataSource).toEqual({ label: 'Season Src', url: 'https://season.example/' });
+  });
+
   test('seasonStartMonth defaults to 7 when not set anywhere', () => {
     const family: CompetitionFamilyEntry = { display_name: 'Test', competitions: {} };
     const comp: CompetitionEntry = { seasons: {} };


### PR DESCRIPTION
Fixes #256

## Summary

- 順位表下部の「データ参照元」リンクが、大会ごとの実際の取得元ではなく generic な Family リンク (特に Jリーグの `jleague.jp/match/`) を継承表示していた問題を修正
- WC_GS / WC_AFC / Olympic_GS / PrincePremierE/W / PrinceKanto の対象シーズンに `season_map.yaml` の Season 階層 `data_source` を補完し、カスケードで Family generic を上書き
- 推測 URL は作らず、reader config (`config/*.yaml`) に authoritative URL があるシーズンのみ上書き。`WC_AFC 2022`・`Prince 2021-2025` は URL 不明のため family default を継続
- JLeagueCup は J1 等と同じく J リーグページが実態のため対象外。WE/ACL/J1-J3 は family リンクが実態と一致しており変更なし

## Changes

| Commit | Description |
| --- | --- |
| `1aa79c4` | WC/Olympic/Prince 対象 8 シーズンに `data_source` を補完 |
| `ab6fba8` | `data_source` カスケード解決テスト 3 件を追加 |

## Test plan

- [x] `uv run pytest` passed (110)
- [x] `uv run python scripts/check_type_sync.py` passed
- [x] `uv run python scripts/check_point_system_csv.py` passed
- [x] `npx vitest run` passed (frontend/)
- [x] `npm run typecheck` passed
- [x] `npm run build` succeeded (frontend/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)