### PR TITLE
Add openfootball-based daily score patcher for WC2026

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,9 @@ JLeague_Matches-Bar_Graph/
 │   ├── set_config.py               #   設定管理 (YAML読み込み)
 │   ├── read_jleague_matches.py     #   Jリーグスクレイピング (BS4)
 │   ├── read_jfamatch.py            #   JFA JSON API データ取得
+│   ├── read_openfootball_wc.py     #   WC2026 日次スコア補完 (openfootball/worldcup.json)
 │   └── ...                         #   ACL, WEリーグ, cron生成等
-├── config/                          #   YAML設定 (jleague.yaml, jfamatch.yaml等)
+├── config/                          #   YAML設定 (jleague.yaml, jfamatch.yaml, openfootball.yaml等)
 ├── tests/                           #   pytest テストコード + test_data/
 ├── docs/                            # GitHub Pages 公開ディレクトリ
 │   ├── j_points.html, assets/      #   ★ ビルド生成物 (gitignore対象)
@@ -63,6 +64,7 @@ uv run pytest                                    # Python テスト実行
 uv run python src/read_jleague_matches.py        # Jリーグデータ取得 (差分更新)
 uv run python src/read_jleague_matches.py -f     # Jリーグデータ取得 (全更新)
 uv run python src/read_jfamatch.py <大会名>       # JFAデータ取得
+uv run python src/read_openfootball_wc.py        # WC2026 スコア補完 (--dry-run/--source 可)
 
 # === TypeScript フロントエンド (frontend/ で実行) ===
 npm test                  # vitest 実行 (npx vitest run)
@@ -201,6 +203,7 @@ uv run python scripts/check_type_sync.py
 ## 設計上の決定事項
 
 - **JFA JSON APIはCSVカラム名の参考情報源** — 新カラム追加時はJFA JSON構造を参照
+- **WC2026 スコアは openfootball が補完ソース** (`read_openfootball_wc.py`): allmatch CSV の生成 (日程・会場・TZ) は JFA リーダーが正本。`read_openfootball_wc.py` は openfootball/worldcup.json から `home_goal`/`away_goal`/`status` (+KO の延長/PK 列) のみを上書きし、JFA 反映遅延を埋める。照合は **GS=チーム名(EN→JP)+group / KO=openfootball `num`↔CSV `match_number`** (KO はプレースホルダ名に非依存)。EN→JP マッピングは `config/openfootball.yaml`。cron では JFA リーダーの**直後**に実行 (スケジュール生成→スコア上書きの順序)。openfootball スコア schema: `ft`(90分)/`et`(延長後・累積)/`p`(PK)。メインスコアは ET 込み、`home_score_ex`=`et`−`ft` の延長分のみ
 - **スクレイピング時のシーズン文字列は `config.season` (YAML) が正** — HTML読み取り値で上書きしない
 - **`get_sub_seasons(category)` の戻り値で更新動作が決まる**: `None` → スキップ / `[]` → 単一シーズン更新 / `[...]` → マルチグループ振り分け
 - **`match_utils.py` が共通ライブラリ** — CSV I/O, season_map 読み込み, 日付計算を提供。各 reader がインポートして使う

--- a/config/openfootball.yaml
+++ b/config/openfootball.yaml
@@ -1,0 +1,68 @@
+# openfootball/worldcup.json based daily score patcher for WC2026.
+#
+# This is a supplementary source: the allmatch CSVs (schedule, venue, timezone)
+# are generated and kept authoritative by read_jfamatch.py. This reader only
+# overwrites home_goal / away_goal / status from openfootball, which reflects
+# live scores faster than the JFA feed.
+#
+# Source: https://github.com/openfootball/worldcup.json (no API key, single curl).
+
+source_url: https://raw.githubusercontent.com/openfootball/worldcup.json/master/2026/worldcup.json
+
+# Target CSVs. GS matches are matched by team name + group (openfootball GS has
+# no match number); KO matches are matched by openfootball `num` <-> CSV
+# `match_number` (robust against placeholder team names in the bracket).
+group_stage_csv: ../docs/csv/2026_allmatch_result-WC_GS.csv
+knockout_csv: ../docs/csv/2026_allmatch_result-WC_KO.csv
+
+# openfootball English team name -> CSV Japanese team name (48 nations).
+# Validated 1:1 against the existing WC_GS CSV (names + home/away orientation).
+team_name_map:
+  Algeria: アルジェリア
+  Argentina: アルゼンチン
+  Australia: オーストラリア
+  Austria: オーストリア
+  Belgium: ベルギー
+  Bosnia & Herzegovina: ボスニア・ヘルツェゴビナ
+  Brazil: ブラジル
+  Canada: カナダ
+  Cape Verde: カーボベルデ
+  Colombia: コロンビア
+  Croatia: クロアチア
+  Curaçao: キュラソー
+  Czech Republic: チェコ
+  DR Congo: コンゴ
+  Ecuador: エクアドル
+  Egypt: エジプト
+  England: イングランド
+  France: フランス
+  Germany: ドイツ
+  Ghana: ガーナ
+  Haiti: ハイチ
+  Iran: イラン
+  Iraq: イラク
+  Ivory Coast: コートジボワール
+  Japan: 日本
+  Jordan: ヨルダン
+  Mexico: メキシコ
+  Morocco: モロッコ
+  Netherlands: オランダ
+  New Zealand: ニュージーランド
+  Norway: ノルウェー
+  Panama: パナマ
+  Paraguay: パラグアイ
+  Portugal: ポルトガル
+  Qatar: カタール
+  Saudi Arabia: サウジアラビア
+  Scotland: スコットランド
+  Senegal: セネガル
+  South Africa: 南アフリカ
+  South Korea: 韓国
+  Spain: スペイン
+  Sweden: スウェーデン
+  Switzerland: スイス
+  Tunisia: チュニジア
+  Turkey: トルコ
+  USA: アメリカ
+  Uruguay: ウルグアイ
+  Uzbekistan: ウズベキスタン

--- a/config/openfootball.yaml
+++ b/config/openfootball.yaml
@@ -8,6 +8,15 @@
 # Source: https://github.com/openfootball/worldcup.json (no API key, single curl).
 
 source_url: https://raw.githubusercontent.com/openfootball/worldcup.json/master/2026/worldcup.json
+http_timeout: 60
+
+# Used by MatchUtils.update_if_diff -> update_timestamp to record the update
+# time (shared with read_jfamatch.py so the frontend "last updated" stamp moves
+# when openfootball patches a score).
+timezone: "Asia/Tokyo"
+standard_date_format: "%Y/%m/%d"
+paths:
+  timestamp_file: "../docs/csv/csv_timestamp.csv"
 
 # Target CSVs. GS matches are matched by team name + group (openfootball GS has
 # no match number); KO matches are matched by openfootball `num` <-> CSV

--- a/scripts/call_update_csv.sh
+++ b/scripts/call_update_csv.sh
@@ -15,10 +15,14 @@ if [ $RUNNING_HOUR -eq 1 ]; then
   # 日ごと深夜自動実行 ⇒ 全CSVのアップデートを実行
   uv run python src/read_jleague_matches.py -f
   uv run python src/read_jfamatch.py PrincePremierE PrincePremierW PrinceKanto WC2026 WC2026KO
+  # JFAでスケジュール生成後、openfootballで日次スコアを上書き (JFA反映遅延の補完)
+  uv run python src/read_openfootball_wc.py
   uv run python src/read_we_league.py
   # uv run python src/read_aclgl_matches.py
 else
   # 試合時間ごとの自動実行では、Jリーグと開催中のWC2026を更新
   uv run python src/read_jleague_matches.py
   uv run python src/read_jfamatch.py WC2026 WC2026KO
+  # JFAでスケジュール生成後、openfootballで日次スコアを上書き (JFA反映遅延の補完)
+  uv run python src/read_openfootball_wc.py
 fi

--- a/src/read_openfootball_wc.py
+++ b/src/read_openfootball_wc.py
@@ -1,0 +1,217 @@
+"""Patch WC2026 scores from openfootball/worldcup.json.
+
+This is a supplementary daily score source. ``read_jfamatch.py`` remains
+authoritative for schedule / venue / timezone; this reader only overwrites
+``home_goal`` / ``away_goal`` / ``status`` (plus extra-time and penalty columns
+for knockout matches) using openfootball, which reflects live scores faster
+than the JFA feed.
+
+Matching strategy (see config ``../config/openfootball.yaml``):
+
+- Group stage: openfootball GS matches carry no match number, so rows are
+  matched by team name (English -> Japanese via ``team_name_map``) + group.
+  Group-stage teams are always real names, so this is safe.
+- Knockout: matched by openfootball ``num`` <-> CSV ``match_number``. This is
+  robust against placeholder team names in the bracket (e.g. ``3A/B/C/D/F``).
+
+openfootball score schema:
+
+- ``score.ft`` full-time (90 min) goals ``[home, away]``
+- ``score.et`` cumulative score after extra time (includes ``ft``)
+- ``score.p``  penalty shootout result
+
+Per the project convention the main score is always extra-time inclusive, and
+``home_score_ex`` / ``away_score_ex`` hold only the extra-time-period goals
+(``et`` minus ``ft``).
+"""
+import argparse
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from match_utils import mu
+
+logger = logging.getLogger(__name__)
+
+CONFIG_PATH = (Path(__file__).resolve().parent / '../config/openfootball.yaml')
+FINISHED_STATUS = '試合終了'
+
+
+def load_source(source: str, timeout: int = 60) -> dict[str, Any]:
+    """Load worldcup.json from a local file path or an HTTP(S) URL.
+
+    Args:
+        source: Local path to a worldcup.json file, or a URL to fetch.
+        timeout: HTTP timeout in seconds (ignored for local files).
+
+    Returns:
+        dict: Parsed worldcup.json content.
+    """
+    if source and Path(source).exists():
+        logger.info("Reading local openfootball source %s", source)
+        with open(source, encoding='utf-8') as handle:
+            return json.load(handle)
+    import requests  # local import so unit tests with a local --source need no network stub
+    logger.info("Fetching openfootball source %s", source)
+    resp = requests.get(source, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def score_updates(score: dict[str, Any] | None) -> dict[str, str] | None:
+    """Map an openfootball score dict to CSV column updates.
+
+    Args:
+        score: openfootball ``score`` object, or None/empty for an unplayed match.
+
+    Returns:
+        dict mapping CSV column -> string value, or None when no full-time score
+        is present (the match has not finished yet).
+    """
+    full_time = score.get('ft') if score else None
+    if not full_time:
+        return None
+    extra_time = score.get('et')
+    penalties = score.get('p')
+    # Main score is always extra-time inclusive.
+    main = extra_time if extra_time else full_time
+    updates = {
+        'home_goal': str(main[0]),
+        'away_goal': str(main[1]),
+        'status': FINISHED_STATUS,
+    }
+    if extra_time and full_time:
+        # Store only the extra-time-period goals (cumulative ET minus full time).
+        updates['home_score_ex'] = str(extra_time[0] - full_time[0])
+        updates['away_score_ex'] = str(extra_time[1] - full_time[1])
+    if penalties:
+        updates['home_pk_score'] = str(penalties[0])
+        updates['away_pk_score'] = str(penalties[1])
+    return updates
+
+
+def _apply_updates(match_df: pd.DataFrame, idx: Any, updates: dict[str, str]) -> bool:
+    """Apply column updates to one row; return True if any value changed.
+
+    Assigns string values so the in-memory DataFrame stays consistent with the
+    string dtype produced by ``read_allmatches_csv`` (otherwise ``matches_differ``
+    would treat int 2 and str '2' as different and rewrite the file every run).
+    A column absent from the CSV (e.g. ``home_score_ex``) is created on demand.
+    """
+    row_changed = False
+    for col, val in updates.items():
+        current = match_df.at[idx, col] if col in match_df.columns else None
+        current_str = '' if current is None or (isinstance(current, float) and pd.isna(current)) else str(current)
+        if current_str != val:
+            match_df.at[idx, col] = val
+            row_changed = True
+    return row_changed
+
+
+def patch_group_stage(match_df: pd.DataFrame, matches: list[dict], name_map: dict[str, str]) -> int:
+    """Patch group-stage rows matched by team name + group. Return changed count."""
+    row_index: dict[tuple[str, str, str], Any] = {}
+    for idx, row in match_df.iterrows():
+        group = '' if row.get('group') is None else str(row.get('group'))
+        row_index[(row['home_team'], row['away_team'], group)] = idx
+
+    changed = 0
+    for match in matches:
+        group = str(match.get('group', ''))
+        if not group.startswith('Group'):
+            continue
+        updates = score_updates(match.get('score'))
+        if updates is None:
+            continue
+        home = name_map.get(match['team1'])
+        away = name_map.get(match['team2'])
+        if home is None or away is None:
+            logger.warning("Unmapped group-stage team: %s / %s", match['team1'], match['team2'])
+            continue
+        letter = group.split()[-1]
+        idx = row_index.get((home, away, letter))
+        if idx is None:
+            logger.warning("No group-stage CSV row for %s vs %s (group %s)", home, away, letter)
+            continue
+        if _apply_updates(match_df, idx, updates):
+            changed += 1
+    return changed
+
+
+def patch_knockout(match_df: pd.DataFrame, matches: list[dict]) -> int:
+    """Patch knockout rows matched by ``num`` <-> ``match_number``. Return changed count."""
+    if 'match_number' not in match_df.columns:
+        logger.warning("Knockout CSV has no match_number column; skipping knockout patch")
+        return 0
+    row_index = {str(val): idx for idx, val in match_df['match_number'].items() if val is not None}
+
+    changed = 0
+    for match in matches:
+        num = match.get('num')
+        if num is None:
+            continue
+        updates = score_updates(match.get('score'))
+        if updates is None:
+            continue
+        idx = row_index.get(str(num))
+        if idx is None:
+            logger.warning("No knockout CSV row for match_number %s", num)
+            continue
+        if _apply_updates(match_df, idx, updates):
+            changed += 1
+    return changed
+
+
+def patch_csv(csv_path: str, patch_fn, label: str, dry_run: bool) -> int:
+    """Read a CSV, apply ``patch_fn``, and write it back if changed (unless dry-run)."""
+    if not Path(csv_path).exists():
+        logger.warning("%s CSV not found: %s", label, csv_path)
+        return 0
+    match_df = mu.read_allmatches_csv(csv_path)
+    changed = patch_fn(match_df)
+    logger.info("openfootball %s: %d row(s) changed", label, changed)
+    if changed and not dry_run:
+        mu.update_if_diff(match_df, csv_path)
+    elif changed:
+        logger.info("[dry-run] would update %s", csv_path)
+    return changed
+
+
+def make_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Patch WC2026 CSV scores from openfootball/worldcup.json")
+    parser.add_argument('--source', help='Local worldcup.json path or URL override')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Log changes without writing the CSV files')
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Fetch openfootball data and patch the WC2026 group-stage and knockout CSVs."""
+    args = make_args()
+    config = mu.init_config(CONFIG_PATH)
+    source = args.source or config.source_url
+    timeout = getattr(config, 'http_timeout', 60)
+    data = load_source(source, timeout)
+    matches = data.get('matches', [])
+    name_map = config.team_name_map.to_dict()
+
+    patch_csv(config.group_stage_csv,
+              lambda df: patch_group_stage(df, matches, name_map),
+              'group stage', args.dry_run)
+    patch_csv(config.knockout_csv,
+              lambda df: patch_knockout(df, matches),
+              'knockout', args.dry_run)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+    # Resolve config-relative CSV paths (e.g. ../docs/csv/...) and the timestamp
+    # file against the src/ directory, matching read_jfamatch.py.
+    os.chdir(Path(__file__).resolve().parent)
+    main()

--- a/tests/test_read_openfootball_wc.py
+++ b/tests/test_read_openfootball_wc.py
@@ -1,0 +1,152 @@
+"""Tests for the openfootball WC2026 score patcher."""
+from pathlib import Path
+
+from match_utils import mu
+import pandas as pd
+import read_openfootball_wc as reader
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WC_GS_CSV = REPO_ROOT / 'docs/csv/2026_allmatch_result-WC_GS.csv'
+
+
+def _gs_row(**overrides) -> dict:
+    base = {
+        'match_date': '2026/06/27', 'section_no': 3, 'start_time': '17:00',
+        'stadium': 'X', 'home_team': 'パナマ', 'away_team': 'イングランド',
+        'status': None, 'match_number': '71', 'round': '第3節',
+        'home_goal': None, 'away_goal': None, 'home_pk_score': None,
+        'away_pk_score': None, 'match_index_in_section': 5, 'group': 'L',
+        'timezone': 'America/New_York',
+    }
+    base.update(overrides)
+    return base
+
+
+def _ko_row(**overrides) -> dict:
+    base = {
+        'match_date': '2026/06/28', 'section_no': -6, 'start_time': '12:00',
+        'stadium': 'LA', 'home_team': '南アフリカ', 'away_team': '3A/B/C/D/F',
+        'status': None, 'match_number': '73', 'round': 'ラウンド32',
+        'home_goal': None, 'away_goal': None, 'home_pk_score': None,
+        'away_pk_score': None, 'match_index_in_section': 1, 'group': None,
+        'timezone': 'America/Los_Angeles',
+    }
+    base.update(overrides)
+    return base
+
+
+# --- score_updates ---------------------------------------------------------
+
+def test_score_updates_full_time_only() -> None:
+    updates = reader.score_updates({'ft': [2, 1], 'ht': [1, 0]})
+    assert updates == {'home_goal': '2', 'away_goal': '1', 'status': reader.FINISHED_STATUS}
+
+
+def test_score_updates_no_score_returns_none() -> None:
+    assert reader.score_updates(None) is None
+    assert reader.score_updates({}) is None
+    assert reader.score_updates({'ht': [0, 0]}) is None
+
+
+def test_score_updates_extra_time_records_delta_and_inclusive_main() -> None:
+    # Main score is extra-time inclusive; score_ex holds only the ET-period goals.
+    updates = reader.score_updates({'ft': [1, 1], 'et': [2, 1]})
+    assert updates['home_goal'] == '2'
+    assert updates['away_goal'] == '1'
+    assert updates['home_score_ex'] == '1'
+    assert updates['away_score_ex'] == '0'
+
+
+def test_score_updates_penalties() -> None:
+    updates = reader.score_updates({'ft': [2, 2], 'et': [3, 3], 'p': [4, 2]})
+    assert updates['home_goal'] == '3'
+    assert updates['away_goal'] == '3'
+    assert updates['home_score_ex'] == '1'
+    assert updates['away_score_ex'] == '1'
+    assert updates['home_pk_score'] == '4'
+    assert updates['away_pk_score'] == '2'
+
+
+# --- patch_group_stage -----------------------------------------------------
+
+def test_patch_group_stage_matches_by_team_and_group() -> None:
+    df = pd.DataFrame([_gs_row()])
+    name_map = {'Panama': 'パナマ', 'England': 'イングランド'}
+    matches = [{'group': 'Group L', 'team1': 'Panama', 'team2': 'England',
+                'score': {'ft': [0, 2]}}]
+    assert reader.patch_group_stage(df, matches, name_map) == 1
+    assert df.at[0, 'home_goal'] == '0'
+    assert df.at[0, 'away_goal'] == '2'
+    assert df.at[0, 'status'] == reader.FINISHED_STATUS
+
+
+def test_patch_group_stage_skips_unscored_and_preserves_existing() -> None:
+    df = pd.DataFrame([_gs_row(home_goal='1', away_goal='1', status='試合終了')])
+    name_map = {'Panama': 'パナマ', 'England': 'イングランド'}
+    matches = [{'group': 'Group L', 'team1': 'Panama', 'team2': 'England'}]  # no score
+    assert reader.patch_group_stage(df, matches, name_map) == 0
+    assert df.at[0, 'home_goal'] == '1'  # not blanked out
+    assert df.at[0, 'away_goal'] == '1'
+
+
+def test_patch_group_stage_unmapped_team_is_skipped() -> None:
+    df = pd.DataFrame([_gs_row()])
+    matches = [{'group': 'Group L', 'team1': 'Panama', 'team2': 'England',
+                'score': {'ft': [0, 2]}}]
+    assert reader.patch_group_stage(df, matches, {}) == 0  # empty map -> no KeyError
+    assert df.at[0, 'home_goal'] is None
+
+
+def test_patch_group_stage_preserves_authoritative_columns() -> None:
+    df = pd.DataFrame([_gs_row()])
+    name_map = {'Panama': 'パナマ', 'England': 'イングランド'}
+    matches = [{'group': 'Group L', 'team1': 'Panama', 'team2': 'England',
+                'score': {'ft': [0, 2]}}]
+    reader.patch_group_stage(df, matches, name_map)
+    assert df.at[0, 'start_time'] == '17:00'
+    assert df.at[0, 'stadium'] == 'X'
+    assert df.at[0, 'timezone'] == 'America/New_York'
+
+
+# --- patch_knockout --------------------------------------------------------
+
+def test_patch_knockout_matches_by_number_ignoring_placeholder_names() -> None:
+    # The CSV away_team is a placeholder ('3A/B/C/D/F') but num matching still binds.
+    df = pd.DataFrame([_ko_row()])
+    matches = [{'round': 'Round of 32', 'num': 73, 'team1': 'South Africa',
+                'team2': 'Canada', 'score': {'ft': [1, 0]}}]
+    assert reader.patch_knockout(df, matches) == 1
+    assert df.at[0, 'home_goal'] == '1'
+    assert df.at[0, 'away_goal'] == '0'
+    assert df.at[0, 'status'] == reader.FINISHED_STATUS
+
+
+def test_patch_knockout_creates_extra_time_and_penalty_columns() -> None:
+    df = pd.DataFrame([_ko_row(match_number='89')])
+    matches = [{'round': 'Round of 16', 'num': 89, 'team1': 'A', 'team2': 'B',
+                'score': {'ft': [2, 2], 'et': [3, 3], 'p': [4, 2]}}]
+    assert reader.patch_knockout(df, matches) == 1
+    assert df.at[0, 'home_goal'] == '3'
+    assert df.at[0, 'away_goal'] == '3'
+    assert df.at[0, 'home_score_ex'] == '1'
+    assert df.at[0, 'away_score_ex'] == '1'
+    assert df.at[0, 'home_pk_score'] == '4'
+    assert df.at[0, 'away_pk_score'] == '2'
+
+
+def test_patch_knockout_without_match_number_column_is_noop() -> None:
+    df = pd.DataFrame([{'home_team': 'A', 'away_team': 'B', 'home_goal': None}])
+    matches = [{'num': 73, 'score': {'ft': [1, 0]}}]
+    assert reader.patch_knockout(df, matches) == 0
+
+
+# --- mapping coverage (real config + real CSV) -----------------------------
+
+def test_team_name_map_covers_all_group_stage_teams() -> None:
+    config = mu.init_config(reader.CONFIG_PATH)
+    name_map = config.team_name_map.to_dict()
+    jp_names = set(name_map.values())
+    df = mu.read_allmatches_csv(str(WC_GS_CSV))
+    csv_teams = set(df['home_team']) | set(df['away_team'])
+    missing = csv_teams - jp_names
+    assert not missing, f"team_name_map missing CSV teams: {missing}"


### PR DESCRIPTION
## 概要

JFA の WC2026 スコア反映が遅い問題を補完する。allmatch CSV の生成 (日程・会場・TZ) は引き続き JFA リーダーを正本とし、日々のスコアだけを openfootball/worldcup.json から取得して既存 CSV にパッチする別系統リーダーを新設した。

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `config/openfootball.yaml` | 取得 URL・対象 CSV パス・EN→JP チーム名マッピング (48カ国) |
| `src/read_openfootball_wc.py` | スコアパッチ本体。KO は openfootball `num` ↔ CSV `match_number` で照合 (プレースホルダ名に非依存)、GS はチーム名(EN→JP)+group で照合 |
| `tests/test_read_openfootball_wc.py` | スコアマッピング・GS/KO 照合・名前マップ網羅性のテスト 12件 |
| `scripts/call_update_csv.sh` | JFA リーダー直後に openfootball パッチャーを実行 |
| `CLAUDE.md` | データソースの設計判断を追記 |

上書き対象は `home_goal`/`away_goal`/`status` (+KO の延長/PK 列) のみ。JFA が正本の `start_time`/`stadium`/`timezone` 等は変更しない。openfootball にスコアが無い試合は CSV を据え置く (既存スコアを空で潰さない)。

## テスト計画

- [x] pytest 124 件全通過 (新規12件含む)
- [x] EN→JP マッピングを実 CSV (既存48チーム) と突き合わせ 1:1 一致を確認
- [x] 実データでドライラン実行し、JFA 未反映だった2試合 (Group L) が正しくパッチ対象になることを確認
- [x] `scripts/check_type_sync.py` / `check_point_system_csv.py` 通過
- [x] JFA 正本列 (start_time/stadium/timezone) が変化しないことをテストで確認

Fixes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)