### PR TITLE
Add rank table column visibility toggle

### DIFF
--- a/docs/j_points.css
+++ b/docs/j_points.css
@@ -150,6 +150,22 @@ p {
   flex-wrap: wrap;
   align-items: center;
 }
+#column_toggle_section {
+  display: inline-block;
+}
+#column_toggle_list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75em;
+  margin-top: 0.5em;
+  max-width: 480px;
+}
+#column_toggle_list label {
+  display: flex;
+  align-items: center;
+  gap: 0.25em;
+  white-space: nowrap;
+}
 #status_bar {
   margin: 0.5em 1em;
   font-size: 0.9em;

--- a/frontend/e2e/rank-table.spec.ts
+++ b/frontend/e2e/rank-table.spec.ts
@@ -87,4 +87,30 @@ test.describe('T5: Rank Table', () => {
 
     await assertInvariants(page);
   });
+
+  test('unchecking a column checkbox hides the column and persists across reload', async ({ page }) => {
+    await page.goto('/j_points.html?competition=J1&season=2024');
+    await waitForRender(page);
+
+    await page.locator('#column_toggle_section summary').click();
+    const pointCheckbox = page.locator('#column_toggle_list label', { hasText: '勝点' }).locator('input[type="checkbox"]');
+    await pointCheckbox.uncheck();
+    await page.waitForTimeout(200);
+
+    let headers = await page.locator('table.ranktable thead th').evaluateAll(
+      (ths) => ths.map((th) => (th as HTMLTableCellElement).dataset.id).filter(Boolean),
+    );
+    expect(headers).not.toContain('point');
+
+    await page.reload();
+    await waitForRender(page);
+
+    headers = await page.locator('table.ranktable thead th').evaluateAll(
+      (ths) => ths.map((th) => (th as HTMLTableCellElement).dataset.id).filter(Boolean),
+    );
+    expect(headers).not.toContain('point');
+    await expect(pointCheckbox).not.toBeChecked();
+
+    await assertInvariants(page);
+  });
 });

--- a/frontend/src/__tests__/ranking/rank-table.test.ts
+++ b/frontend/src/__tests__/ranking/rank-table.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
 import { describe, test, expect, beforeAll, vi } from 'vitest';
-import { makeRankData, makeRankTable } from '../../ranking/rank-table';
+import {
+  makeRankData, makeRankTable, makeCrossGroupTable, getToggleableColumns,
+} from '../../ranking/rank-table';
+import type { CrossGroupRow } from '../../ranking/rank-table';
+import type { CrossGroupStanding } from '../../types/season';
 import type { TeamData } from '../../types/match';
 import { TeamStats } from '../../types/match';
 import { makeLeagueSeasonInfo } from '../fixtures/match-data';
@@ -681,5 +685,82 @@ describe('makeRankTable – thead hasEx=true', () => {
     const ids = getHeaderIds(table);
     expect(ids).not.toContain('pk_win');
     expect(ids).not.toContain('ex_win');
+  });
+});
+
+// ─── Column visibility toggle (#257) ────────────────────────────────────────
+
+describe('getToggleableColumns', () => {
+  test('excludes always-visible columns (name, rank, champion, promotion, relegation)', () => {
+    const ids = getToggleableColumns().map(c => c.id);
+    expect(ids).not.toContain('name');
+    expect(ids).not.toContain('rank');
+    expect(ids).not.toContain('champion');
+    expect(ids).not.toContain('promotion');
+    expect(ids).not.toContain('relegation');
+  });
+
+  test('returns exactly the 11 stat + goal columns', () => {
+    const ids = getToggleableColumns().map(c => c.id);
+    expect(ids).toEqual([
+      'all_game', 'point', 'avrg_pt', 'avlbl_pt', 'win', 'draw', 'loss',
+      'goal_get', 'goal_lose', 'goal_diff', 'future_game',
+    ]);
+  });
+});
+
+describe('makeRankTable – hiddenColumns', () => {
+  test('omits a hidden stat column from thead', () => {
+    const table = makeTableEl();
+    makeRankTable(table, [], false, false, undefined, new Set(['point']));
+    expect(getHeaderIds(table)).not.toContain('point');
+  });
+
+  test('omits a hidden goal column from thead', () => {
+    const table = makeTableEl();
+    makeRankTable(table, [], false, false, undefined, new Set(['goal_diff']));
+    expect(getHeaderIds(table)).not.toContain('goal_diff');
+  });
+
+  test('does not hide always-visible columns even if requested', () => {
+    const table = makeTableEl();
+    makeRankTable(table, [], false, false, undefined, new Set(['name', 'rank', 'champion']));
+    const ids = getHeaderIds(table);
+    expect(ids).toContain('name');
+    expect(ids).toContain('rank');
+    expect(ids).toContain('champion');
+  });
+
+  test('no hiddenColumns argument → all columns shown (regression)', () => {
+    const table = makeTableEl();
+    makeRankTable(table, [], false, false);
+    const ids = getHeaderIds(table);
+    for (const col of getToggleableColumns()) {
+      expect(ids).toContain(col.id);
+    }
+  });
+});
+
+describe('makeCrossGroupTable – hiddenColumns', () => {
+  const config: CrossGroupStanding = { position: 3 };
+
+  function getCrossGroupHeaderIds(table: HTMLTableElement): string[] {
+    return Array.from(table.querySelectorAll('thead th'))
+      .map(th => th.getAttribute('data-id') ?? '');
+  }
+
+  test('omits a hidden column from thead', () => {
+    const rows: CrossGroupRow[] = [];
+    const table = makeCrossGroupTable(rows, config, new Set(['avrg_pt']));
+    expect(getCrossGroupHeaderIds(table)).not.toContain('avrg_pt');
+  });
+
+  test('no hiddenColumns argument → all columns shown (regression)', () => {
+    const rows: CrossGroupRow[] = [];
+    const table = makeCrossGroupTable(rows, config);
+    const ids = getCrossGroupHeaderIds(table);
+    for (const col of getToggleableColumns()) {
+      expect(ids).toContain(col.id);
+    }
   });
 });

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -24,7 +24,7 @@ import { prepareRenderData } from './core/prepare-render';
 import type { MatchSortKey } from './ranking/stats-calculator';
 import {
   makeRankData, makeRankTable,
-  buildCrossGroupRows, makeCrossGroupTable,
+  buildCrossGroupRows, makeCrossGroupTable, getToggleableColumns,
 } from './ranking/rank-table';
 import type { GroupRenderResult } from './ranking/rank-table';
 import { getMaxPointsPerGame } from './core/point-calculator';
@@ -70,6 +70,7 @@ interface ViewerControlState {
   futureOpacity: number;
   targetDate: string | null;
   displayTimezone: string;  // '' = browser default; otherwise an IANA TZ name
+  hiddenColumns: Set<string>;  // rank table column data-ids hidden by the user
 }
 
 interface LeagueControlState {
@@ -90,6 +91,7 @@ function createControlStateFromPrefs(prefs: ViewerPrefs): ControlState {
       futureOpacity: prefs.futureOpacity ? parseFloat(prefs.futureOpacity) : 0.1,
       targetDate: prefs.targetDate ?? null,
       displayTimezone: prefs.displayTimezone ?? '',
+      hiddenColumns: new Set(prefs.hiddenColumns ?? []),
     },
     league: {
       teamSortKey: prefs.teamSortKey ?? 'disp_point',
@@ -239,6 +241,30 @@ function populateFixedSelect(
     opt.value = value;
     opt.textContent = label;
     sel.appendChild(opt);
+  }
+}
+
+// ---- Column visibility toggle population -------------------------------
+
+// Builds one checkbox per toggleable rank-table column inside #column_toggle_list.
+// onToggle is invoked with (columnId, checked) whenever a checkbox changes.
+function populateColumnToggleList(
+  hiddenColumns: ReadonlySet<string>,
+  onToggle: (columnId: string, checked: boolean) => void,
+): void {
+  const container = document.getElementById('column_toggle_list');
+  if (!container) return;
+  container.innerHTML = '';
+  for (const col of getToggleableColumns()) {
+    if (!col.id) continue;
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = !hiddenColumns.has(col.id);
+    checkbox.addEventListener('change', () => onToggle(col.id!, checkbox.checked));
+    label.appendChild(checkbox);
+    label.appendChild(document.createTextNode(col.label));
+    container.appendChild(label);
   }
 }
 
@@ -429,7 +455,7 @@ function renderFromCache(
       table.appendChild(document.createElement('thead'));
       sortableDiv.appendChild(table);
       const rankData = makeRankData(groupData, sortedTeams, perGroupInfo, disp, hasPk, hasEx);
-      makeRankTable(table, rankData, hasPk, hasEx, perGroupInfo.promotionLabel);
+      makeRankTable(table, rankData, hasPk, hasEx, perGroupInfo.promotionLabel, controlState.viewer.hiddenColumns);
     }
 
     // Collect for cross-group comparison.
@@ -445,7 +471,7 @@ function renderFromCache(
     const rows = buildCrossGroupRows(allGroupResults, cgs, disp, targetDate, maxPt);
     if (rows.length > 0) {
       sortableDiv.appendChild(document.createElement('hr'));
-      sortableDiv.appendChild(makeCrossGroupTable(rows, cgs));
+      sortableDiv.appendChild(makeCrossGroupTable(rows, cgs, controlState.viewer.hiddenColumns));
     }
   }
 
@@ -626,6 +652,13 @@ async function main(): Promise<void> {
   if (teamSortSel)  teamSortSel.value  = controlState.league.teamSortKey;
   if (matchSortSel) matchSortSel.value = controlState.league.matchSortKey;
   if (displayTzSel) displayTzSel.value = controlState.viewer.displayTimezone;
+
+  populateColumnToggleList(controlState.viewer.hiddenColumns, (columnId, checked) => {
+    if (checked) controlState.viewer.hiddenColumns.delete(columnId);
+    else controlState.viewer.hiddenColumns.add(columnId);
+    savePrefs({ hiddenColumns: [...controlState.viewer.hiddenColumns] });
+    loadAndRender(seasonMap);
+  });
 
   const futureOpacityEl = document.getElementById('future_opacity') as HTMLInputElement | null;
   const spaceColorEl    = document.getElementById('space_color')    as HTMLInputElement | null;

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -20,6 +20,7 @@ export const en: Record<MessageKey, string> = {
   'label.bracketLayout': 'Layout',
   'label.layoutHorizontal': 'Horizontal (L→R)',
   'label.layoutVertical': 'Vertical (bottom→up)',
+  'label.columnToggle': 'Columns',
 
   // Buttons
   'btn.resetDate': 'Reset to latest',

--- a/frontend/src/i18n/messages/ja.ts
+++ b/frontend/src/i18n/messages/ja.ts
@@ -18,6 +18,7 @@ export const ja = {
   'label.bracketLayout': '表示方向',
   'label.layoutHorizontal': '横 (左→右)',
   'label.layoutVertical': '縦 (下→上)',
+  'label.columnToggle': '表示列の選択',
 
   // Buttons
   'btn.resetDate': '最新にリセット',

--- a/frontend/src/j_points.html
+++ b/frontend/src/j_points.html
@@ -90,6 +90,10 @@
     <input type="color" id="space_color" value="#000000"/>
   </label>
   <button id="reset_prefs" data-i18n="btn.resetPrefs"></button>
+  <details id="column_toggle_section">
+    <summary data-i18n="label.columnToggle"></summary>
+    <div id="column_toggle_list"><!-- populated by app.ts --></div>
+  </details>
 </section>
 
 <!-- Status message and data timestamp -->

--- a/frontend/src/ranking/rank-table.ts
+++ b/frontend/src/ranking/rank-table.ts
@@ -47,6 +47,18 @@ function getGoalCols(): ColDef[] {
   ];
 }
 
+// Columns the user may hide via the column-visibility control (rank/name and the
+// champion/promotion/relegation/pk/ex columns always stay visible).
+export function getToggleableColumns(): ColDef[] {
+  return [...getStatCols().filter(c => c.id !== 'name'), ...getGoalCols()];
+}
+
+// Removes columns whose id is in hiddenColumns. Columns without an id (e.g. the
+// '-' separator) and 'name' (always required, embedded in getStatCols()) are never hidden.
+function filterHiddenCols(cols: ColDef[], hiddenColumns: ReadonlySet<string>): ColDef[] {
+  return cols.filter(c => !c.id || c.id === 'name' || !hiddenColumns.has(c.id));
+}
+
 // Builds a <thead> row from a column definition array.
 function buildTableHead(tableEl: HTMLElement, cols: ColDef[]): void {
   const thead = tableEl.querySelector('thead');
@@ -217,10 +229,14 @@ export function makeRankData(
 // Builds the <thead> for per-group ranking tables.
 // pk_win / pk_loss columns are included only when hasPk=true.
 // ex_win / ex_loss columns are included only when hasEx=true.
-function buildRankTableHead(tableEl: HTMLElement, hasPk: boolean, hasEx: boolean, promotionLabel: string = t('col.promotion')): void {
+function buildRankTableHead(
+  tableEl: HTMLElement, hasPk: boolean, hasEx: boolean,
+  promotionLabel: string = t('col.promotion'),
+  hiddenColumns: ReadonlySet<string> = new Set(),
+): void {
   const cols: ColDef[] = [
     { id: 'rank',        label: '',          sortable: true },
-    ...getStatCols(),
+    ...filterHiddenCols(getStatCols(), hiddenColumns),
     ...(hasPk ? [
       { id: 'pk_win',  label: t('col.pkWin'),  sortable: true as true },
       { id: 'pk_loss', label: t('col.pkLoss'), sortable: true as true },
@@ -229,7 +245,7 @@ function buildRankTableHead(tableEl: HTMLElement, hasPk: boolean, hasEx: boolean
       { id: 'ex_win',  label: t('col.exWin'),  sortable: true as true },
       { id: 'ex_loss', label: t('col.exLoss'), sortable: true as true },
     ] : []),
-    ...getGoalCols(),
+    ...filterHiddenCols(getGoalCols(), hiddenColumns),
     {                    label: '-' },
     { id: 'champion',    label: t('col.champion'),    sortable: true },
     { id: 'promotion',   label: promotionLabel, sortable: true },
@@ -254,8 +270,12 @@ function applyRowClasses(tbody: HTMLElement, rankMap: Map<number, string>): void
 // hasPk controls whether PK win/loss columns appear in the table header.
 // Row CSS classes (promoted/relegated/etc.) are applied based on points-based rank
 // and reapplied after every re-sort via MutationObserver.
-export function makeRankTable(tableEl: HTMLElement, rankData: RankRow[], hasPk: boolean, hasEx: boolean = false, promotionLabel: string = t('col.promotion')): void {
-  buildRankTableHead(tableEl, hasPk, hasEx, promotionLabel);
+export function makeRankTable(
+  tableEl: HTMLElement, rankData: RankRow[], hasPk: boolean, hasEx: boolean = false,
+  promotionLabel: string = t('col.promotion'),
+  hiddenColumns: ReadonlySet<string> = new Set(),
+): void {
+  buildRankTableHead(tableEl, hasPk, hasEx, promotionLabel, hiddenColumns);
   const sortableTable = new SortableTable();
   sortableTable.setTable(tableEl);
   sortableTable.setData(rankData);
@@ -400,6 +420,7 @@ export function buildCrossGroupRows(
 // Highlights top advance_count rows with .promoted CSS class.
 export function makeCrossGroupTable(
   rows: CrossGroupRow[], config: CrossGroupStanding,
+  hiddenColumns: ReadonlySet<string> = new Set(),
 ): HTMLTableElement {
   const { position, exclude_from_rank, advance_count = 0 } = config;
 
@@ -415,8 +436,8 @@ export function makeCrossGroupTable(
   table.appendChild(document.createElement('thead'));
   buildTableHead(table, [
     { id: 'rank', label: t('col.group'), sortable: true },
-    ...getStatCols(),
-    ...getGoalCols(),
+    ...filterHiddenCols(getStatCols(), hiddenColumns),
+    ...filterHiddenCols(getGoalCols(), hiddenColumns),
   ]);
 
   const sortableTable = new SortableTable();

--- a/frontend/src/storage/local-storage.ts
+++ b/frontend/src/storage/local-storage.ts
@@ -17,6 +17,7 @@ export interface ViewerPrefs {
   locale?: string;
   displayTimezone?: string;  // display IANA TZ name ('' or absent = browser default)
   roundStart?: string;   // bracket round start selection (or '__multi_section__')
+  hiddenColumns?: string[];  // rank table column data-ids hidden by the user (default: none hidden)
 }
 
 export function loadPrefs(): ViewerPrefs {


### PR DESCRIPTION
Fixes #257

## Summary
- 順位表 (`table.ranktable`) の統計列・得点列11列をチェックボックスでON/OFF切替できるコントロールパネルを追加
- `rank`/`name`/`champion`/`promotion`/`relegation`等の必須列は常時表示のまま維持
- 通常の順位表とグループ間比較表 (cross-group) の両方に同じ表示状態を反映
- 選択状態は localStorage (`jleague_viewer_prefs.hiddenColumns`) に永続化し、再訪時に復元

## Changes
| Commit | Description |
|--------|-------------|
| `a49fdec` | `ViewerPrefs.hiddenColumns` 追加 + `rank-table.ts` に列フィルタリング機構 (`getToggleableColumns`/`filterHiddenCols`) を追加 |
| `eff3c00` | `<details>` 列選択パネルの HTML 枠 + i18n ラベル追加 |
| `b262804` | `app.ts` でチェックボックス動的生成・状態管理・永続化・再描画を接続 |
| `e15faa3` | パネルの CSS レイアウト調整 |
| `c129765` | 単体テスト (`rank-table.test.ts`) + E2E テスト (永続化込み) を追加 |

## Test plan
- [x] `uv run pytest` passed (124 tests)
- [x] `npx vitest run` passed (548 tests, frontend/)
- [x] `npm run typecheck` passed (frontend/)
- [x] `npm run build` succeeded (frontend/)
- [x] `npx playwright test rank-table.spec.ts` passed (14 tests, chromium+webkit)
- [x] `uv run python scripts/check_type_sync.py` / `check_point_system_csv.py` passed
- [x] ブラウザ目視確認 (J1 2024 通常表 + WC_GS 2026 12グループ・cross-group表)

Generated with Claude Sonnet 4.6