### PR TITLE
Add unified match viewer page shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ local_data/
 # TypeScript build artifacts (managed by CI deploy-pages.yaml, not committed to git)
 docs/j_points.html
 docs/tournament.html
+docs/matches.html
 docs/assets/
 
 # Vite dev server cache

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,1 +1,1 @@
-j_points.html
+matches.html

--- a/docs/j_points.css
+++ b/docs/j_points.css
@@ -124,14 +124,14 @@ p {
 }
 
 /* --- Controls layout (TS template) --- */
-#controls {
+#controls, #shared_controls, #league_controls {
   margin: 1em;
   display: flex;
   gap: 1.5em;
   flex-wrap: wrap;
   align-items: center;
 }
-#date_slider_section {
+#date_slider_section, #league_date_slider_section {
   margin: 0.5em 0;
   display: flex;
   gap: 0.5em;
@@ -139,7 +139,7 @@ p {
   align-items: center;
   width: 100%;
 }
-#date_slider {
+#date_slider, #league_date_slider, #bracket_date_slider {
   flex: 1;
   min-width: 200px;
 }
@@ -166,12 +166,12 @@ p {
   gap: 0.25em;
   white-space: nowrap;
 }
-#status_bar {
+#status_bar, #league_status_bar, #bracket_status_bar {
   margin: 0.5em 1em;
   font-size: 0.9em;
   color: #666;
 }
-#status_bar .timestamp-label {
+#status_bar .timestamp-label, #league_status_bar .timestamp-label {
   color: #999;
   margin-left: 1em;
 }
@@ -187,12 +187,22 @@ p {
 #ranktable_section {
   margin: 1em;
 }
-#date_slider_up, #date_slider_down {
+#date_slider_up, #date_slider_down,
+#league_date_slider_up, #league_date_slider_down,
+#bracket_date_slider_up, #bracket_date_slider_down {
   background-color: black;
   color: white;
 }
 #target_date {
   font-weight: bold;
+}
+
+/* --- Issue #269: unified page shell (matches.html) view switch --- */
+#view_root[data-active="league"] #bracket_view {
+  display: none;
+}
+#view_root[data-active="bracket"] #league_view {
+  display: none;
 }
 
 /***********************************************************************************/

--- a/frontend/src/matches.html
+++ b/frontend/src/matches.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Match Results Viewer</title>
+  <meta property="og:title" content="JLeague_Matches-Bar_Graph" />
+  <meta property="og:description" content="Jリーグ・各種サッカー大会の勝ち点積み上げグラフとトーナメントブラケットを統合表示" />
+  <meta property="og:image" content="https://mokekuma-git.github.io/JLeague_Matches-Bar_Graph/android-chrome-256x256.png" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:site" content="@Moke_kuma" />
+  <link rel="icon" href="favicon.ico">
+  <link rel="apple-touch-icon" href="apple-touch-icon.png">
+  <link rel="icon" type="image/png" href="android-chrome-192x192.png">
+  <script src="https://cdn.jsdelivr.net/npm/@riversun/sortable-table@1.1.2/lib/sortable-table.js"
+          integrity="sha384-LWX4/EsjUytgODwrauhUKkKTx/K3AFLgbEh/Mhr4YZABcgO0N9yZeK7uBWuLWYPn"
+          crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="j_points.css">
+  <link rel="stylesheet" href="team_style.css">
+  <link rel="stylesheet" href="national_team_style.css">
+</head>
+<body>
+<main>
+
+<!-- Shared controls: meaning is common to League View / Bracket View, IDs are not namespaced -->
+<section id="shared_controls">
+  <label>
+    <span data-i18n="label.competition"></span>
+    <select id="competition_key">
+      <!-- populated dynamically from season_map.yaml -->
+    </select>
+  </label>
+  <label>
+    <span data-i18n="label.season"></span>
+    <select id="season_key"></select>
+  </label>
+  <label>
+    <span data-i18n="label.language"></span>
+    <select id="locale_key">
+      <option value="ja">日本語</option>
+      <option value="en">English</option>
+    </select>
+  </label>
+  <label id="display_timezone_label" hidden>
+    <span data-i18n="label.displayTz"></span>
+    <select id="display_timezone"></select>
+  </label>
+</section>
+
+<!-- View switch: Phase 2 orchestrator will set #view_root[data-active] to toggle which view is shown -->
+<div id="view_root" data-active="league">
+
+<div id="league_view">
+
+<section id="league_controls">
+  <label>
+    <span data-i18n="label.teamSort"></span>
+    <select id="team_sort_key">
+      <!-- populated by app.ts -->
+    </select>
+  </label>
+  <label>
+    <span data-i18n="label.matchSort"></span>
+    <select id="match_sort_key">
+      <!-- populated by app.ts -->
+    </select>
+  </label>
+</section>
+
+<!-- Date slider -->
+<section id="league_date_slider_section">
+  <span id="pre_date_slider" data-i18n="slider.preseason"></span>
+  <button id="league_date_slider_down" data-i18n="btn.sliderPrev"></button>
+  <input type="range" id="league_date_slider" min="0" max="0" step="1" value="0"/>
+  <button id="league_date_slider_up" data-i18n="btn.sliderNext"></button>
+  <span id="league_post_date_slider"></span>
+  <button id="reset_date_slider" data-i18n="btn.resetDate"></button>
+  <label>
+    <span data-i18n="label.displayDate"></span>
+    <input type="date" id="target_date">
+  </label>
+</section>
+
+<!-- Appearance controls -->
+<section id="appearance_controls">
+  <label>
+    <span data-i18n="label.graphScale"></span>
+    <input type="range" id="league_scale_slider" min="0.1" max="1" step="0.1" value="1"/>
+    <span id="league_current_scale">1</span><span data-i18n="label.scaleUnit"></span>
+  </label>
+  <label>
+    <span data-i18n="label.futureOpacity"></span>
+    <input type="range" id="league_future_opacity" min="0" max="0.5" step="0.01" value="0.1"/>
+    [<span id="league_current_opacity"></span>]
+  </label>
+  <label>
+    <span data-i18n="label.spaceColor"></span>
+    <input type="color" id="space_color" value="#000000"/>
+  </label>
+  <button id="reset_prefs" data-i18n="btn.resetPrefs"></button>
+  <details id="column_toggle_section">
+    <summary data-i18n="label.columnToggle"></summary>
+    <div id="column_toggle_list"><!-- populated by app.ts --></div>
+  </details>
+</section>
+
+<!-- Status message and data timestamp -->
+<div id="league_status_bar">
+  <span id="league_status_msg"></span>
+  <span class="timestamp-label"><span data-i18n="label.dataTimestamp"></span> <span id="data_timestamp"></span></span>
+</div>
+
+<!-- Warning message (team color CSS undefined etc.) -->
+<div id="warning_msg" hidden></div>
+
+<!-- Bar graph container -->
+<div id="box_container"></div>
+
+<hr/>
+<span id="data_source_section"></span>
+
+<section id="ranktable_section">
+  <div class="sortable-table">
+    <table id="ranktable" class="ranktable">
+      <thead></thead>
+    </table>
+  </div>
+  <ul>
+    <li data-i18n="note.judgmentCaveat"></li>
+    <li data-i18n="note.judgmentDecided"></li>
+    <li data-i18n="note.playoffNote"></li>
+    <li data-i18n="note.otherLeague"></li>
+  </ul>
+  <ul id="league_season_notes"></ul>
+</section>
+
+</div><!-- /#league_view -->
+
+<div id="bracket_view">
+
+<section id="bracket_round_select">
+  <label>
+    <span data-i18n="label.roundStart"></span>
+    <select id="round_start_key"></select>
+  </label>
+</section>
+
+<section id="bracket_controls">
+  <div id="bracket_date_slider_section">
+    <button id="bracket_date_slider_down" data-i18n="btn.sliderPrev"></button>
+    <input type="range" id="bracket_date_slider" min="0" max="0" step="1" value="0"/>
+    <button id="bracket_date_slider_up" data-i18n="btn.sliderNext"></button>
+    <span id="bracket_post_date_slider"></span>
+    <button id="date_slider_reset" data-i18n="btn.resetDate"></button>
+  </div>
+  <label>
+    <span data-i18n="label.futureOpacity"></span>
+    <input type="range" id="bracket_future_opacity" min="0" max="0.5" step="0.01" value="0.2"/>
+    [<span id="bracket_current_opacity"></span>]
+  </label>
+  <label>
+    <span data-i18n="label.graphScale"></span>
+    <input type="range" id="bracket_scale_slider" min="0.3" max="1" step="0.1" value="1"/>
+    <span id="bracket_current_scale">1</span><span data-i18n="label.scaleUnit"></span>
+  </label>
+  <label>
+    <span data-i18n="label.bracketLayout"></span>
+    <select id="layout_toggle">
+      <option value="horizontal" data-i18n="label.layoutHorizontal"></option>
+      <option value="vertical" data-i18n="label.layoutVertical"></option>
+    </select>
+  </label>
+</section>
+
+<div id="bracket_status_bar">
+  <span id="bracket_status_msg"></span>
+</div>
+
+<div id="bracket_container"></div>
+
+<ul id="bracket_season_notes"></ul>
+
+</div><!-- /#bracket_view -->
+
+</div><!-- /#view_root -->
+
+<hr/>
+<a href="https://github.com/mokekuma-git/JLeague_Matches-Bar_Graph" data-i18n="link.github"></a>
+
+</main>
+
+<!-- Phase 2: load the view orchestrator module here (app.ts / tournament-app.ts logic extraction) -->
+
+</body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(({ command }) => ({
       input: {
         j_points: new URL('src/j_points.html', import.meta.url).pathname,
         tournament: new URL('src/tournament.html', import.meta.url).pathname,
+        matches: new URL('src/matches.html', import.meta.url).pathname,
       },
     },
   },


### PR DESCRIPTION
Refs #269

> このPRは `feature/issue-268-merge-league-tournament-view` への統合PRです。`main` への統合は親Issue #268の完了PRで行います。

## Summary
- League ViewとBracket Viewを収容する統合`matches.html`シェルを追加
- 共有コントロールとView固有IDを整理し、属性駆動の表示切替CSSを追加
- Viteの3つ目のエントリと`docs/index.html`の統合ページ向けリンクを設定

## Changes
| Commit | Description |
|--------|-------------|
| `d4eab6b` | 統合ページシェルとViteエントリを追加 |
| `1106e64` | View切替用CSSを追加 |
| `186563d` | `docs/index.html`を統合ページへ変更 |

## Test plan
- [x] `npm test` passed (frontend/)
- [x] `npm run typecheck` passed (frontend/)
- [x] `npm run build` succeeded (frontend/)
- [x] View visibility切替、ID重複なし、symlink解決を目視・ブラウザ確認

Generated with Codex