### PR TITLE
Link bracket nodes to CSV rows by position, not team name

### DIFF
--- a/frontend/src/__tests__/bracket/bracket-data.test.ts
+++ b/frontend/src/__tests__/bracket/bracket-data.test.ts
@@ -499,14 +499,26 @@ describe('buildBracket — real tournament fixtures', () => {
     expect(main.bracket_order).toHaveLength(32);
     const mainRoot = buildBracket(rows, main.bracket_order);
     assertNoUndefinedChildren(mainRoot);
-    // Round of 32 leaf nodes exist at depth 4, carrying the bracket_order teams.
-    // We intentionally do NOT assert that a leaf links to a CSV row here: leaves
-    // are matched to CSV rows by team name, which breaks once group placeholders
-    // (e.g. "グループA2位") resolve to real qualifiers. Position-based (match_number)
-    // linkage is tracked in #258 — restore a matchDate assertion once that lands.
+
+    // Round of 32 leaf is linked to its CSV row by match_number (#258), not by
+    // name. The CSV's away_team ("パラグアイ") has already resolved past the
+    // static season_map.yaml placeholder ("A/B/C/D/F3位" — see main.bracket_order[1])
+    // — proving the leaf follows the live CSV instead of going stale with it.
     const r32Leaf = mainRoot.children[0]?.children[0]?.children[0]?.children[0];
-    expect(r32Leaf).toBeDefined();
-    expect(r32Leaf?.homeTeam ?? r32Leaf?.awayTeam).toBeTruthy();
+    expect(main.bracket_order[1]).toBe('A/B/C/D/F3位');
+    expect(r32Leaf?.matchNumber).toBe(74);
+    expect(r32Leaf?.matchDate).toBe('2026/06/29');
+    expect(r32Leaf?.homeTeam).toBe('ドイツ');
+    expect(r32Leaf?.awayTeam).toBe('パラグアイ');
+
+    // An internal (not-yet-played) round is also linked by position: it
+    // carries the real schedule/venue even though its own CSV row still
+    // shows the feeder placeholder as entrant text.
+    const r16Node = mainRoot.children[0]?.children[0]?.children[0];
+    expect(r16Node?.matchNumber).toBe(89);
+    expect(r16Node?.matchDate).toBe('2026/07/04');
+    expect(r16Node?.homeTeam).toBe('No.74の勝者');
+    expect(r16Node?.awayTeam).toBe('No.77の勝者');
 
     // Third-place match is a standalone 2-team block.
     const thirdRoot = buildBracket(rows, third.bracket_order);

--- a/frontend/src/__tests__/bracket/bracket-reference-graph.test.ts
+++ b/frontend/src/__tests__/bracket/bracket-reference-graph.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import Papa from 'papaparse';
+import {
+  parseSlotReference,
+  buildReferenceTopology,
+} from '../../bracket/bracket-reference-graph';
+import type { RawMatchRow } from '../../types/match';
+
+function loadCsv(path: string): RawMatchRow[] {
+  const csvText = readFileSync(resolve(__dirname, path), 'utf-8');
+  return Papa.parse<RawMatchRow>(csvText, {
+    header: true,
+    skipEmptyLines: 'greedy',
+  }).data;
+}
+
+describe('parseSlotReference', () => {
+  it('parses a winner reference', () => {
+    expect(parseSlotReference('No.74の勝者')).toEqual({ role: 'winner', matchNumber: 74 });
+  });
+
+  it('parses a loser reference', () => {
+    expect(parseSlotReference('No.101の敗者')).toEqual({ role: 'loser', matchNumber: 101 });
+  });
+
+  it('returns null for a concrete team name', () => {
+    expect(parseSlotReference('ドイツ')).toBeNull();
+  });
+
+  it('returns null for a group-rank placeholder', () => {
+    expect(parseSlotReference('グループA2位')).toBeNull();
+  });
+
+  it('returns null for undefined/empty', () => {
+    expect(parseSlotReference(undefined)).toBeNull();
+    expect(parseSlotReference('')).toBeNull();
+  });
+});
+
+describe('buildReferenceTopology', () => {
+  it('derives leaf match numbers and parent links from WC_KO feeder references', () => {
+    const rows = loadCsv('../../../../docs/csv/2026_allmatch_result-WC_KO.csv');
+    const topology = buildReferenceTopology(rows);
+
+    expect(topology).not.toBeNull();
+    expect(topology?.leafMatchNumbers).toEqual([
+      74, 77, 73, 75, 83, 84, 81, 82, 76, 78, 79, 80, 86, 88, 85, 87,
+    ]);
+    expect(topology?.parentByChildPair.get('74-77')).toBe(89);
+    expect(topology?.parentByChildPair.get('89-90')).toBe(97);
+    expect(topology?.parentByChildPair.get('101-102')).toBe(104);
+    // 3rd-place playoff (loser-refs only) is not part of the winner-ref tree.
+    expect(topology?.parentByChildPair.get('101-103')).toBeUndefined();
+  });
+
+  it('returns null for competitions without feeder references (name-matched fallback)', () => {
+    const rows = loadCsv('../../../../docs/csv/2024_allmatch_result-EmperorsCup.csv');
+    expect(buildReferenceTopology(rows)).toBeNull();
+  });
+
+  it('returns null for an empty row set', () => {
+    expect(buildReferenceTopology([])).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/bracket/mask-bracket-for-date.test.ts
+++ b/frontend/src/__tests__/bracket/mask-bracket-for-date.test.ts
@@ -136,6 +136,36 @@ describe('maskBracketForDate', () => {
     expect(masked.homeGoal).toBeUndefined();
   });
 
+  it('keeps the feeder-reference label for a still-pending child instead of TBD', () => {
+    const rows = [
+      makeRow({
+        home_team: 'A', away_team: 'B',
+        home_goal: '2', away_goal: '1',
+        match_date: '2024/12/01', round: '準決勝', match_number: '1',
+      }),
+      makeRow({
+        home_team: 'C', away_team: 'D',
+        home_goal: '', away_goal: '',
+        match_date: '2024/12/15', round: '準決勝', match_number: '2',
+      }),
+      makeRow({
+        home_team: 'No.1の勝者', away_team: 'No.2の勝者',
+        home_goal: '', away_goal: '',
+        match_date: '2024/12/22', round: '決勝', match_number: '3',
+      }),
+    ];
+    const root = buildBracket(rows, ['A', 'B', 'C', 'D']);
+    const masked = maskBracketForDate(root, '2024/12/10');
+
+    // SF1 completed → winner known. SF2 still pending.
+    expect(masked.children[0]!.winner).toBe('A');
+    expect(masked.children[1]!.winner).toBeNull();
+    // Final: home resolved from the known SF1 winner; away keeps the CSV's
+    // own pending feeder-reference label instead of collapsing to null.
+    expect(masked.homeTeam).toBe('A');
+    expect(masked.awayTeam).toBe('No.2の勝者');
+  });
+
   describe('H&A aggregate masking', () => {
     function buildHABracket(): BracketNode {
       const rows = [

--- a/frontend/src/bracket/bracket-data.ts
+++ b/frontend/src/bracket/bracket-data.ts
@@ -450,6 +450,21 @@ export function buildBracket(
 }
 
 /**
+ * Decide what entrant label to show on a future (unplayed) node.
+ * - Leaf node (no child): keep the node's own label as-is.
+ * - Child winner already known: show it (richer than a stale reference text).
+ * - Child winner still unknown: keep the node's own label only if it's an
+ *   honest "pending" feeder reference (e.g. "No.89の勝者"); a concrete name
+ *   that merely happens to sit in the row is masked to TBD (null), matching
+ *   the conservative no-spoiler default for unresolved matches.
+ */
+function resolveFutureEntrant(label: string | null, maskedChild: BracketNode | null): string | null {
+  if (!maskedChild) return label;
+  if (maskedChild.winner != null) return maskedChild.winner;
+  return parseSlotReference(label) ? label : null;
+}
+
+/**
  * Mask a bracket tree for a target date.
  * - Nodes with matchDate > targetDate: clear scores and winner, keep date/stadium
  * - Aggregate (H&A) nodes: use earliest leg date; partially mask if between legs
@@ -476,9 +491,8 @@ export function maskBracketForDate(node: BracketNode, targetDate: string): Brack
   const isFuture = effectiveDate != null && effectiveDate > targetDate;
 
   if (isFuture) {
-    // Replace teams with child winners (may be null = TBD)
-    const homeTeam = maskedUpper ? maskedUpper.winner : node.homeTeam;
-    const awayTeam = maskedLower ? maskedLower.winner : node.awayTeam;
+    const homeTeam = resolveFutureEntrant(node.homeTeam, maskedUpper);
+    const awayTeam = resolveFutureEntrant(node.awayTeam, maskedLower);
     return {
       ...node,
       homeTeam,

--- a/frontend/src/bracket/bracket-data.ts
+++ b/frontend/src/bracket/bracket-data.ts
@@ -7,6 +7,9 @@ import type { RawMatchRow } from '../types/match';
 import type { AggregateTiebreakCriterion } from '../types/season';
 import type { BracketNode, DecidedBy, LegDetail } from './bracket-types';
 import { normalizeBracketRoundLabel } from './round-label';
+import {
+  buildReferenceTopology, childPairKey, parseSlotReference, type ReferenceTopology,
+} from './bracket-reference-graph';
 
 /**
  * Determine the winner of a KO match from a CSV row.
@@ -61,6 +64,7 @@ function nodeFromMatch(
   upperTeam: string | null,
   lowerTeam: string | null,
   children: [BracketNode | null, BracketNode | null] = [null, null],
+  needsSwapOverride?: boolean,
 ): BracketNode {
   if (!row) {
     // Auto-advance: if one team exists and the opponent side is entirely
@@ -85,7 +89,10 @@ function nodeFromMatch(
 
   // Preserve bracket position: upperTeam must be homeTeam in the node.
   // If CSV home/away is reversed relative to bracket order, swap scores.
-  const needsSwap = upperTeam != null && row.home_team !== upperTeam;
+  // needsSwapOverride is used for position-linked nodes, where orientation is
+  // known from the CSV's own feeder reference rather than by name comparison
+  // (the row's text may still be an unresolved "No.Xの勝者" placeholder).
+  const needsSwap = needsSwapOverride ?? (upperTeam != null && row.home_team !== upperTeam);
   const parse = (v: string | undefined): number | undefined =>
     v ? parseInt(v, 10) : undefined;
 
@@ -314,6 +321,46 @@ function resolveMatch(
 }
 
 /**
+ * Determine swap orientation from the CSV row's own feeder reference, when
+ * the row still carries an unresolved placeholder (e.g. "No.74の勝者").
+ * Returns undefined when the row has no reference (real name already
+ * resolved), so callers fall back to name-based orientation detection.
+ */
+function needsSwapFromReference(row: RawMatchRow, upperMatchNumber: number): boolean | undefined {
+  const homeRef = parseSlotReference(row.home_team);
+  if (!homeRef) return undefined;
+  return homeRef.matchNumber !== upperMatchNumber;
+}
+
+/** Resolve a leaf matchup by CSV position (match_number) instead of team name. */
+function resolveLeafByPosition(
+  topology: ReferenceTopology,
+  pairIndex: number,
+  upperTeam: string | null,
+  lowerTeam: string | null,
+): BracketNode | null {
+  const matchNumber = topology.leafMatchNumbers[pairIndex];
+  const row = topology.rowsByMatchNumber.get(matchNumber);
+  if (!row) return null;
+  return nodeFromMatch(row, upperTeam, lowerTeam);
+}
+
+/** Resolve an internal-round matchup by CSV position (match_number) instead of team name. */
+function resolveInternalByPosition(
+  topology: ReferenceTopology,
+  upper: BracketNode,
+  lower: BracketNode,
+): BracketNode | null {
+  if (upper.matchNumber == null || lower.matchNumber == null) return null;
+  const parentNumber = topology.parentByChildPair.get(childPairKey(upper.matchNumber, lower.matchNumber));
+  if (parentNumber == null) return null;
+  const row = topology.rowsByMatchNumber.get(parentNumber);
+  if (!row) return null;
+  const needsSwap = needsSwapFromReference(row, upper.matchNumber);
+  return nodeFromMatch(row, upper.winner, lower.winner, [upper, lower], needsSwap);
+}
+
+/**
  * Recursively build a bracket tree from bracket_order positions.
  */
 function isValidPairingOrder(order: number[], width: number): boolean {
@@ -333,19 +380,26 @@ function buildNode(
   teams: (string | null)[],
   aggregateTiebreakOrder: AggregateTiebreakCriterion[],
   pairingOrders?: number[][],
+  topology?: ReferenceTopology,
 ): BracketNode {
+  // Position-based leaf linkage only applies when `teams` is the canonical
+  // entry-round array the topology was derived from (same pair count).
+  // Other lengths (e.g. round-start collapsed/extended arrays) fall back to
+  // name matching, which already works for those cases.
+  const usePositionLeaves = topology != null && topology.leafMatchNumbers.length === teams.length / 2;
+
+  const resolveLeaf = (pairIndex: number, upperTeam: string | null, lowerTeam: string | null): BracketNode => (
+    (usePositionLeaves && resolveLeafByPosition(topology, pairIndex, upperTeam, lowerTeam))
+      || resolveMatch(rows, upperTeam, lowerTeam, aggregateTiebreakOrder)
+  );
+
   if (teams.length === 2) {
-    return resolveMatch(rows, teams[0], teams[1], aggregateTiebreakOrder);
+    return resolveLeaf(0, teams[0], teams[1]);
   }
 
   let levelNodes: BracketNode[] = [];
   for (let i = 0; i < teams.length; i += 2) {
-    levelNodes.push(resolveMatch(
-      rows,
-      teams[i] ?? null,
-      teams[i + 1] ?? null,
-      aggregateTiebreakOrder,
-    ));
+    levelNodes.push(resolveLeaf(i / 2, teams[i] ?? null, teams[i + 1] ?? null));
   }
   let level = 0;
 
@@ -359,7 +413,8 @@ function buildNode(
     for (let i = 0; i < orderedNodes.length; i += 2) {
       const upper = orderedNodes[i];
       const lower = orderedNodes[i + 1];
-      nextLevel.push(resolveMatch(
+      const positionNode = topology && resolveInternalByPosition(topology, upper, lower);
+      nextLevel.push(positionNode || resolveMatch(
         rows,
         upper.winner,
         lower.winner,
@@ -390,7 +445,8 @@ export function buildBracket(
   if (bracketOrder.length < 2) {
     throw new Error(`bracket_order must have at least 2 teams, got ${bracketOrder.length}`);
   }
-  return buildNode(rows, bracketOrder, aggregateTiebreakOrder, pairingOrders);
+  const topology = buildReferenceTopology(rows) ?? undefined;
+  return buildNode(rows, bracketOrder, aggregateTiebreakOrder, pairingOrders, topology);
 }
 
 /**

--- a/frontend/src/bracket/bracket-order-inference.ts
+++ b/frontend/src/bracket/bracket-order-inference.ts
@@ -1,6 +1,6 @@
 import type { RawMatchRow } from '../types/match';
 
-function parseMatchNumber(row: RawMatchRow): number | undefined {
+export function parseMatchNumber(row: RawMatchRow): number | undefined {
   if (!row.match_number) return undefined;
   const value = Number.parseInt(row.match_number, 10);
   return Number.isNaN(value) ? undefined : value;

--- a/frontend/src/bracket/bracket-reference-graph.ts
+++ b/frontend/src/bracket/bracket-reference-graph.ts
@@ -1,0 +1,90 @@
+// Reconstruct the result-reference graph from KO CSV rows that encode bracket
+// structure via feeder placeholders (e.g. "No.74の勝者" / "No.101の敗者").
+// This lets nodes be linked to CSV rows by match_number (position) instead of
+// by team name, so the link survives placeholder -> real-name updates.
+
+import type { RawMatchRow } from '../types/match';
+import { parseMatchNumber } from './bracket-order-inference';
+
+export interface SlotReference {
+  role: 'winner' | 'loser';
+  matchNumber: number;
+}
+
+const SLOT_REFERENCE_PATTERN = /^No\.(\d+)の(勝者|敗者)$/;
+
+/** Parse a feeder placeholder like "No.74の勝者". Returns null for concrete team names. */
+export function parseSlotReference(name: string | null | undefined): SlotReference | null {
+  if (!name) return null;
+  const match = SLOT_REFERENCE_PATTERN.exec(name);
+  if (!match) return null;
+  return {
+    matchNumber: Number.parseInt(match[1], 10),
+    role: match[2] === '勝者' ? 'winner' : 'loser',
+  };
+}
+
+export interface ReferenceTopology {
+  /** Leaf (entry-round) match numbers, left-to-right, one per bracket_order pair. */
+  leafMatchNumbers: number[];
+  /** Maps a normalized child match-number pair to the parent match number. */
+  parentByChildPair: Map<string, number>;
+}
+
+function childPairKey(a: number, b: number): string {
+  return a < b ? `${a}-${b}` : `${b}-${a}`;
+}
+
+/**
+ * Reconstruct the winner-reference tree from KO CSV rows.
+ * Returns null when rows have no "No.X の勝者" feeder references (historical
+ * competitions where bracket_order pairs are still matched by team name).
+ */
+export function buildReferenceTopology(rows: RawMatchRow[]): ReferenceTopology | null {
+  const rowsByMatchNumber = new Map<number, RawMatchRow>();
+  for (const row of rows) {
+    const matchNumber = parseMatchNumber(row);
+    if (matchNumber !== undefined) rowsByMatchNumber.set(matchNumber, row);
+  }
+  if (rowsByMatchNumber.size === 0) return null;
+
+  // A match is an "internal" node only when BOTH slots reference another
+  // match's winner. Mixed/partial references don't occur in known data and
+  // are treated as leaves (no recursion).
+  const winnerRefChildren = new Set<number>();
+  const parentByChildPair = new Map<string, number>();
+  for (const [matchNumber, row] of rowsByMatchNumber) {
+    const homeRef = parseSlotReference(row.home_team);
+    const awayRef = parseSlotReference(row.away_team);
+    if (homeRef?.role === 'winner' && awayRef?.role === 'winner') {
+      winnerRefChildren.add(homeRef.matchNumber);
+      winnerRefChildren.add(awayRef.matchNumber);
+      parentByChildPair.set(childPairKey(homeRef.matchNumber, awayRef.matchNumber), matchNumber);
+    }
+  }
+  if (parentByChildPair.size === 0) return null;
+
+  // The root is the unique parent that is never itself referenced as a child
+  // (e.g. the final). Other terminal matches such as a 3rd-place playoff
+  // (loser-refs only) never enter parentByChildPair and are excluded here.
+  const allParents = new Set(parentByChildPair.values());
+  const rootCandidates = [...allParents].filter((m) => !winnerRefChildren.has(m));
+  if (rootCandidates.length !== 1) return null;
+
+  const leafMatchNumbers: number[] = [];
+  function visit(matchNumber: number): void {
+    const row = rowsByMatchNumber.get(matchNumber);
+    if (!row) return;
+    const homeRef = parseSlotReference(row.home_team);
+    const awayRef = parseSlotReference(row.away_team);
+    if (homeRef?.role === 'winner' && awayRef?.role === 'winner') {
+      visit(homeRef.matchNumber);
+      visit(awayRef.matchNumber);
+    } else {
+      leafMatchNumbers.push(matchNumber);
+    }
+  }
+  visit(rootCandidates[0]);
+
+  return { leafMatchNumbers, parentByChildPair };
+}

--- a/frontend/src/bracket/bracket-reference-graph.ts
+++ b/frontend/src/bracket/bracket-reference-graph.ts
@@ -29,9 +29,11 @@ export interface ReferenceTopology {
   leafMatchNumbers: number[];
   /** Maps a normalized child match-number pair to the parent match number. */
   parentByChildPair: Map<string, number>;
+  /** All KO rows in this CSV, indexed by match_number. */
+  rowsByMatchNumber: Map<number, RawMatchRow>;
 }
 
-function childPairKey(a: number, b: number): string {
+export function childPairKey(a: number, b: number): string {
   return a < b ? `${a}-${b}` : `${b}-${a}`;
 }
 
@@ -86,5 +88,5 @@ export function buildReferenceTopology(rows: RawMatchRow[]): ReferenceTopology |
   }
   visit(rootCandidates[0]);
 
-  return { leafMatchNumbers, parentByChildPair };
+  return { leafMatchNumbers, parentByChildPair, rowsByMatchNumber };
 }


### PR DESCRIPTION
## 概要

トーナメントのブラケットは、リーフ（最深部）の試合をチーム名で CSV 行に照合していたため、グループステージ確定で CSV のチーム名がプレースホルダ→実チーム名に更新されると `season_map.yaml` の静的な `bracket_order`（プレースホルダのまま）とドリフトし、試合データ（日付・会場・スコア）に結びつかなくなっていた。WC2026 ノックアウトで顕在化。

エントリ round のリーフだけでなく、内部ラウンドも含めて **`match_number`（位置）で CSV 行に照合**する「結果参照グラフ」方式に変更した。CSV の `No.74の勝者` のようなフィーダー参照から構造を導出し、これを `bracket_order`（形状定義）とは独立した連結キーとして使う。

副次効果として、未確定の内部ラウンドでも日程・会場・「勝者参照」ラベルが表示されるようになった（従来は内部ラウンドが事実上 CSV 行に結びつかなかったため、これらは表示されなかった）。

## 変更内容

- `bracket-reference-graph.ts` (新規): CSV のフィーダー参照からリーフ順序・親子マップを導出
- `bracket-data.ts`: リーフ・内部ノードを match_number で連結（参照を持たない大会は従来の名前照合にフォールバック）
- `maskBracketForDate`: 未確定ノードの参照ラベルを TBD で潰さず保持（確定済み実名のスポイラー防止は維持）
- `bracket-data.test.ts`: WC2026 ケースを position ベース検証に復元（リーフ＋内部ラウンド）
- `mask-bracket-for-date.test.ts`: 参照ラベル保持の新規テスト追加

## テスト計画

- [x] vitest 540件全通過
- [x] typecheck 通過
- [x] `npm run build` 成功
- [x] pytest 124件全通過（型同期含む、Python側無変更だが既存テストへの影響なし確認）
- [x] E2E (bracket-render, bracket-tooltip) 18件全通過
- [x] ブラウザ目視: WC_KO で R32 リーフが season_map のプレースホルダではなく CSV の実名（パラグアイ等）に追従し、R16以降の未確定ラウンドも日程・会場・参照ラベルを表示することを確認

Fixes #258