### PR TITLE
Unify match viewer state and view orchestration

### DIFF
--- a/docs/j_points.css
+++ b/docs/j_points.css
@@ -205,6 +205,11 @@ p {
   display: none;
 }
 
+#view_root[data-active="pending"] #league_view,
+#view_root[data-active="pending"] #bracket_view {
+  display: none;
+}
+
 /***********************************************************************************/
 /* Refer to https://www.w3schools.com/css/css_tooltip.asp */ 
 /* Tooltip container */

--- a/frontend/src/__tests__/config/season-map.test.ts
+++ b/frontend/src/__tests__/config/season-map.test.ts
@@ -1,10 +1,13 @@
 import { describe, test, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import yaml from 'js-yaml';
 import type {
   SeasonMap, CompetitionFamilyEntry, CompetitionEntry, RawSeasonEntry,
 } from '../../types/season';
 import {
   getCsvFilename,
   findCompetition,
+  resolveCompetitionViewType,
   resolveLeagueSeasonInfo,
   resolveTournamentSeasonInfo,
 } from '../../config/season-map';
@@ -54,6 +57,49 @@ const sampleMap: SeasonMap = {
   jleague: sampleFamily,
   national: nationalFamily,
 };
+
+describe('resolveCompetitionViewType', () => {
+  test('defaults to league when no view_type is configured', () => {
+    expect(resolveCompetitionViewType(sampleFamily, sampleFamily.competitions.J1)).toBe('league');
+  });
+
+  test('returns an explicitly configured bracket view', () => {
+    const competition: CompetitionEntry = {
+      view_type: ['bracket'],
+      seasons: {},
+    };
+    expect(resolveCompetitionViewType(sampleFamily, competition)).toBe('bracket');
+  });
+
+  test('rejects ambiguous inherited view types', () => {
+    const family: CompetitionFamilyEntry = {
+      ...sampleFamily,
+      view_type: ['league'],
+    };
+    const competition: CompetitionEntry = {
+      view_type: ['bracket'],
+      seasons: {},
+    };
+    expect(() => resolveCompetitionViewType(family, competition))
+      .toThrow('Ambiguous competition view_type');
+  });
+
+  test('every shipped competition resolves to exactly one view type', () => {
+    const source = readFileSync(
+      new URL('../../../../docs/yaml/season_map.yaml', import.meta.url),
+      'utf8',
+    );
+    const seasonMap = yaml.load(source) as SeasonMap;
+    for (const [familyKey, family] of Object.entries(seasonMap)) {
+      for (const [competitionKey, competition] of Object.entries(family.competitions)) {
+        expect(
+          () => resolveCompetitionViewType(family, competition),
+          `${familyKey}.${competitionKey}`,
+        ).not.toThrow();
+      }
+    }
+  });
+});
 
 // ---- getCsvFilename -------------------------------------------------------
 

--- a/frontend/src/__tests__/matches-orchestration.test.ts
+++ b/frontend/src/__tests__/matches-orchestration.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { SeasonMap } from '../types/season';
+import {
+  resolveInitialCompetition,
+  resolveInitialSeason,
+  shouldShowTimezone,
+} from '../matches-orchestration';
+
+const seasonMap: SeasonMap = {
+  domestic: {
+    competitions: {
+      J1: {
+        seasons: {
+          '2026': {},
+          '2025': {},
+        },
+      },
+      EmperorsCup: {
+        view_type: ['bracket'],
+        seasons: {
+          '2025': { bracket_round_start: '１回戦' },
+          '2024': {},
+        },
+      },
+    },
+  },
+};
+
+describe('resolveInitialCompetition', () => {
+  it('uses URL, prefs, then default in priority order', () => {
+    expect(resolveInitialCompetition(
+      seasonMap,
+      { competition: 'EmperorsCup' },
+      { competition: 'J1' },
+    )).toBe('EmperorsCup');
+    expect(resolveInitialCompetition(
+      seasonMap,
+      { competition: 'unknown' },
+      { competition: 'EmperorsCup' },
+    )).toBe('EmperorsCup');
+    expect(resolveInitialCompetition(
+      seasonMap,
+      { competition: 'unknown' },
+      { competition: 'also-unknown' },
+    )).toBe('J1');
+  });
+
+  it('returns empty when no candidate exists', () => {
+    expect(resolveInitialCompetition({}, {}, {}, 'unknown')).toBe('');
+  });
+});
+
+describe('resolveInitialSeason', () => {
+  it('uses URL, prefs, then the newest season in priority order', () => {
+    expect(resolveInitialSeason(
+      seasonMap,
+      'J1',
+      { season: '2025' },
+      { season: '2026' },
+    )).toBe('2025');
+    expect(resolveInitialSeason(
+      seasonMap,
+      'J1',
+      { season: 'unknown' },
+      { season: '2025' },
+    )).toBe('2025');
+    expect(resolveInitialSeason(
+      seasonMap,
+      'J1',
+      { season: 'unknown' },
+      { season: 'also-unknown' },
+    )).toBe('2026');
+  });
+
+  it('only restores a season available to the selected view', () => {
+    expect(resolveInitialSeason(
+      seasonMap,
+      'EmperorsCup',
+      { season: '2024' },
+      {},
+      ['2025'],
+    )).toBe('2025');
+  });
+
+  it('returns empty for an unknown competition', () => {
+    expect(resolveInitialSeason(seasonMap, 'unknown', {}, {})).toBe('');
+  });
+});
+
+describe('shouldShowTimezone', () => {
+  it('follows season timezone availability for league view', () => {
+    expect(shouldShowTimezone('league', true)).toBe(true);
+    expect(shouldShowTimezone('league', false)).toBe(false);
+  });
+
+  it('always hides timezone control for bracket view', () => {
+    expect(shouldShowTimezone('bracket', true)).toBe(false);
+    expect(shouldShowTimezone('bracket', false)).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/tournament/tournament-app.test.ts
+++ b/frontend/src/__tests__/tournament/tournament-app.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { __testables } from '../../tournament-app';
+import { __testables } from '../../bracket-view';
 import type { RawMatchRow } from '../../types/match';
 import type { BracketBlock } from '../../types/season';
 import type { BracketNode } from '../../bracket/bracket-types';

--- a/frontend/src/__tests__/view-bootstrap.test.ts
+++ b/frontend/src/__tests__/view-bootstrap.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampToSlider,
+  createSharedViewerControlState,
+  normalizeTargetDate,
+  toInputDate,
+} from '../view-bootstrap';
+
+describe('viewer preference normalization', () => {
+  it.each([
+    ['2026-06-28', '2026/06/28'],
+    ['2026/06/28', '2026/06/28'],
+    [undefined, null],
+    ['', null],
+  ])('normalizes %s to %s', (input, expected) => {
+    expect(normalizeTargetDate(input)).toBe(expected);
+  });
+
+  it('converts a canonical date for input[type=date]', () => {
+    expect(toInputDate('2026/06/28')).toBe('2026-06-28');
+  });
+
+  it('migrates a legacy saved targetDate when creating shared state', () => {
+    expect(createSharedViewerControlState({ targetDate: '2026-06-28' }).targetDate)
+      .toBe('2026/06/28');
+  });
+});
+
+describe('clampToSlider', () => {
+  const slider = { min: '0.3', max: '1', value: '1' } as HTMLInputElement;
+
+  it('clamps values below the bracket minimum', () => {
+    expect(clampToSlider(0.1, slider)).toBe(0.3);
+  });
+
+  it('keeps values inside the slider range', () => {
+    expect(clampToSlider(0.7, slider)).toBe(0.7);
+  });
+});

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -34,8 +34,10 @@ import { findTeamsWithoutColor } from './graph/css-validator';
 import { teamCssClass } from './core/team-utils';
 import { loadPrefs, savePrefs, clearPrefs } from './storage/local-storage';
 import type { ViewerPrefs } from './storage/local-storage';
-import { t, applyI18nAttributes, setLocale } from './i18n';
-import type { Locale } from './i18n';
+import { t } from './i18n';
+import {
+  readUrlParams, writeUrlParams, restoreLocaleAndApplyI18n, createSharedViewerControlState,
+} from './view-bootstrap';
 
 // ---- Application state ------------------------------------------------
 
@@ -87,9 +89,7 @@ interface ControlState {
 function createControlStateFromPrefs(prefs: ViewerPrefs): ControlState {
   return {
     viewer: {
-      scale: prefs.scale ? parseFloat(prefs.scale) : 1,
-      futureOpacity: prefs.futureOpacity ? parseFloat(prefs.futureOpacity) : 0.1,
-      targetDate: prefs.targetDate ?? null,
+      ...createSharedViewerControlState(prefs),
       displayTimezone: prefs.displayTimezone ?? '',
       hiddenColumns: new Set(prefs.hiddenColumns ?? []),
     },
@@ -206,23 +206,6 @@ function showTimestamp(csvFilename: string): void {
   const el = document.getElementById('data_timestamp');
   if (!el || !state.timestampMap) return;
   el.textContent = state.timestampMap[csvFilename] ?? '';
-}
-
-// ---- URL parameter management ------------------------------------------
-
-function readUrlParams(): { competition: string; season?: string } {
-  const params = new URLSearchParams(location.search);
-  return {
-    competition: params.get('competition') ?? '',
-    season: params.get('season') ?? undefined,
-  };
-}
-
-function writeUrlParams(competition: string, season: string): void {
-  const url = new URL(location.href);
-  url.searchParams.set('competition', competition);
-  url.searchParams.set('season', season);
-  history.replaceState(null, '', url.toString());
 }
 
 // ---- Fixed dropdown population -----------------------------------------
@@ -598,10 +581,8 @@ function loadAndRender(seasonMap: SeasonMap): void {
 
 async function main(): Promise<void> {
   // Restore locale from prefs before any i18n calls.
-  const savedLocale = loadPrefs().locale;
-  if (savedLocale === 'ja' || savedLocale === 'en') setLocale(savedLocale as Locale);
+  const savedLocale = restoreLocaleAndApplyI18n(loadPrefs().locale);
 
-  applyI18nAttributes();
   void loadTimestampMap();
 
   let seasonMap: SeasonMap;

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -1,779 +1,143 @@
-// Unified viewer entry point.
-//
-// Navigates the 4-tier season_map.yaml hierarchy:
-//   family → competition → seasons → entry
-//
-// - Competition dropdown is populated dynamically with family separators.
-// - URL parameters (?competition=J1&season=2026East) are read on init and written on change.
-// - User preferences are persisted via localStorage and restored on reload.
-// - Data timestamp is loaded from csv/csv_timestamp.csv and displayed.
+// Standalone league viewer entry point.
 
-import Papa from 'papaparse';
-import type { RawMatchRow, TeamMap } from './types/match';
-import type { SeasonMap, LeagueSeasonInfo } from './types/season';
+import type { SeasonMap } from './types/season';
 import {
-  loadSeasonMap, getCsvFilename, findCompetition, resolveLeagueSeasonInfo,
+  findCompetition,
   getCompetitionViewTypes,
+  loadSeasonMap,
 } from './config/season-map';
-import { parseCsvResults } from './core/csv-parser';
-import { dateFormat } from './core/date-utils';
 import {
-  getLastMatchDate, getSliderDate, syncSliderToTargetDate,
-} from './core/date-slider';
-import { prepareRenderData } from './core/prepare-render';
-import type { MatchSortKey } from './ranking/stats-calculator';
-import {
-  makeRankData, makeRankTable,
-  buildCrossGroupRows, makeCrossGroupTable, getToggleableColumns,
-} from './ranking/rank-table';
-import type { GroupRenderResult } from './ranking/rank-table';
-import { getMaxPointsPerGame } from './core/point-calculator';
-import { renderBarGraph } from './graph/renderer';
-import { DEFAULT_HEIGHT_UNIT, getHeightUnit, setFutureOpacity, setSpace, setScale } from './graph/css-utils';
-import { findTeamsWithoutColor } from './graph/css-validator';
-import { teamCssClass } from './core/team-utils';
-import { loadPrefs, savePrefs, clearPrefs } from './storage/local-storage';
-import type { ViewerPrefs } from './storage/local-storage';
-import { t } from './i18n';
-import {
-  readUrlParams, writeUrlParams, restoreLocaleAndApplyI18n, createSharedViewerControlState,
+  createSharedViewerControlState,
+  readUrlParams,
+  restoreLocaleAndApplyI18n,
+  writeUrlParams,
 } from './view-bootstrap';
-
-// ---- Application state ------------------------------------------------
-
-interface TeamMapCache {
-  key: string;
-  teamMap: TeamMap;
-  teamCount: number;
-  hasPk: boolean;
-  hasEx: boolean;
-  hasTimezone: boolean;  // true → at least one match carries a source TZ (per-row column or season)
-}
-
-/** Mutable application state collected in one place. */
-interface AppState {
-  timestampMap: Record<string, string> | null;
-  teamMapCache: TeamMapCache | null;
-  currentMatchDates: string[];
-  heightUnit: number;
-}
-
-const state: AppState = {
-  timestampMap: null,
-  teamMapCache: null,
-  currentMatchDates: [],
-  heightUnit: DEFAULT_HEIGHT_UNIT,
-};
-
-// ---- Control state (symmetric with tournament-app.ts) -----------------
-
-interface ViewerControlState {
-  scale: number;
-  futureOpacity: number;
-  targetDate: string | null;
-  displayTimezone: string;  // '' = browser default; otherwise an IANA TZ name
-  hiddenColumns: Set<string>;  // rank table column data-ids hidden by the user
-}
-
-interface LeagueControlState {
-  teamSortKey: string;
-  matchSortKey: string;
-  spaceColor: string;
-}
-
-interface ControlState {
-  viewer: ViewerControlState;
-  league: LeagueControlState;
-}
-
-function createControlStateFromPrefs(prefs: ViewerPrefs): ControlState {
-  return {
-    viewer: {
-      ...createSharedViewerControlState(prefs),
-      displayTimezone: prefs.displayTimezone ?? '',
-      hiddenColumns: new Set(prefs.hiddenColumns ?? []),
-    },
-    league: {
-      teamSortKey: prefs.teamSortKey ?? 'disp_point',
-      matchSortKey: prefs.matchSortKey ?? 'old_bottom',
-      spaceColor: prefs.spaceColor ?? '#cccccc',
-    },
-  };
-}
-
-let controlState: ControlState = createControlStateFromPrefs({});
+import {
+  initLeagueView,
+  LEAGUE_STANDALONE_IDS,
+} from './league-view';
+import { clearPrefs, loadPrefs, savePrefs } from './storage/local-storage';
+import { t } from './i18n';
 
 const DEFAULT_COMPETITION = 'J1';
-const DEFAULT_GROUP = 'matches';
 
-// CSV URL cache-busting: same bucket for requests within this window (seconds).
-const CACHE_BUST_WINDOW_SEC = 300; // 5 minutes
-
-// ---- Fixed dropdown options (generated into HTML by TS) ------------------
-
-const MATCH_SORT_VALUES = ['old_bottom', 'new_bottom', 'first_bottom', 'last_bottom'] as const;
-
-function getTeamSortOptions(): { value: string; label: string }[] {
-  return [
-    { value: 'disp_point',    label: t('sort.dispPoint') },
-    { value: 'disp_avlbl_pt', label: t('sort.dispAvlblPt') },
-    { value: 'point',         label: t('sort.point') },
-    { value: 'avlbl_pt',      label: t('sort.avlblPt') },
-  ];
-}
-
-function getMatchSortOptions(): { value: string; label: string }[] {
-  return [
-    { value: 'old_bottom',   label: t('sort.oldBottom') },
-    { value: 'new_bottom',   label: t('sort.newBottom') },
-    { value: 'first_bottom', label: t('sort.firstBottom') },
-    { value: 'last_bottom',  label: t('sort.lastBottom') },
-  ];
-}
-
-// Curated display-TZ list: browser default (empty value) + JST/UTC + WC2026 host zones.
-// Labels are language-neutral (IANA name + offset hint); only the default is translated.
-function getDisplayTzOptions(): { value: string; label: string }[] {
-  return [
-    { value: '',                     label: t('tz.browserDefault') },
-    { value: 'Asia/Tokyo',           label: 'Asia/Tokyo (JST)' },
-    { value: 'UTC',                  label: 'UTC' },
-    { value: 'America/New_York',     label: 'America/New_York (ET)' },
-    { value: 'America/Chicago',      label: 'America/Chicago (CT)' },
-    { value: 'America/Denver',       label: 'America/Denver (MT)' },
-    { value: 'America/Los_Angeles',  label: 'America/Los_Angeles (PT)' },
-    { value: 'America/Mexico_City',  label: 'America/Mexico_City' },
-    { value: 'America/Monterrey',    label: 'America/Monterrey' },
-    { value: 'America/Vancouver',    label: 'America/Vancouver' },
-    { value: 'America/Toronto',      label: 'America/Toronto' },
-  ];
-}
-
-// ---- DOM helpers -------------------------------------------------------
-
-function getSelectValue(id: string): string {
-  return (document.getElementById(id) as HTMLSelectElement).value;
-}
-
-function setStatus(msg: string): void {
-  const el = document.getElementById('status_msg');
-  if (el) el.textContent = msg;
-}
-
-function showWarning(msg: string | null): void {
-  const el = document.getElementById('warning_msg');
-  if (!el) return;
-  if (msg) {
-    el.textContent = msg;
-    el.hidden = false;
-  } else {
-    el.textContent = '';
-    el.hidden = true;
-  }
-}
-
-// ---- Timestamp management ----------------------------------------------
-
-async function loadTimestampMap(): Promise<Record<string, string>> {
-  if (state.timestampMap !== null) return state.timestampMap;
-  try {
-    const res = await fetch('./csv/csv_timestamp.csv');
-    if (!res.ok) return (state.timestampMap = {});
-    const text = await res.text();
-    const result = Papa.parse<{ file: string; date: string }>(text, {
-      header: true,
-      skipEmptyLines: 'greedy',
-    });
-    const map: Record<string, string> = {};
-    for (const row of result.data) {
-      const key = row.file.replace('../docs/', '');
-      const d = new Date(row.date.replace(' ', 'T'));
-      map[key] = isNaN(d.getTime()) ? row.date : formatTimestamp(d);
-    }
-    return (state.timestampMap = map);
-  } catch {
-    return (state.timestampMap = {});
-  }
-}
-
-function formatTimestamp(d: Date): string {
-  const pad = (n: number): string => String(n).padStart(2, '0');
-  return `${d.getFullYear()}/${pad(d.getMonth() + 1)}/${pad(d.getDate())} `
-       + `${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
-function showTimestamp(csvFilename: string): void {
-  const el = document.getElementById('data_timestamp');
-  if (!el || !state.timestampMap) return;
-  el.textContent = state.timestampMap[csvFilename] ?? '';
-}
-
-// ---- Fixed dropdown population -----------------------------------------
-
-type MatchSortUiValue = typeof MATCH_SORT_VALUES[number];
-
-function populateFixedSelect(
-  id: string,
-  options: ReadonlyArray<{ readonly value: string; readonly label: string }>,
-): void {
-  const sel = document.getElementById(id) as HTMLSelectElement | null;
-  if (!sel) return;
-  sel.innerHTML = '';
-  for (const { value, label } of options) {
-    const opt = document.createElement('option');
-    opt.value = value;
-    opt.textContent = label;
-    sel.appendChild(opt);
-  }
-}
-
-// ---- Column visibility toggle population -------------------------------
-
-// Builds one checkbox per toggleable rank-table column inside #column_toggle_list.
-// onToggle is invoked with (columnId, checked) whenever a checkbox changes.
-function populateColumnToggleList(
-  hiddenColumns: ReadonlySet<string>,
-  onToggle: (columnId: string, checked: boolean) => void,
-): void {
-  const container = document.getElementById('column_toggle_list');
-  if (!container) return;
-  container.innerHTML = '';
-  for (const col of getToggleableColumns()) {
-    if (!col.id) continue;
-    const label = document.createElement('label');
-    const checkbox = document.createElement('input');
-    checkbox.type = 'checkbox';
-    checkbox.checked = !hiddenColumns.has(col.id);
-    checkbox.addEventListener('change', () => onToggle(col.id!, checkbox.checked));
-    label.appendChild(checkbox);
-    label.appendChild(document.createTextNode(col.label));
-    container.appendChild(label);
-  }
-}
-
-// ---- Match sort key mapping --------------------------------------------
-
-function getMatchSortKey(uiValue: string): MatchSortKey {
-  const v = uiValue as MatchSortUiValue;
-  return (v === 'first_bottom' || v === 'last_bottom') ? 'section_no' : 'match_date';
-}
-
-function isBottomFirst(uiValue: string): boolean {
-  const v = uiValue as MatchSortUiValue;
-  return (v === 'old_bottom' || v === 'first_bottom');
-}
-
-// ---- Competition pulldown population -----------------------------------
-
-function populateCompetitionPulldown(seasonMap: SeasonMap): void {
-  const sel = document.getElementById('competition_key') as HTMLSelectElement;
-  sel.innerHTML = '';
+function populateCompetitionPulldown(seasonMap: SeasonMap, select: HTMLSelectElement): void {
+  select.replaceChildren();
   const families = Object.entries(seasonMap);
   const multiFamily = families.length > 1;
   for (const [familyKey, family] of families) {
     if (multiFamily) {
-      // Disabled separator showing family name (only when multiple families exist)
-      const sep = document.createElement('option');
-      sep.disabled = true;
-      sep.textContent = `── ${family.display_name ?? familyKey} `;
-      sel.appendChild(sep);
+      const separator = document.createElement('option');
+      separator.disabled = true;
+      separator.textContent = `── ${family.display_name ?? familyKey} `;
+      select.appendChild(separator);
     }
-
-    for (const [compKey, comp] of Object.entries(family.competitions)) {
-      if (!getCompetitionViewTypes(family, comp).includes('league')) continue;
-      const opt = document.createElement('option');
-      opt.value = compKey;
-      opt.textContent = comp.league_display ?? compKey;
-      sel.appendChild(opt);
+    for (const [competitionKey, competition] of Object.entries(family.competitions)) {
+      if (!getCompetitionViewTypes(family, competition).includes('league')) continue;
+      const option = document.createElement('option');
+      option.value = competitionKey;
+      option.textContent = competition.league_display ?? competitionKey;
+      select.appendChild(option);
     }
   }
 }
 
-// ---- Season pulldown population ----------------------------------------
-
-function populateSeasonPulldown(seasonMap: SeasonMap, competition: string): void {
-  const sel = document.getElementById('season_key') as HTMLSelectElement;
-  sel.innerHTML = '';
-  const found = findCompetition(seasonMap, competition);
-  if (!found) return;
-  const seasons = Object.keys(found.competition.seasons).sort().reverse();
-  for (const s of seasons) {
-    const opt = document.createElement('option');
-    opt.value = s;
-    opt.textContent = s;
-    sel.appendChild(opt);
-  }
-}
-
-// ---- Date slider management --------------------------------------------
-
-function resetDateSlider(matchDates: string[], targetDate: string): void {
-  state.currentMatchDates = matchDates;
-  const slider = document.getElementById('date_slider') as HTMLInputElement | null;
-  if (!slider || matchDates.length === 0) return;
-  syncSliderToTargetDate(slider, matchDates, targetDate);
-
-  const postEl = document.getElementById('post_date_slider');
-  const lastDate = getLastMatchDate(matchDates);
-  if (postEl && lastDate) postEl.textContent = lastDate;
-}
-
-// ---- Core render pipeline ----------------------------------------------
-
-function renderFromCache(
-  cache: TeamMapCache,
+function populateSeasonPulldown(
   seasonMap: SeasonMap,
   competition: string,
-  season: string,
-  targetDate: string,
-  sortKey: string,
-  matchSortKey: MatchSortKey,
-  bottomFirst: boolean,
-  disp: boolean,
+  select: HTMLSelectElement,
 ): void {
+  select.replaceChildren();
   const found = findCompetition(seasonMap, competition);
   if (!found) return;
-  const entry = found.competition.seasons[season];
-  if (!entry) return;
-  const seasonInfo = resolveLeagueSeasonInfo(found.family, found.competition, entry, found.familyKey);
-  const { hasPk, hasEx } = cache;
-
-  // Show the display-timezone selector only when this season actually has source TZ data.
-  const tzLabel = document.getElementById('display_timezone_label');
-  if (tzLabel) tzLabel.hidden = !cache.hasTimezone;
-
-  // Determine which groups to render and in what order.
-  const allGroups = Object.keys(cache.teamMap);
-  const groupKeys = seasonInfo.shownGroups
-    ? seasonInfo.shownGroups.filter(g => allGroups.includes(g))
-    : allGroups.sort();
-  const isMultiGroup = groupKeys.length > 1;
-
-  const globalMatchDateSet = new Set<string>();
-  const allTeamCssClasses: string[] = [];
-  const boxCon = document.getElementById('box_container') as HTMLElement | null;
-  if (boxCon) {
-    boxCon.replaceChildren();
-    // Multi-group graphs are laid out as stacked block rows (column); single-group
-    // keeps the original single horizontal row.
-    boxCon.classList.toggle('blockrows', isMultiGroup);
-  }
-
-  // Block-row wrapping state (multi-group only): accumulate team counts and wrap to
-  // a new .group_block_row once the next group would exceed maxRowTeams.
-  let currentBlockRow: HTMLElement | null = null;
-  let currentRowTeams = 0;
-
-  // Prepare ranking table container.
-  const sortableDiv = document.querySelector('#ranktable_section .sortable-table') as HTMLElement | null;
-  if (sortableDiv) sortableDiv.innerHTML = '';
-
-  // Collect per-group results for cross-group comparison (populated during loop).
-  const allGroupResults: Record<string, GroupRenderResult> = {};
-
-  for (const groupKey of groupKeys) {
-    const singleGroupData = cache.teamMap[groupKey];
-    if (!singleGroupData) continue;
-
-    // For multi-group: use per-group team count from config.
-    // promotionCount is kept as-is (group-stage competitions advance a fixed number per group).
-    // relegationCount is zeroed because relegation is never decided per-group.
-    const groupTeamCount = seasonInfo.groupTeamCount?.[groupKey] ?? seasonInfo.teamCount;
-    const perGroupInfo: LeagueSeasonInfo = isMultiGroup
-      ? { ...seasonInfo, teamCount: groupTeamCount, relegationCount: 0 }
-      : seasonInfo;
-
-    const { groupData, sortedTeams } = prepareRenderData({
-      groupData: singleGroupData, seasonInfo: perGroupInfo, targetDate, sortKey, matchSortKey,
-    });
-
-    for (const team of sortedTeams) allTeamCssClasses.push(teamCssClass(team));
-
-    if (boxCon) {
-      const { fragment, matchDates } = renderBarGraph(
-        groupData, sortedTeams, perGroupInfo,
-        targetDate, disp, bottomFirst, state.heightUnit, hasPk, hasEx,
-        controlState.viewer.displayTimezone || undefined,
-      );
-      for (const d of matchDates) globalMatchDateSet.add(d);
-
-      if (isMultiGroup) {
-        // Wrap each group's graph in a flex container with a label.
-        const wrapper = document.createElement('div');
-        wrapper.classList.add('group_wrapper');
-        const label = document.createElement('div');
-        label.classList.add('group_label');
-        label.textContent = t('graph.group', { key: groupKey });
-        wrapper.appendChild(label);
-        wrapper.appendChild(fragment);
-
-        // Start a new block row when the current one would overflow maxRowTeams.
-        // Use the actual rendered column count (sortedTeams.length), not the config
-        // team count. Wrapping happens only at group boundaries (a group is never split).
-        const rowTeams = sortedTeams.length;
-        if (currentBlockRow === null
-            || (currentRowTeams > 0 && currentRowTeams + rowTeams > seasonInfo.maxRowTeams)) {
-          currentBlockRow = document.createElement('div');
-          currentBlockRow.classList.add('group_block_row');
-          boxCon.appendChild(currentBlockRow);
-          currentRowTeams = 0;
-        }
-        currentBlockRow.appendChild(wrapper);
-        currentRowTeams += rowTeams;
-      } else {
-        boxCon.appendChild(fragment);
-      }
-    }
-
-    // Ranking table: one table per group (or single table for single-group).
-    if (sortableDiv) {
-      const table = document.createElement('table');
-      table.className = 'ranktable';
-      if (!isMultiGroup) table.id = 'ranktable';
-      if (isMultiGroup) {
-        const caption = document.createElement('caption');
-        caption.textContent = `Group ${groupKey}`;
-        table.appendChild(caption);
-      }
-      table.appendChild(document.createElement('thead'));
-      sortableDiv.appendChild(table);
-      const rankData = makeRankData(groupData, sortedTeams, perGroupInfo, disp, hasPk, hasEx);
-      makeRankTable(table, rankData, hasPk, hasEx, perGroupInfo.promotionLabel, controlState.viewer.hiddenColumns);
-    }
-
-    // Collect for cross-group comparison.
-    if (isMultiGroup && seasonInfo.crossGroupStanding) {
-      allGroupResults[groupKey] = { sortedTeams, groupData };
-    }
-  }
-
-  // Cross-group standing comparison table (after all per-group tables).
-  if (sortableDiv && seasonInfo.crossGroupStanding && Object.keys(allGroupResults).length > 1) {
-    const cgs = seasonInfo.crossGroupStanding;
-    const maxPt = getMaxPointsPerGame(seasonInfo.pointSystem);
-    const rows = buildCrossGroupRows(allGroupResults, cgs, disp, targetDate, maxPt);
-    if (rows.length > 0) {
-      sortableDiv.appendChild(document.createElement('hr'));
-      sortableDiv.appendChild(makeCrossGroupTable(rows, cgs, controlState.viewer.hiddenColumns));
-    }
-  }
-
-  if (boxCon) {
-    const scaleSlider = document.getElementById('scale_slider') as HTMLInputElement | null;
-    setScale(boxCon, scaleSlider?.value ?? '1');
-    const globalMatchDates = [...globalMatchDateSet].sort();
-    resetDateSlider(globalMatchDates, targetDate);
-  }
-
-  // Update season notes from season_map config.
-  const notesEl = document.getElementById('season_notes');
-  if (notesEl) {
-    notesEl.replaceChildren();
-    for (const text of seasonInfo.notes) {
-      const li = document.createElement('li');
-      li.textContent = text;
-      notesEl.appendChild(li);
-    }
-  }
-
-  // Update data source link from season_map config.
-  const dsSection = document.getElementById('data_source_section');
-  if (dsSection) {
-    if (seasonInfo.dataSource) {
-      const a = document.createElement('a');
-      a.href = seasonInfo.dataSource.url;
-      a.textContent = seasonInfo.dataSource.label;
-      dsSection.replaceChildren(t('status.dataSource'), a);
-    } else {
-      dsSection.replaceChildren();
-    }
-  }
-
-  // I3: Warn about teams with undefined CSS colors.
-  const undefinedTeams = findTeamsWithoutColor(allTeamCssClasses);
-  if (undefinedTeams.length > 0) {
-    showWarning(t('warn.undefinedColor', { teams: undefinedTeams.join(', ') }));
-  } else {
-    showWarning(null);
+  for (const season of Object.keys(found.competition.seasons).sort().reverse()) {
+    const option = document.createElement('option');
+    option.value = season;
+    option.textContent = season;
+    select.appendChild(option);
   }
 }
-
-function loadAndRender(seasonMap: SeasonMap): void {
-  const competition = getSelectValue('competition_key');
-  const season      = getSelectValue('season_key');
-  const csvKey      = `${competition}/${season}`;
-
-  const targetDate    = controlState.viewer.targetDate?.replace(/-/g, '/') ?? dateFormat(new Date(), '/');
-
-  const sortKey      = controlState.league.teamSortKey;
-  const matchSortKey = getMatchSortKey(controlState.league.matchSortKey);
-  const bottomFirst  = isBottomFirst(controlState.league.matchSortKey);
-  const disp         = sortKey.startsWith('disp_');
-
-  const found = findCompetition(seasonMap, competition);
-  if (!found || !found.competition.seasons[season]) {
-    setStatus(t('status.noSeason', { competition, season }));
-    return;
-  }
-
-  const leagueDisplay = resolveLeagueSeasonInfo(
-    found.family,
-    found.competition,
-    found.competition.seasons[season],
-    found.familyKey,
-  ).leagueDisplay;
-
-  writeUrlParams(competition, season);
-  savePrefs({
-    competition, season,
-    targetDate: controlState.viewer.targetDate ?? undefined,
-    teamSortKey: sortKey,
-    matchSortKey: controlState.league.matchSortKey,
-  });
-
-  const filename = getCsvFilename(competition, season);
-
-  if (state.teamMapCache?.key === csvKey) {
-    renderFromCache(state.teamMapCache, seasonMap, competition, season, targetDate, sortKey, matchSortKey, bottomFirst, disp);
-    showTimestamp(filename);
-    setStatus(t('status.cached', { league: leagueDisplay, season }));
-    return;
-  }
-
-  const cachebuster = Math.floor(Date.now() / 1000 / CACHE_BUST_WINDOW_SEC);
-  setStatus(t('status.loading'));
-
-  Papa.parse<RawMatchRow>(filename + '?_=' + cachebuster, {
-    header: true,
-    skipEmptyLines: 'greedy',
-    download: true,
-    complete: (results) => {
-      const entry = found.competition.seasons[season];
-      const seasonInfo = resolveLeagueSeasonInfo(found.family, found.competition, entry, found.familyKey);
-      const teamMap = parseCsvResults(
-        results.data,
-        results.meta.fields ?? [],
-        seasonInfo.teams,
-        DEFAULT_GROUP,
-        seasonInfo.pointSystem,
-        seasonInfo.timezone,
-      );
-      const fields = results.meta.fields ?? [];
-      const hasPk = fields.includes('home_pk_score');
-      const hasEx = fields.includes('home_score_ex');
-      // Source TZ is available when the CSV carries a per-row column or the season sets one.
-      const hasTimezone = fields.includes('timezone') || Boolean(seasonInfo.timezone);
-
-      const newCache = { key: csvKey, teamMap, teamCount: seasonInfo.teamCount, hasPk, hasEx, hasTimezone };
-      state.teamMapCache = newCache;
-
-      renderFromCache(newCache, seasonMap, competition, season, targetDate, sortKey, matchSortKey, bottomFirst, disp);
-      showTimestamp(filename);
-      setStatus(t('status.loaded', { league: leagueDisplay, season, rows: results.data.length }));
-    },
-    error: (err: unknown) => {
-      setStatus(t('status.error', { detail: String(err) }));
-    },
-  });
-}
-
-// ---- Initialization & event wiring ------------------------------------
 
 async function main(): Promise<void> {
-  // Restore locale from prefs before any i18n calls.
-  const savedLocale = restoreLocaleAndApplyI18n(loadPrefs().locale);
-
-  void loadTimestampMap();
+  const prefs = loadPrefs();
+  const savedLocale = restoreLocaleAndApplyI18n(prefs.locale);
+  const status = document.getElementById('status_msg');
 
   let seasonMap: SeasonMap;
   try {
     seasonMap = await loadSeasonMap();
-  } catch (err) {
-    setStatus(t('status.seasonMapError'));
-    console.error('Failed to load season map:', err);
+  } catch (error) {
+    if (status) status.textContent = t('status.seasonMapError');
+    console.error('Failed to load season map:', error);
     return;
   }
 
-  state.heightUnit = getHeightUnit();
+  const competitionSelect = document.getElementById('competition_key') as HTMLSelectElement;
+  const seasonSelect = document.getElementById('season_key') as HTMLSelectElement;
+  populateCompetitionPulldown(seasonMap, competitionSelect);
 
-  populateCompetitionPulldown(seasonMap);
-  populateFixedSelect('team_sort_key', getTeamSortOptions());
-  populateFixedSelect('match_sort_key', getMatchSortOptions());
-  populateFixedSelect('display_timezone', getDisplayTzOptions());
-
-  // Determine initial competition/season from URL params → localStorage → default
   const urlParams = readUrlParams();
-  const prefs     = loadPrefs();
-
-  const competitionSel = document.getElementById('competition_key') as HTMLSelectElement;
-  const initCompetition = (urlParams.competition && findCompetition(seasonMap, urlParams.competition))
+  const initialCompetition = (urlParams.competition && findCompetition(seasonMap, urlParams.competition))
     ? urlParams.competition
     : (prefs.competition && findCompetition(seasonMap, prefs.competition))
-    ? prefs.competition
-    : DEFAULT_COMPETITION;
-  competitionSel.value = initCompetition;
+      ? prefs.competition
+      : DEFAULT_COMPETITION;
+  competitionSelect.value = initialCompetition;
+  populateSeasonPulldown(seasonMap, initialCompetition, seasonSelect);
 
-  populateSeasonPulldown(seasonMap, initCompetition);
-
-  const seasonSel = document.getElementById('season_key') as HTMLSelectElement;
-  const found = findCompetition(seasonMap, initCompetition);
-  const initSeason = (urlParams.season && found?.competition.seasons[urlParams.season])
+  const found = findCompetition(seasonMap, initialCompetition);
+  const initialSeason = (urlParams.season && found?.competition.seasons[urlParams.season])
     ? urlParams.season
     : (prefs.season && found?.competition.seasons[prefs.season])
-    ? prefs.season
-    : seasonSel.options[0]?.value ?? '';
-  seasonSel.value = initSeason;
+      ? prefs.season
+      : seasonSelect.options[0]?.value ?? '';
+  seasonSelect.value = initialSeason;
 
-  // Restore control state from prefs
-  controlState = createControlStateFromPrefs(prefs);
-
-  const teamSortSel  = document.getElementById('team_sort_key') as HTMLSelectElement | null;
-  const matchSortSel = document.getElementById('match_sort_key') as HTMLSelectElement | null;
-  const displayTzSel = document.getElementById('display_timezone') as HTMLSelectElement | null;
-  if (teamSortSel)  teamSortSel.value  = controlState.league.teamSortKey;
-  if (matchSortSel) matchSortSel.value = controlState.league.matchSortKey;
-  if (displayTzSel) displayTzSel.value = controlState.viewer.displayTimezone;
-
-  populateColumnToggleList(controlState.viewer.hiddenColumns, (columnId, checked) => {
-    if (checked) controlState.viewer.hiddenColumns.delete(columnId);
-    else controlState.viewer.hiddenColumns.add(columnId);
-    savePrefs({ hiddenColumns: [...controlState.viewer.hiddenColumns] });
-    loadAndRender(seasonMap);
-  });
-
-  const futureOpacityEl = document.getElementById('future_opacity') as HTMLInputElement | null;
-  const spaceColorEl    = document.getElementById('space_color')    as HTMLInputElement | null;
-  const scaleSliderEl   = document.getElementById('scale_slider')   as HTMLInputElement | null;
-  if (futureOpacityEl) futureOpacityEl.value = String(controlState.viewer.futureOpacity);
-  if (spaceColorEl)    spaceColorEl.value    = controlState.league.spaceColor;
-  if (scaleSliderEl)   scaleSliderEl.value   = String(controlState.viewer.scale);
-
-  setFutureOpacity(String(controlState.viewer.futureOpacity), false);
-  if (prefs.spaceColor) setSpace(controlState.league.spaceColor, false);
-
-  const dateInput = document.getElementById('target_date') as HTMLInputElement;
-  dateInput.value = controlState.viewer.targetDate ?? dateFormat(new Date(), '-');
-
-  // ---- Data-selection events ----
-
-  competitionSel.addEventListener('change', () => {
-    state.teamMapCache = null;
-    populateSeasonPulldown(seasonMap, competitionSel.value);
-    loadAndRender(seasonMap);
-  });
-
-  document.getElementById('season_key')?.addEventListener('change', () => {
-    state.teamMapCache = null;
-    loadAndRender(seasonMap);
-  });
-
-  document.getElementById('target_date')?.addEventListener('change', () => {
-    controlState.viewer.targetDate = (document.getElementById('target_date') as HTMLInputElement).value;
-    loadAndRender(seasonMap);
-  });
-
-  document.getElementById('team_sort_key')?.addEventListener('change', () => {
-    controlState.league.teamSortKey = getSelectValue('team_sort_key');
-    loadAndRender(seasonMap);
-  });
-
-  document.getElementById('match_sort_key')?.addEventListener('change', () => {
-    controlState.league.matchSortKey = getSelectValue('match_sort_key');
-    loadAndRender(seasonMap);
-  });
-
-  // ---- Date slider events ----
-
-  const dateSlider = document.getElementById('date_slider') as HTMLInputElement | null;
-  if (dateSlider) {
-    const updateFromSlider = (): void => {
-      const date = getSliderDate(state.currentMatchDates, parseInt(dateSlider.value, 10));
-      if (!date) return;
-      const htmlDate = date.replace(/\//g, '-');
-      (document.getElementById('target_date') as HTMLInputElement).value = htmlDate;
-      controlState.viewer.targetDate = htmlDate;
-      loadAndRender(seasonMap);
-    };
-
-    dateSlider.addEventListener('change', updateFromSlider);
-
-    // Show date label in real-time while dragging (no graph redraw)
-    dateSlider.addEventListener('input', () => {
-      const date = getSliderDate(state.currentMatchDates, parseInt(dateSlider.value, 10));
-      if (!date) return;
-      (document.getElementById('target_date') as HTMLInputElement).value = date.replace(/\//g, '-');
-    });
-
-    document.getElementById('date_slider_down')?.addEventListener('click', () => {
-      dateSlider.value = String(Math.max(0, parseInt(dateSlider.value, 10) - 1));
-      updateFromSlider();
-    });
-    document.getElementById('date_slider_up')?.addEventListener('click', () => {
-      dateSlider.value = String(Math.min(parseInt(dateSlider.max, 10), parseInt(dateSlider.value, 10) + 1));
-      updateFromSlider();
-    });
-    document.getElementById('reset_date_slider')?.addEventListener('click', () => {
-      const today = dateFormat(new Date(), '-');
-      (document.getElementById('target_date') as HTMLInputElement).value = today;
-      controlState.viewer.targetDate = today;
-      loadAndRender(seasonMap);
-    });
+  const shared = createSharedViewerControlState(prefs);
+  if (prefs.targetDate && prefs.targetDate !== shared.targetDate) {
+    savePrefs({ targetDate: shared.targetDate ?? undefined });
   }
-
-  // ---- Appearance events ----
-
-  const boxCon = document.getElementById('box_container') as HTMLElement;
-
-  document.getElementById('scale_slider')?.addEventListener('input', (e) => {
-    const v = (e.target as HTMLInputElement).value;
-    controlState.viewer.scale = parseFloat(v);
-    setScale(boxCon, v);
-    savePrefs({ scale: v });
+  const leagueView = initLeagueView(LEAGUE_STANDALONE_IDS, {
+    shared,
+    onViewerChange() {
+      savePrefs({
+        scale: String(shared.scale),
+        futureOpacity: String(shared.futureOpacity),
+        targetDate: shared.targetDate ?? undefined,
+      });
+    },
   });
 
-  document.getElementById('future_opacity')?.addEventListener('input', (e) => {
-    const v = (e.target as HTMLInputElement).value;
-    controlState.viewer.futureOpacity = parseFloat(v);
-    setFutureOpacity(v);
-    savePrefs({ futureOpacity: v });
+  const activate = (): void => {
+    const selection = {
+      competition: competitionSelect.value,
+      season: seasonSelect.value,
+    };
+    writeUrlParams(selection.competition, selection.season);
+    savePrefs(selection);
+    leagueView.activate(seasonMap, selection);
+  };
+
+  competitionSelect.addEventListener('change', () => {
+    populateSeasonPulldown(seasonMap, competitionSelect.value, seasonSelect);
+    activate();
   });
+  seasonSelect.addEventListener('change', activate);
 
-  document.getElementById('space_color')?.addEventListener('input', (e) => {
-    const v = (e.target as HTMLInputElement).value;
-    controlState.league.spaceColor = v;
-    setSpace(v);
-    savePrefs({ spaceColor: v });
-  });
-
-  // ---- Display timezone selector ----
-
-  document.getElementById('display_timezone')?.addEventListener('change', (e) => {
-    const v = (e.target as HTMLSelectElement).value;
-    controlState.viewer.displayTimezone = v;
-    savePrefs({ displayTimezone: v });
-    loadAndRender(seasonMap);
-  });
-
-  // ---- Locale selector ----
-
-  const localeSel = document.getElementById('locale_key') as HTMLSelectElement | null;
-  if (localeSel) {
-    if (savedLocale) localeSel.value = savedLocale;
-    localeSel.addEventListener('change', () => {
-      savePrefs({ locale: localeSel.value });
+  const localeSelect = document.getElementById('locale_key') as HTMLSelectElement | null;
+  if (localeSelect) {
+    if (savedLocale) localeSelect.value = savedLocale;
+    localeSelect.addEventListener('change', () => {
+      savePrefs({ locale: localeSelect.value });
       location.reload();
     });
   }
-
-  // ---- Reset ----
-
   document.getElementById('reset_prefs')?.addEventListener('click', () => {
     clearPrefs();
     location.assign(location.pathname);
   });
 
-  // Initial render
-  loadAndRender(seasonMap);
+  activate();
 }
 
 main().catch(console.error);

--- a/frontend/src/bracket-view.ts
+++ b/frontend/src/bracket-view.ts
@@ -1,0 +1,980 @@
+// Tournament bracket view module.
+//
+// Loads season_map.yaml, filters to bracket-enabled competitions,
+// and renders a CSS bracket for the selected season.
+// Provides date slider, opacity, zoom, and layout controls.
+
+import Papa from 'papaparse';
+import type { RawMatchRow } from './types/match';
+import type {
+  SeasonMap,
+  BracketBlock,
+  AggregateTiebreakCriterion,
+  RawSeasonEntry,
+  TournamentSeasonInfo,
+} from './types/season';
+import {
+  getCsvFilename, findCompetition, resolveTournamentSeasonInfo,
+} from './config/season-map';
+import {
+  PRESEASON_SENTINEL,
+  formatSliderDate,
+  getLastMatchDate,
+  getSliderDate,
+  resolveTargetDate,
+  syncSliderToTargetDate,
+} from './core/date-slider';
+import { buildBracket, maskBracketForDate } from './bracket/bracket-data';
+import { extractTeamsFromBracketOrder, inferBracketOrderFromRows } from './bracket/bracket-order-inference';
+import { normalizeBracketRoundLabel } from './bracket/round-label';
+import { inferRoundFilter } from './bracket/round-filter-inference';
+import { renderBracketInto, unpinTooltip } from './bracket/bracket-renderer';
+import { loadPrefs, savePrefs } from './storage/local-storage';
+import type { ViewerPrefs } from './storage/local-storage';
+import { t } from './i18n';
+import { clampToSlider, createSharedViewerControlState } from './view-bootstrap';
+import type { SharedViewerControlState } from './view-bootstrap';
+import type { BracketNode } from './bracket/bracket-types';
+
+// ---- State ------------------------------------------------------------------
+
+interface BracketState {
+  csvRows: RawMatchRow[];
+  bracketOrder: (string | null)[];
+  seasonInfo: TournamentSeasonInfo;
+  fullRoot: BracketNode;        // full tree built from bracketOrder
+  roundsByDepth: string[];      // round labels root-to-leaf (e.g. ['決勝戦','準決勝','準々決勝','ラウンド16'])
+  allRounds: string[];          // all CSV rounds in chronological order
+  bracketBlocks?: BracketBlock[];  // multi-section definitions from season_map
+  matchDates: string[];         // sorted unique dates from CSV
+  season: string;
+}
+
+type ViewerControlState = SharedViewerControlState;
+
+interface BracketControlState {
+  layout: 'horizontal' | 'vertical';
+  roundStart: string | null;
+}
+
+interface ControlState {
+  viewer: ViewerControlState;
+  bracket: BracketControlState;
+}
+
+interface SingleBracketRenderInput {
+  rows: RawMatchRow[];
+  order: (string | null)[];
+  aggregateTiebreakOrder: AggregateTiebreakCriterion[];
+  targetDate: string | null;
+  lastDate: string;
+  cssFiles: string[];
+}
+
+const MULTI_SECTION_VALUE = '__multi_section__';
+
+let currentState: BracketState | null = null;
+
+/** Cache buildBracket results to avoid redundant rebuilds on slider/layout changes. */
+let bracketCache = new Map<string, BracketNode>();
+
+let controlState: ControlState = {
+  viewer: {
+    scale: 1,
+    futureOpacity: 0.2,
+    targetDate: null,
+  },
+  bracket: {
+    layout: 'horizontal',
+    roundStart: null,
+  },
+};
+
+function createControlStateFromPrefs(
+  prefs: ViewerPrefs,
+  shared = createSharedViewerControlState(prefs, { futureOpacity: 0.2 }),
+): ControlState {
+  return {
+    viewer: shared,
+    bracket: {
+      layout: 'horizontal',
+      roundStart: prefs.roundStart ?? null,
+    },
+  };
+}
+
+export interface BracketViewSelection {
+  competition: string;
+  season: string;
+}
+
+export interface BracketViewContext {
+  shared: SharedViewerControlState;
+  onViewerChange(): void;
+}
+
+export interface BracketViewHandle {
+  activate(seasonMap: SeasonMap, selection: BracketViewSelection): void;
+  deactivate(): void;
+}
+
+export interface BracketViewIds {
+  competition: string;
+  season: string;
+  roundStart: string;
+  dateSlider: string;
+  dateSliderDown: string;
+  dateSliderUp: string;
+  dateSliderReset: string;
+  postDateSlider: string;
+  futureOpacity: string;
+  currentOpacity: string;
+  scaleSlider: string;
+  currentScale: string;
+  layout: string;
+  status: string;
+  container: string;
+  seasonNotes: string;
+}
+
+export const BRACKET_STANDALONE_IDS: BracketViewIds = {
+  competition: 'competition_key',
+  season: 'season_key',
+  roundStart: 'round_start_key',
+  dateSlider: 'date_slider',
+  dateSliderDown: 'date_slider_down',
+  dateSliderUp: 'date_slider_up',
+  dateSliderReset: 'date_slider_reset',
+  postDateSlider: 'post_date_slider',
+  futureOpacity: 'future_opacity',
+  currentOpacity: 'current_opacity',
+  scaleSlider: 'scale_slider',
+  currentScale: 'current_scale',
+  layout: 'layout_toggle',
+  status: 'status_msg',
+  container: 'bracket_container',
+  seasonNotes: 'season_notes',
+};
+
+export const BRACKET_NAMESPACED_IDS: BracketViewIds = {
+  ...BRACKET_STANDALONE_IDS,
+  dateSlider: 'bracket_date_slider',
+  dateSliderDown: 'bracket_date_slider_down',
+  dateSliderUp: 'bracket_date_slider_up',
+  postDateSlider: 'bracket_post_date_slider',
+  futureOpacity: 'bracket_future_opacity',
+  currentOpacity: 'bracket_current_opacity',
+  scaleSlider: 'bracket_scale_slider',
+  currentScale: 'bracket_current_scale',
+  status: 'bracket_status_msg',
+  seasonNotes: 'bracket_season_notes',
+};
+
+interface BracketViewRefs {
+  competition: HTMLSelectElement;
+  season: HTMLSelectElement;
+  roundStart: HTMLSelectElement;
+  dateSlider: HTMLInputElement;
+  dateSliderDown: HTMLElement;
+  dateSliderUp: HTMLElement;
+  dateSliderReset: HTMLElement;
+  postDateSlider: HTMLElement;
+  futureOpacity: HTMLInputElement;
+  currentOpacity: HTMLElement;
+  scaleSlider: HTMLInputElement;
+  currentScale: HTMLElement;
+  layout: HTMLSelectElement;
+  status: HTMLElement;
+  container: HTMLElement;
+  seasonNotes: HTMLElement;
+}
+
+let refs: BracketViewRefs;
+let viewContext: BracketViewContext;
+let activeSelection: BracketViewSelection | null = null;
+
+function requireElement<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) throw new Error(`Bracket view element not found: #${id}`);
+  return element as T;
+}
+
+function resolveRefs(ids: BracketViewIds): BracketViewRefs {
+  return {
+    competition: requireElement(ids.competition),
+    season: requireElement(ids.season),
+    roundStart: requireElement(ids.roundStart),
+    dateSlider: requireElement(ids.dateSlider),
+    dateSliderDown: requireElement(ids.dateSliderDown),
+    dateSliderUp: requireElement(ids.dateSliderUp),
+    dateSliderReset: requireElement(ids.dateSliderReset),
+    postDateSlider: requireElement(ids.postDateSlider),
+    futureOpacity: requireElement(ids.futureOpacity),
+    currentOpacity: requireElement(ids.currentOpacity),
+    scaleSlider: requireElement(ids.scaleSlider),
+    currentScale: requireElement(ids.currentScale),
+    layout: requireElement(ids.layout),
+    status: requireElement(ids.status),
+    container: requireElement(ids.container),
+    seasonNotes: requireElement(ids.seasonNotes),
+  };
+}
+
+function setStatus(msg: string): void {
+  refs.status.textContent = msg;
+}
+
+// ---- Match date collection --------------------------------------------------
+
+function collectMatchDates(rows: RawMatchRow[]): string[] {
+  const dates = new Set<string>();
+  for (const r of rows) {
+    if (r.match_date) dates.add(r.match_date);
+  }
+  const sorted = Array.from(dates).sort();
+  // Prepend sentinel so slider index 0 = "before any match"
+  sorted.unshift(PRESEASON_SENTINEL);
+  return sorted;
+}
+
+function resolveSeasonBracketOrder(
+  entry: RawSeasonEntry,
+  inferredOrder?: (string | null)[],
+): (string | null)[] | undefined {
+  const explicitOrder = entry.bracket_order;
+  if (explicitOrder != null && explicitOrder.length > 0) {
+    return explicitOrder;
+  }
+
+  const legacyOrder = entry.teams;
+  if (legacyOrder != null && legacyOrder.length > 0) {
+    return legacyOrder;
+  }
+
+  const sectionOrder = entry.bracket_blocks?.flatMap((section) => section.bracket_order ?? []);
+  if (sectionOrder != null && sectionOrder.length > 0) {
+    return sectionOrder;
+  }
+
+  return inferredOrder;
+}
+
+function resolveSectionBracketOrders(
+  sections: BracketBlock[],
+  seasonTeams: string[],
+): BracketBlock[] {
+  return sections.map((section) => (
+    section.bracket_order && section.bracket_order.length > 0
+      ? section
+      : { ...section, bracket_order: seasonTeams }
+  ));
+}
+
+function hasBracketMetadata(entry: RawSeasonEntry): boolean {
+  return entry.bracket_order != null
+    || entry.bracket_blocks != null
+    || (entry.teams?.length ?? 0) > 0
+    || entry.bracket_round_start != null;
+}
+
+// ---- Dropdown population ---------------------------------------------------
+
+export function populateBracketSeasonPulldown(
+  seasonMap: SeasonMap,
+  competition: string,
+  select: HTMLSelectElement = refs.season,
+): void {
+  select.replaceChildren();
+  const found = findCompetition(seasonMap, competition);
+  if (!found) return;
+  const seasons = Object.keys(found.competition.seasons)
+    .filter(s => {
+      const e = found.competition.seasons[s];
+      return hasBracketMetadata(e);
+    })
+    .sort().reverse();
+  for (const s of seasons) {
+    const opt = document.createElement('option');
+    opt.value = s;
+    opt.textContent = s;
+    select.appendChild(opt);
+  }
+}
+
+// ---- Round start helpers ---------------------------------------------------
+
+/** Collect round labels at each tree depth via BFS (root → leaf). */
+function collectRoundsByDepth(node: BracketNode): string[] {
+  const rounds: string[] = [];
+  let level: BracketNode[] = [node];
+  while (level.length > 0) {
+    const roundName = level.find(n => n.round)?.round ?? '';
+    if (roundName) rounds.push(roundName);
+    const next: BracketNode[] = [];
+    for (const n of level) {
+      for (const child of n.children) {
+        if (child) next.push(child);
+      }
+    }
+    level = next;
+  }
+  return rounds;
+}
+
+/** Collect unique normalized KO rounds from the built bracket tree in play order. */
+function collectBracketRounds(node: BracketNode): string[] {
+  return collectRoundsByDepth(node)
+    .map(r => normalizeBracketRoundLabel(r))
+    .reverse();
+}
+
+/** Filter rows by round using raw or normalized bracket labels. */
+function filterRowsByRounds(rows: RawMatchRow[], roundFilter: string[]): RawMatchRow[] {
+  const rawSet = new Set(roundFilter);
+  const normalizedSet = new Set(roundFilter.map(r => normalizeBracketRoundLabel(r)));
+  return rows.filter((r) => {
+    const round = r.round ?? '';
+    return rawSet.has(round) || normalizedSet.has(normalizeBracketRoundLabel(round));
+  });
+}
+
+/** Apply default_round_filter to sections that lack their own round_filter. */
+function resolveSectionRoundFilters(
+  sections: BracketBlock[], defaultRoundFilter?: string[],
+): BracketBlock[] {
+  if (!defaultRoundFilter || defaultRoundFilter.length === 0) return sections;
+  return sections.map(s =>
+    s.round_filter ? s : { ...s, round_filter: defaultRoundFilter },
+  );
+}
+
+/** Infer round_filter for sections still without one after default resolution. */
+function inferMissingSectionRoundFilters(
+  sections: BracketBlock[], rows: RawMatchRow[],
+): BracketBlock[] {
+  return sections.map(s => {
+    if (s.round_filter) return s;
+    const inferred = inferRoundFilter(rows, s.bracket_order ?? [], s.matchup_pairs);
+    return inferred ? { ...s, round_filter: inferred } : s;
+  });
+}
+
+function collectBracketSourceRows(rows: RawMatchRow[], sections?: BracketBlock[]): RawMatchRow[] {
+  if (!sections || sections.length === 0) return rows;
+  const merged: RawMatchRow[] = [];
+  const seen = new Set<string>();
+  for (const section of sections) {
+    const sectionRows = section.round_filter
+      ? filterRowsByRounds(rows, section.round_filter)
+      : rows;
+    for (const row of sectionRows) {
+      const key = [
+        row.match_number ?? '',
+        row.match_date ?? '',
+        row.home_team ?? '',
+        row.away_team ?? '',
+        row.round ?? '',
+        row.leg ?? '',
+        row.stadium ?? '',
+      ].join('|');
+      if (seen.has(key)) continue;
+      seen.add(key);
+      merged.push(row);
+    }
+  }
+  return merged;
+}
+
+/** Collect unique rounds from CSV in chronological order. */
+function collectRoundsFromCsv(rows: RawMatchRow[]): string[] {
+  const seen = new Set<string>();
+  const rounds: string[] = [];
+  const sorted = [...rows].sort(
+    (a, b) => (a.match_date ?? '').localeCompare(b.match_date ?? ''),
+  );
+  for (const row of sorted) {
+    const normalized = row.round ? normalizeBracketRoundLabel(row.round) : '';
+    if (normalized && !seen.has(normalized)) {
+      seen.add(normalized);
+      rounds.push(normalized);
+    }
+  }
+  return rounds;
+}
+
+export const __testables = {
+  createControlStateFromPrefs,
+  resolveSeasonBracketOrder,
+  resolveSectionBracketOrders,
+  filterRowsByRounds,
+  resolveSectionRoundFilters,
+  inferMissingSectionRoundFilters,
+  collectBracketSourceRows,
+  collectRoundsFromCsv,
+  resolveInclusiveBracketOrder,
+  shouldRenderMultiSectionView,
+};
+
+/** Collect winners at a given tree depth (in bracket positional order). */
+function collectWinnersAtDepth(
+  node: BracketNode, depth: number,
+): (string | null)[] {
+  if (depth === 0) return [node.winner];
+  const results: (string | null)[] = [];
+  for (const child of node.children) {
+    if (child) results.push(...collectWinnersAtDepth(child, depth - 1));
+  }
+  return results;
+}
+
+/**
+ * Extend bracket order backward by one round.
+ * For each team, find their match in the given round and expand to [home, away].
+ * Teams that entered at a later round (no match found) become [team, null] (bye).
+ */
+function extendBracketBackward(
+  order: (string | null)[],
+  rows: RawMatchRow[],
+  round: string,
+): (string | null)[] {
+  const extended: (string | null)[] = [];
+  for (const team of order) {
+    if (!team) {
+      extended.push(null, null);
+      continue;
+    }
+    const match = rows.find(r =>
+      normalizeBracketRoundLabel(r.round ?? '') === round
+        && (r.home_team === team || r.away_team === team),
+    );
+    if (match) {
+      extended.push(match.home_team, match.away_team);
+    } else {
+      // Team entered at a later round (bye)
+      extended.push(team, null);
+    }
+  }
+  return extended;
+}
+
+function populateRoundStartPulldown(
+  allRounds: string[], defaultRound?: string,
+  hasSections?: boolean,
+  explicitOptions?: string[],
+): void {
+  const sel = refs.roundStart;
+  sel.replaceChildren();
+  sel.disabled = false;
+
+  const options = explicitOptions ?? [
+    ...(hasSections ? [MULTI_SECTION_VALUE] : []),
+    ...allRounds,
+  ];
+
+  for (const round of options) {
+    const opt = document.createElement('option');
+    opt.value = round;
+    opt.textContent = round === MULTI_SECTION_VALUE ? t('label.multiSection') : round;
+    sel.appendChild(opt);
+  }
+
+  if (explicitOptions && explicitOptions.length === 1) {
+    sel.value = explicitOptions[0];
+    sel.disabled = true;
+  } else if (defaultRound && options.includes(defaultRound)) {
+    sel.value = defaultRound;
+  } else if (options.includes(MULTI_SECTION_VALUE)) {
+    sel.value = MULTI_SECTION_VALUE;
+  } else if (options.length > 0) {
+    sel.value = options[0];
+  }
+}
+
+/** Resolve bracket order for the single-tree ("inclusive") bracket view. */
+function resolveInclusiveBracketOrder(
+  state: Pick<BracketState, 'fullRoot' | 'bracketOrder' | 'roundsByDepth' | 'allRounds' | 'csvRows'>,
+  selectedRoundStart: string | null,
+): (string | null)[] {
+  const { fullRoot, bracketOrder, roundsByDepth, allRounds, csvRows } = state;
+  const selected = selectedRoundStart ?? '';
+  const leafRound = roundsByDepth[roundsByDepth.length - 1];
+  const leafIdx = allRounds.indexOf(leafRound);
+  const selectedIdx = allRounds.indexOf(selected);
+  if (selectedIdx < 0) return bracketOrder;
+
+  if (selectedIdx === leafIdx) {
+    // Same as configured leaf → original bracket order
+    return bracketOrder;
+  } else if (selectedIdx > leafIdx) {
+    // Later round → collapse using bracket tree
+    const treeDepthIdx = roundsByDepth.indexOf(selected);
+    if (treeDepthIdx < 0) return bracketOrder;
+    return collectWinnersAtDepth(fullRoot, treeDepthIdx + 1);
+  } else {
+    // Earlier round → extend backward from leaf
+    let order: (string | null)[] = [...bracketOrder];
+    for (let i = leafIdx - 1; i >= selectedIdx; i--) {
+      order = extendBracketBackward(order, csvRows, allRounds[i]);
+    }
+    return order;
+  }
+}
+
+// ---- Bracket rendering with date filter ------------------------------------
+
+function getTargetDate(): string | null {
+  return controlState.viewer.targetDate;
+}
+
+/** Check whether the selection should render bracket sections independently. */
+function shouldRenderMultiSectionView(
+  bracketBlocks: BracketBlock[] | undefined,
+  roundStart: string | null,
+): boolean {
+  return roundStart === MULTI_SECTION_VALUE && bracketBlocks != null;
+}
+
+/**
+ * Build and render a bracket tree (with date mask) into a container.
+ * Uses cache to avoid redundant buildBracket calls on slider/layout changes.
+ */
+function buildAndRenderBracket(
+  container: HTMLElement,
+  input: SingleBracketRenderInput,
+): void {
+  const { rows, order, aggregateTiebreakOrder, targetDate, lastDate, cssFiles } = input;
+  if (order.length < 2) return;
+  const cacheKey = JSON.stringify(order);
+  let fullRoot = bracketCache.get(cacheKey);
+  if (!fullRoot) {
+    fullRoot = buildBracket(rows, order, aggregateTiebreakOrder);
+    bracketCache.set(cacheKey, fullRoot);
+  }
+  const root = (targetDate && targetDate < lastDate)
+    ? maskBracketForDate(fullRoot, targetDate) : fullRoot;
+  renderBracketInto(container, root, cssFiles, controlState.bracket.layout);
+}
+
+function createSingleBracketRenderInput(
+  state: Pick<BracketState, 'csvRows' | 'seasonInfo' | 'matchDates'>,
+  order: (string | null)[],
+): SingleBracketRenderInput | null {
+  if (order.length < 2 || state.matchDates.length === 0) return null;
+  return {
+    rows: state.csvRows,
+    order,
+    aggregateTiebreakOrder: state.seasonInfo.aggregateTiebreakOrder,
+    targetDate: getTargetDate(),
+    lastDate: state.matchDates[state.matchDates.length - 1],
+    cssFiles: state.seasonInfo.cssFiles,
+  };
+}
+
+function createInclusiveBracketRenderInput(
+  state: Pick<
+  BracketState,
+  'csvRows' | 'seasonInfo' | 'matchDates' |
+  'fullRoot' | 'bracketOrder' | 'roundsByDepth' | 'allRounds'
+  >,
+): SingleBracketRenderInput | null {
+  const order = resolveInclusiveBracketOrder(state, controlState.bracket.roundStart);
+  return createSingleBracketRenderInput(state, order);
+}
+
+/**
+ * Render multi-section view: each BracketBlock becomes an independent
+ * collapsible bracket, all sharing the same CSV and date filter.
+ */
+function renderMultiSections(): void {
+  if (!currentState?.bracketBlocks) return;
+  const container = refs.container;
+
+  // Save open/closed state of existing sections before re-render
+  const prevOpen = new Map<string, boolean>();
+  for (const d of Array.from(container.querySelectorAll<HTMLDetailsElement>('.bracket-section'))) {
+    const label = d.querySelector('.bracket-section-summary')?.textContent ?? '';
+    if (label) prevOpen.set(label, d.open);
+  }
+
+  container.replaceChildren();
+
+  // Toggle-all button
+  const toggleBtn = document.createElement('button');
+  toggleBtn.id = 'toggle_section_all';
+  toggleBtn.textContent = t('btn.collapseAll');
+  toggleBtn.addEventListener('click', () => {
+    const allDetails = container.querySelectorAll<HTMLDetailsElement>('.bracket-section');
+    const anyOpen = Array.from(allDetails).some(d => d.open);
+    for (const d of Array.from(allDetails)) d.open = !anyOpen;
+    toggleBtn.textContent = anyOpen ? t('btn.expandAll') : t('btn.collapseAll');
+    applyScale();
+  });
+  container.appendChild(toggleBtn);
+
+  for (const section of currentState.bracketBlocks) {
+    const sectionOrder = section.bracket_order ?? [];
+    if (sectionOrder.length < 2) continue;
+
+    // Pre-filter CSV rows by round_filter if specified
+    const rows = section.round_filter
+      ? filterRowsByRounds(currentState.csvRows, section.round_filter)
+      : currentState.csvRows;
+
+    // Create collapsible section
+    const details = document.createElement('details');
+    details.classList.add('bracket-section');
+    // Restore previous open state; default to open for new sections
+    details.open = prevOpen.get(section.label) ?? true;
+    details.addEventListener('toggle', () => {
+      applyScale();
+    });
+    const summary = document.createElement('summary');
+    summary.classList.add('bracket-section-summary');
+    summary.textContent = section.label;
+    details.appendChild(summary);
+
+    // Bracket wrapper (needed as container for adjustBracketPositions)
+    const sectionWrapper = document.createElement('div');
+    sectionWrapper.classList.add('bracket-section-content');
+    details.appendChild(sectionWrapper);
+
+    // Append to DOM before rendering (getBoundingClientRect needs layout)
+    container.appendChild(details);
+
+    if (section.matchup_pairs) {
+      // Matchup pairs: split bracket_order into pairs and render each independently
+      const order = sectionOrder;
+      for (let i = 0; i < order.length; i += 2) {
+        const pair = order.slice(i, i + 2);
+        if (pair.every(t => t == null)) continue;
+        const input = createSingleBracketRenderInput(
+          { ...currentState, csvRows: rows },
+          pair,
+        );
+        if (input) buildAndRenderBracket(sectionWrapper, input);
+      }
+    } else {
+      const input = createSingleBracketRenderInput(
+        { ...currentState, csvRows: rows },
+        sectionOrder,
+      );
+      if (input) buildAndRenderBracket(sectionWrapper, input);
+    }
+  }
+}
+
+/** Render the single-tree ("inclusive") bracket view. */
+function renderInclusiveBracket(container: HTMLElement): void {
+  if (!currentState) return;
+  const input = createInclusiveBracketRenderInput(currentState);
+  if (!input) return;
+  container.replaceChildren();
+  buildAndRenderBracket(container, input);
+}
+
+function renderWithDateFilter(): void {
+  if (!currentState) return;
+  const container = refs.container;
+
+  // Dismiss any pinned tooltip before re-render (DOM will be replaced)
+  unpinTooltip();
+
+  // Multi-section mode: render each section as its own bracket block.
+  if (shouldRenderMultiSectionView(currentState.bracketBlocks, controlState.bracket.roundStart)) {
+    renderMultiSections();
+    return;
+  }
+
+  // Inclusive mode: resolve one effective bracket order, then render it as one tree.
+  renderInclusiveBracket(container);
+}
+
+/** Sync viewer control targetDate from slider position. */
+function syncTargetDateFromSlider(): void {
+  if (!currentState) return;
+  const slider = refs.dateSlider;
+  controlState.viewer.targetDate = getSliderDate(currentState.matchDates, parseInt(slider.value, 10));
+}
+
+/** Align slider position to the kept target date without overwriting the target itself. */
+function syncSliderFromTargetDate(): void {
+  if (!currentState) return;
+  const slider = refs.dateSlider;
+  syncSliderToTargetDate(slider, currentState.matchDates, controlState.viewer.targetDate);
+}
+
+/** Update display label from current slider position + kept target date. */
+function updateSliderDisplay(): void {
+  if (!currentState) return;
+  const slider = refs.dateSlider;
+  const display = refs.postDateSlider;
+  const sliderDate = getSliderDate(currentState.matchDates, parseInt(slider.value, 10)) ?? '';
+  const targetDate = resolveTargetDate(currentState.matchDates, controlState.viewer.targetDate) ?? sliderDate;
+  display.textContent = formatSliderDate(sliderDate, targetDate);
+}
+
+// ---- Controls: opacity, scale, layout --------------------------------------
+
+/** Apply futureOpacity from controlState to all .bracket-future elements. */
+function applyFutureOpacity(): void {
+  const container = refs.container;
+  const value = String(controlState.viewer.futureOpacity);
+  for (const el of Array.from(container.querySelectorAll('.bracket-future'))) {
+    (el as HTMLElement).style.opacity = value;
+  }
+  refs.currentOpacity.textContent = value;
+}
+
+/** Keep layout height in sync with the visual scale of the bracket container. */
+function syncBracketContainerHeight(container: HTMLElement): void {
+  container.style.height = 'auto';
+  const rawHeight = container.scrollHeight;
+  if (rawHeight > 0) {
+    container.style.height = `${rawHeight * controlState.viewer.scale}px`;
+  }
+}
+
+/** Apply scale from controlState to bracket container. */
+function applyScale(): void {
+  const container = refs.container;
+  const value = String(controlState.viewer.scale);
+  container.style.transform = `scale(${value})`;
+  container.style.transformOrigin = 'top left';
+  syncBracketContainerHeight(container);
+  refs.currentScale.textContent = value;
+}
+
+// ---- Render pipeline -------------------------------------------------------
+
+const CACHE_BUST_WINDOW_SEC = 300;
+
+function loadAndRender(seasonMap: SeasonMap): void {
+  const competition = activeSelection?.competition ?? '';
+  const season = activeSelection?.season ?? '';
+  if (!competition || !season) return;
+
+  const found = findCompetition(seasonMap, competition);
+  if (!found || !found.competition.seasons[season]) {
+    setStatus(t('status.noSeason', { competition, season }));
+    return;
+  }
+
+  const entry = found.competition.seasons[season];
+
+  const filename = getCsvFilename(competition, season);
+  const cachebuster = Math.floor(Date.now() / 1000 / CACHE_BUST_WINDOW_SEC);
+  setStatus(t('status.loading'));
+
+  Papa.parse<RawMatchRow>(filename + '?_=' + cachebuster, {
+    header: true,
+    skipEmptyLines: 'greedy',
+    download: true,
+    complete: (results) => {
+      const inferredOrder = inferBracketOrderFromRows(results.data);
+      const seasonTeams = entry.teams && entry.teams.length > 0
+        ? entry.teams
+        : (inferredOrder ? extractTeamsFromBracketOrder(inferredOrder) : []);
+      const rawSections = entry.bracket_blocks
+        ? resolveSectionBracketOrders(entry.bracket_blocks, seasonTeams)
+        : undefined;
+      const resolvedEntry = {
+        ...entry,
+        teams: seasonTeams,
+        team_count: entry.team_count ?? (seasonTeams.length > 0 ? seasonTeams.length : undefined),
+        bracket_blocks: rawSections,
+      };
+      const tournamentSeasonInfo = resolveTournamentSeasonInfo(
+        found.family, found.competition, resolvedEntry, found.familyKey,
+      );
+      const bracketOrder = resolveSeasonBracketOrder(entry, inferredOrder);
+      if (!bracketOrder || bracketOrder.length === 0) {
+        setStatus('No bracket data for this season.');
+        return;
+      }
+      const resolved = rawSections
+        ? resolveSectionRoundFilters(rawSections, entry.default_round_filter)
+        : undefined;
+      const bracketBlocks = resolved
+        ? inferMissingSectionRoundFilters(resolved, results.data)
+        : undefined;
+      const bracketRows = collectBracketSourceRows(results.data, bracketBlocks);
+      const matchDates = collectMatchDates(bracketRows);
+
+      // Build full tree to extract round structure and pre-populate cache
+      const fullRoot = buildBracket(
+        bracketRows,
+        bracketOrder,
+        tournamentSeasonInfo.aggregateTiebreakOrder,
+      );
+      bracketCache = new Map();
+      bracketCache.set(JSON.stringify(bracketOrder), fullRoot);
+      const roundsByDepth = collectRoundsByDepth(fullRoot);
+      const bracketRounds = collectBracketRounds(fullRoot);
+      const allRounds = bracketBlocks
+        ? bracketRounds
+        : collectRoundsFromCsv(bracketRows).filter(r => bracketRounds.includes(r));
+
+      currentState = {
+        csvRows: bracketRows,
+        bracketOrder,
+        seasonInfo: tournamentSeasonInfo,
+        fullRoot,
+        roundsByDepth,
+        allRounds,
+        bracketBlocks,
+        matchDates,
+        season,
+      };
+
+      // Populate round start dropdown (with multi-section option if sections exist)
+      populateRoundStartPulldown(
+        allRounds,
+        tournamentSeasonInfo.defaultRoundStart,
+        bracketBlocks != null,
+        tournamentSeasonInfo.roundStartOptions,
+      );
+
+      // Sync round start: restore from controlState or pick up dropdown default
+      const roundSel = refs.roundStart;
+      if (controlState.bracket.roundStart) {
+        const normalizedSelected = normalizeBracketRoundLabel(controlState.bracket.roundStart);
+        const hasOption = Array.from(roundSel.options).some(o => o.value === normalizedSelected);
+        if (hasOption) {
+          roundSel.value = normalizedSelected;
+          controlState.bracket.roundStart = normalizedSelected;
+        } else {
+          controlState.bracket.roundStart = roundSel.value;
+        }
+      } else {
+        controlState.bracket.roundStart = roundSel.value;
+      }
+
+      // Set up date slider and sync viewer control targetDate
+      const slider = refs.dateSlider;
+      if (matchDates.length > 0) {
+        slider.min = '0';
+        if (!controlState.viewer.targetDate) {
+          controlState.viewer.targetDate = getLastMatchDate(matchDates);
+        }
+        syncSliderFromTargetDate();
+      }
+
+      renderWithDateFilter();
+      updateSliderDisplay();
+      applyFutureOpacity();
+      applyScale();
+
+      // Update season notes + bracket-specific notes
+      const notesEl = refs.seasonNotes;
+      {
+        notesEl.replaceChildren();
+        const bracketNotes = [
+          t('bracketNote.aggregateScore'),
+          t('bracketNote.etIncluded'),
+          t('bracketNote.pkAnnotation'),
+        ];
+        for (const text of [...tournamentSeasonInfo.notes, ...bracketNotes]) {
+          const li = document.createElement('li');
+          li.textContent = text;
+          notesEl.appendChild(li);
+        }
+      }
+
+      setStatus(t('status.loaded', {
+        league: tournamentSeasonInfo.leagueDisplay, season, rows: bracketRows.length,
+      }));
+    },
+    error: (err: unknown) => {
+      setStatus(t('status.error', { detail: String(err) }));
+    },
+  });
+}
+
+// ---- Lifecycle -------------------------------------------------------------
+
+export function initBracketView(
+  ids: BracketViewIds,
+  context: BracketViewContext,
+): BracketViewHandle {
+  refs = resolveRefs(ids);
+  viewContext = context;
+  const prefs = loadPrefs();
+  controlState = createControlStateFromPrefs(prefs, context.shared);
+
+  refs.dateSlider.addEventListener('input', () => {
+    syncTargetDateFromSlider();
+    updateSliderDisplay();
+  });
+  refs.dateSlider.addEventListener('change', () => {
+    syncTargetDateFromSlider();
+    updateSliderDisplay();
+    renderWithDateFilter();
+    applyFutureOpacity();
+    viewContext.onViewerChange();
+  });
+  refs.dateSliderDown.addEventListener('click', () => {
+    refs.dateSlider.value = String(Math.max(0, parseInt(refs.dateSlider.value, 10) - 1));
+    syncTargetDateFromSlider();
+    updateSliderDisplay();
+    renderWithDateFilter();
+    applyFutureOpacity();
+    viewContext.onViewerChange();
+  });
+  refs.dateSliderUp.addEventListener('click', () => {
+    refs.dateSlider.value = String(Math.min(
+      parseInt(refs.dateSlider.max, 10), parseInt(refs.dateSlider.value, 10) + 1,
+    ));
+    syncTargetDateFromSlider();
+    updateSliderDisplay();
+    renderWithDateFilter();
+    applyFutureOpacity();
+    viewContext.onViewerChange();
+  });
+  refs.dateSliderReset.addEventListener('click', () => {
+    if (!currentState) return;
+    controlState.viewer.targetDate = getLastMatchDate(currentState.matchDates);
+    syncSliderFromTargetDate();
+    updateSliderDisplay();
+    renderWithDateFilter();
+    applyFutureOpacity();
+    viewContext.onViewerChange();
+  });
+  refs.futureOpacity.addEventListener('input', () => {
+    controlState.viewer.futureOpacity = parseFloat(refs.futureOpacity.value);
+    applyFutureOpacity();
+    viewContext.onViewerChange();
+  });
+  refs.scaleSlider.addEventListener('input', () => {
+    controlState.viewer.scale = parseFloat(refs.scaleSlider.value);
+    applyScale();
+    viewContext.onViewerChange();
+  });
+  refs.layout.addEventListener('change', () => {
+    controlState.bracket.layout = refs.layout.value as 'horizontal' | 'vertical';
+    renderWithDateFilter();
+    applyFutureOpacity();
+  });
+  refs.roundStart.addEventListener('change', () => {
+    controlState.bracket.roundStart = refs.roundStart.value;
+    renderWithDateFilter();
+    applyFutureOpacity();
+    savePrefs({ roundStart: controlState.bracket.roundStart });
+  });
+
+  return {
+    activate(seasonMap, selection) {
+      activeSelection = selection;
+      refs.competition.value = selection.competition;
+      refs.season.value = selection.season;
+      refs.futureOpacity.value = String(controlState.viewer.futureOpacity);
+      const previousScale = controlState.viewer.scale;
+      controlState.viewer.scale = clampToSlider(previousScale, refs.scaleSlider);
+      refs.scaleSlider.value = String(controlState.viewer.scale);
+      if (controlState.viewer.scale !== previousScale) viewContext.onViewerChange();
+      loadAndRender(seasonMap);
+    },
+    deactivate() {
+      unpinTooltip();
+    },
+  };
+}

--- a/frontend/src/bracket-view.ts
+++ b/frontend/src/bracket-view.ts
@@ -682,11 +682,11 @@ function renderWithDateFilter(): void {
   // Multi-section mode: render each section as its own bracket block.
   if (shouldRenderMultiSectionView(currentState.bracketBlocks, controlState.bracket.roundStart)) {
     renderMultiSections();
-    return;
+  } else {
+    // Inclusive mode: resolve one effective bracket order, then render it as one tree.
+    renderInclusiveBracket(container);
   }
 
-  // Inclusive mode: resolve one effective bracket order, then render it as one tree.
-  renderInclusiveBracket(container);
 }
 
 /** Sync viewer control targetDate from slider position. */
@@ -728,9 +728,17 @@ function applyFutureOpacity(): void {
 /** Keep layout height in sync with the visual scale of the bracket container. */
 function syncBracketContainerHeight(container: HTMLElement): void {
   container.style.height = 'auto';
-  const rawHeight = container.scrollHeight;
-  if (rawHeight > 0) {
-    container.style.height = `${rawHeight * controlState.viewer.scale}px`;
+  // scrollHeight can retain the previous explicit height and offsetHeight
+  // excludes the translated match wrappers used to align bracket branches.
+  // Measure the rendered descendant bounds, which include those transforms.
+  const containerTop = container.getBoundingClientRect().top;
+  const visualBottom = Array.from(container.querySelectorAll<HTMLElement>('*')).reduce(
+    (bottom, child) => Math.max(bottom, child.getBoundingClientRect().bottom),
+    containerTop,
+  );
+  const visualHeight = visualBottom - containerTop;
+  if (visualHeight > 0) {
+    container.style.height = `${visualHeight}px`;
   }
 }
 
@@ -953,11 +961,13 @@ export function initBracketView(
     controlState.bracket.layout = refs.layout.value as 'horizontal' | 'vertical';
     renderWithDateFilter();
     applyFutureOpacity();
+    applyScale();
   });
   refs.roundStart.addEventListener('change', () => {
     controlState.bracket.roundStart = refs.roundStart.value;
     renderWithDateFilter();
     applyFutureOpacity();
+    applyScale();
     savePrefs({ roundStart: controlState.bracket.roundStart });
   });
 

--- a/frontend/src/config/season-map.ts
+++ b/frontend/src/config/season-map.ts
@@ -64,6 +64,18 @@ export function getCompetitionViewTypes(family: CompetitionFamilyEntry, comp: Co
   return viewTypes.length > 0 ? viewTypes : ['league'];
 }
 
+/** Resolve the one view used by a competition, rejecting ambiguous inheritance. */
+export function resolveCompetitionViewType(
+  family: CompetitionFamilyEntry,
+  comp: CompetitionEntry,
+): ViewType {
+  const viewTypes = getCompetitionViewTypes(family, comp);
+  if (viewTypes.length !== 1) {
+    throw new Error(`Ambiguous competition view_type: ${viewTypes.join(', ')}`);
+  }
+  return viewTypes[0];
+}
+
 function pickCascade<T>(...values: (T | undefined)[]): T | undefined {
   return values.find((value) => value !== undefined);
 }

--- a/frontend/src/league-view.ts
+++ b/frontend/src/league-view.ts
@@ -1,0 +1,786 @@
+// League view module.
+//
+// Navigates the 4-tier season_map.yaml hierarchy:
+//   family → competition → seasons → entry
+//
+// - Competition dropdown is populated dynamically with family separators.
+// - URL parameters (?competition=J1&season=2026East) are read on init and written on change.
+// - User preferences are persisted via localStorage and restored on reload.
+// - Data timestamp is loaded from csv/csv_timestamp.csv and displayed.
+
+import Papa from 'papaparse';
+import type { RawMatchRow, TeamMap } from './types/match';
+import type { SeasonMap, LeagueSeasonInfo } from './types/season';
+import {
+  getCsvFilename, findCompetition, resolveLeagueSeasonInfo,
+} from './config/season-map';
+import { parseCsvResults } from './core/csv-parser';
+import { dateFormat } from './core/date-utils';
+import {
+  getLastMatchDate, getSliderDate, syncSliderToTargetDate,
+} from './core/date-slider';
+import { prepareRenderData } from './core/prepare-render';
+import type { MatchSortKey } from './ranking/stats-calculator';
+import {
+  makeRankData, makeRankTable,
+  buildCrossGroupRows, makeCrossGroupTable, getToggleableColumns,
+} from './ranking/rank-table';
+import type { GroupRenderResult } from './ranking/rank-table';
+import { getMaxPointsPerGame } from './core/point-calculator';
+import { renderBarGraph } from './graph/renderer';
+import { DEFAULT_HEIGHT_UNIT, getHeightUnit, setFutureOpacity, setSpace, setScale } from './graph/css-utils';
+import { findTeamsWithoutColor } from './graph/css-validator';
+import { teamCssClass } from './core/team-utils';
+import { loadPrefs, savePrefs } from './storage/local-storage';
+import type { ViewerPrefs } from './storage/local-storage';
+import { t } from './i18n';
+import {
+  clampToSlider, normalizeTargetDate, toInputDate,
+} from './view-bootstrap';
+import type { SharedViewerControlState } from './view-bootstrap';
+
+// ---- Application state ------------------------------------------------
+
+interface TeamMapCache {
+  key: string;
+  teamMap: TeamMap;
+  teamCount: number;
+  hasPk: boolean;
+  hasEx: boolean;
+  hasTimezone: boolean;  // true → at least one match carries a source TZ (per-row column or season)
+}
+
+/** Mutable application state collected in one place. */
+interface AppState {
+  timestampMap: Record<string, string> | null;
+  teamMapCache: TeamMapCache | null;
+  currentMatchDates: string[];
+  heightUnit: number;
+  renderVersion: number;
+}
+
+const state: AppState = {
+  timestampMap: null,
+  teamMapCache: null,
+  currentMatchDates: [],
+  heightUnit: DEFAULT_HEIGHT_UNIT,
+  renderVersion: 0,
+};
+
+// ---- Control state (symmetric with tournament-app.ts) -----------------
+
+interface LeagueViewerControlState extends SharedViewerControlState {
+  displayTimezone: string;  // '' = browser default; otherwise an IANA TZ name
+  hiddenColumns: Set<string>;  // rank table column data-ids hidden by the user
+}
+
+interface LeagueControlState {
+  teamSortKey: string;
+  matchSortKey: string;
+  spaceColor: string;
+}
+
+interface ControlState {
+  viewer: LeagueViewerControlState;
+  league: LeagueControlState;
+}
+
+function createControlStateFromPrefs(
+  prefs: ViewerPrefs,
+  shared: SharedViewerControlState,
+): ControlState {
+  return {
+    viewer: {
+      ...shared,
+      displayTimezone: prefs.displayTimezone ?? '',
+      hiddenColumns: new Set(prefs.hiddenColumns ?? []),
+    },
+    league: {
+      teamSortKey: prefs.teamSortKey ?? 'disp_point',
+      matchSortKey: prefs.matchSortKey ?? 'old_bottom',
+      spaceColor: prefs.spaceColor ?? '#cccccc',
+    },
+  };
+}
+
+let controlState: ControlState;
+let activeSeasonMap: SeasonMap | null = null;
+let activeSelection: LeagueViewSelection | null = null;
+
+const DEFAULT_GROUP = 'matches';
+
+// CSV URL cache-busting: same bucket for requests within this window (seconds).
+const CACHE_BUST_WINDOW_SEC = 300; // 5 minutes
+
+export interface LeagueViewSelection {
+  competition: string;
+  season: string;
+}
+
+export interface LeagueViewContext {
+  shared: SharedViewerControlState;
+  onViewerChange(): void;
+}
+
+export interface LeagueViewHandle {
+  activate(seasonMap: SeasonMap, selection: LeagueViewSelection): void;
+  deactivate(): void;
+}
+
+export interface LeagueViewIds {
+  competition: string;
+  season: string;
+  teamSort: string;
+  matchSort: string;
+  displayTimezone: string;
+  displayTimezoneLabel: string;
+  dateSlider: string;
+  dateSliderDown: string;
+  dateSliderUp: string;
+  dateSliderReset: string;
+  postDateSlider: string;
+  targetDate: string;
+  scaleSlider: string;
+  futureOpacity: string;
+  spaceColor: string;
+  columnToggleList: string;
+  status: string;
+  warning: string;
+  timestamp: string;
+  boxContainer: string;
+  ranktableSection: string;
+  seasonNotes: string;
+  dataSourceSection: string;
+}
+
+export const LEAGUE_STANDALONE_IDS: LeagueViewIds = {
+  competition: 'competition_key',
+  season: 'season_key',
+  teamSort: 'team_sort_key',
+  matchSort: 'match_sort_key',
+  displayTimezone: 'display_timezone',
+  displayTimezoneLabel: 'display_timezone_label',
+  dateSlider: 'date_slider',
+  dateSliderDown: 'date_slider_down',
+  dateSliderUp: 'date_slider_up',
+  dateSliderReset: 'reset_date_slider',
+  postDateSlider: 'post_date_slider',
+  targetDate: 'target_date',
+  scaleSlider: 'scale_slider',
+  futureOpacity: 'future_opacity',
+  spaceColor: 'space_color',
+  columnToggleList: 'column_toggle_list',
+  status: 'status_msg',
+  warning: 'warning_msg',
+  timestamp: 'data_timestamp',
+  boxContainer: 'box_container',
+  ranktableSection: 'ranktable_section',
+  seasonNotes: 'season_notes',
+  dataSourceSection: 'data_source_section',
+};
+
+export const LEAGUE_NAMESPACED_IDS: LeagueViewIds = {
+  ...LEAGUE_STANDALONE_IDS,
+  dateSlider: 'league_date_slider',
+  dateSliderDown: 'league_date_slider_down',
+  dateSliderUp: 'league_date_slider_up',
+  postDateSlider: 'league_post_date_slider',
+  scaleSlider: 'league_scale_slider',
+  futureOpacity: 'league_future_opacity',
+  status: 'league_status_msg',
+  seasonNotes: 'league_season_notes',
+};
+
+interface LeagueViewRefs {
+  competition: HTMLSelectElement;
+  season: HTMLSelectElement;
+  teamSort: HTMLSelectElement;
+  matchSort: HTMLSelectElement;
+  displayTimezone: HTMLSelectElement;
+  displayTimezoneLabel: HTMLElement;
+  dateSlider: HTMLInputElement;
+  dateSliderDown: HTMLElement;
+  dateSliderUp: HTMLElement;
+  dateSliderReset: HTMLElement;
+  postDateSlider: HTMLElement;
+  targetDate: HTMLInputElement;
+  scaleSlider: HTMLInputElement;
+  futureOpacity: HTMLInputElement;
+  spaceColor: HTMLInputElement;
+  columnToggleList: HTMLElement;
+  status: HTMLElement;
+  warning: HTMLElement;
+  timestamp: HTMLElement;
+  boxContainer: HTMLElement;
+  sortableTable: HTMLElement;
+  seasonNotes: HTMLElement;
+  dataSourceSection: HTMLElement;
+}
+
+let refs: LeagueViewRefs;
+let viewContext: LeagueViewContext;
+
+function requireElement<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) throw new Error(`League view element not found: #${id}`);
+  return element as T;
+}
+
+function resolveRefs(ids: LeagueViewIds): LeagueViewRefs {
+  const ranktableSection = requireElement<HTMLElement>(ids.ranktableSection);
+  const sortableTable = ranktableSection.querySelector<HTMLElement>('.sortable-table');
+  if (!sortableTable) throw new Error(`League view sortable table not found in #${ids.ranktableSection}`);
+  return {
+    competition: requireElement(ids.competition),
+    season: requireElement(ids.season),
+    teamSort: requireElement(ids.teamSort),
+    matchSort: requireElement(ids.matchSort),
+    displayTimezone: requireElement(ids.displayTimezone),
+    displayTimezoneLabel: requireElement(ids.displayTimezoneLabel),
+    dateSlider: requireElement(ids.dateSlider),
+    dateSliderDown: requireElement(ids.dateSliderDown),
+    dateSliderUp: requireElement(ids.dateSliderUp),
+    dateSliderReset: requireElement(ids.dateSliderReset),
+    postDateSlider: requireElement(ids.postDateSlider),
+    targetDate: requireElement(ids.targetDate),
+    scaleSlider: requireElement(ids.scaleSlider),
+    futureOpacity: requireElement(ids.futureOpacity),
+    spaceColor: requireElement(ids.spaceColor),
+    columnToggleList: requireElement(ids.columnToggleList),
+    status: requireElement(ids.status),
+    warning: requireElement(ids.warning),
+    timestamp: requireElement(ids.timestamp),
+    boxContainer: requireElement(ids.boxContainer),
+    sortableTable,
+    seasonNotes: requireElement(ids.seasonNotes),
+    dataSourceSection: requireElement(ids.dataSourceSection),
+  };
+}
+
+// ---- Fixed dropdown options (generated into HTML by TS) ------------------
+
+const MATCH_SORT_VALUES = ['old_bottom', 'new_bottom', 'first_bottom', 'last_bottom'] as const;
+
+function getTeamSortOptions(): { value: string; label: string }[] {
+  return [
+    { value: 'disp_point',    label: t('sort.dispPoint') },
+    { value: 'disp_avlbl_pt', label: t('sort.dispAvlblPt') },
+    { value: 'point',         label: t('sort.point') },
+    { value: 'avlbl_pt',      label: t('sort.avlblPt') },
+  ];
+}
+
+function getMatchSortOptions(): { value: string; label: string }[] {
+  return [
+    { value: 'old_bottom',   label: t('sort.oldBottom') },
+    { value: 'new_bottom',   label: t('sort.newBottom') },
+    { value: 'first_bottom', label: t('sort.firstBottom') },
+    { value: 'last_bottom',  label: t('sort.lastBottom') },
+  ];
+}
+
+// Curated display-TZ list: browser default (empty value) + JST/UTC + WC2026 host zones.
+// Labels are language-neutral (IANA name + offset hint); only the default is translated.
+function getDisplayTzOptions(): { value: string; label: string }[] {
+  return [
+    { value: '',                     label: t('tz.browserDefault') },
+    { value: 'Asia/Tokyo',           label: 'Asia/Tokyo (JST)' },
+    { value: 'UTC',                  label: 'UTC' },
+    { value: 'America/New_York',     label: 'America/New_York (ET)' },
+    { value: 'America/Chicago',      label: 'America/Chicago (CT)' },
+    { value: 'America/Denver',       label: 'America/Denver (MT)' },
+    { value: 'America/Los_Angeles',  label: 'America/Los_Angeles (PT)' },
+    { value: 'America/Mexico_City',  label: 'America/Mexico_City' },
+    { value: 'America/Monterrey',    label: 'America/Monterrey' },
+    { value: 'America/Vancouver',    label: 'America/Vancouver' },
+    { value: 'America/Toronto',      label: 'America/Toronto' },
+  ];
+}
+
+// ---- DOM helpers -------------------------------------------------------
+
+function setStatus(msg: string): void {
+  refs.status.textContent = msg;
+}
+
+function showWarning(msg: string | null): void {
+  if (msg) {
+    refs.warning.textContent = msg;
+    refs.warning.hidden = false;
+  } else {
+    refs.warning.textContent = '';
+    refs.warning.hidden = true;
+  }
+}
+
+// ---- Timestamp management ----------------------------------------------
+
+async function loadTimestampMap(): Promise<Record<string, string>> {
+  if (state.timestampMap !== null) return state.timestampMap;
+  try {
+    const res = await fetch('./csv/csv_timestamp.csv');
+    if (!res.ok) return (state.timestampMap = {});
+    const text = await res.text();
+    const result = Papa.parse<{ file: string; date: string }>(text, {
+      header: true,
+      skipEmptyLines: 'greedy',
+    });
+    const map: Record<string, string> = {};
+    for (const row of result.data) {
+      const key = row.file.replace('../docs/', '');
+      const d = new Date(row.date.replace(' ', 'T'));
+      map[key] = isNaN(d.getTime()) ? row.date : formatTimestamp(d);
+    }
+    return (state.timestampMap = map);
+  } catch {
+    return (state.timestampMap = {});
+  }
+}
+
+function formatTimestamp(d: Date): string {
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  return `${d.getFullYear()}/${pad(d.getMonth() + 1)}/${pad(d.getDate())} `
+       + `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function showTimestamp(csvFilename: string): void {
+  if (!state.timestampMap) return;
+  refs.timestamp.textContent = state.timestampMap[csvFilename] ?? '';
+}
+
+// ---- Fixed dropdown population -----------------------------------------
+
+type MatchSortUiValue = typeof MATCH_SORT_VALUES[number];
+
+function populateFixedSelect(
+  sel: HTMLSelectElement,
+  options: ReadonlyArray<{ readonly value: string; readonly label: string }>,
+): void {
+  sel.innerHTML = '';
+  for (const { value, label } of options) {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = label;
+    sel.appendChild(opt);
+  }
+}
+
+// ---- Column visibility toggle population -------------------------------
+
+// Builds one checkbox per toggleable rank-table column inside #column_toggle_list.
+// onToggle is invoked with (columnId, checked) whenever a checkbox changes.
+function populateColumnToggleList(
+  hiddenColumns: ReadonlySet<string>,
+  onToggle: (columnId: string, checked: boolean) => void,
+): void {
+  const container = refs.columnToggleList;
+  container.innerHTML = '';
+  for (const col of getToggleableColumns()) {
+    if (!col.id) continue;
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = !hiddenColumns.has(col.id);
+    checkbox.addEventListener('change', () => onToggle(col.id!, checkbox.checked));
+    label.appendChild(checkbox);
+    label.appendChild(document.createTextNode(col.label));
+    container.appendChild(label);
+  }
+}
+
+// ---- Match sort key mapping --------------------------------------------
+
+function getMatchSortKey(uiValue: string): MatchSortKey {
+  const v = uiValue as MatchSortUiValue;
+  return (v === 'first_bottom' || v === 'last_bottom') ? 'section_no' : 'match_date';
+}
+
+function isBottomFirst(uiValue: string): boolean {
+  const v = uiValue as MatchSortUiValue;
+  return (v === 'old_bottom' || v === 'first_bottom');
+}
+
+// ---- Date slider management --------------------------------------------
+
+function resetDateSlider(matchDates: string[], targetDate: string): void {
+  state.currentMatchDates = matchDates;
+  if (matchDates.length === 0) return;
+  syncSliderToTargetDate(refs.dateSlider, matchDates, targetDate);
+
+  const lastDate = getLastMatchDate(matchDates);
+  if (lastDate) refs.postDateSlider.textContent = lastDate;
+}
+
+// ---- Core render pipeline ----------------------------------------------
+
+function renderFromCache(
+  cache: TeamMapCache,
+  seasonMap: SeasonMap,
+  competition: string,
+  season: string,
+  targetDate: string,
+  sortKey: string,
+  matchSortKey: MatchSortKey,
+  bottomFirst: boolean,
+  disp: boolean,
+): void {
+  const found = findCompetition(seasonMap, competition);
+  if (!found) return;
+  const entry = found.competition.seasons[season];
+  if (!entry) return;
+  const seasonInfo = resolveLeagueSeasonInfo(found.family, found.competition, entry, found.familyKey);
+  const { hasPk, hasEx } = cache;
+
+  // Show the display-timezone selector only when this season actually has source TZ data.
+  refs.displayTimezoneLabel.hidden = !cache.hasTimezone;
+
+  // Determine which groups to render and in what order.
+  const allGroups = Object.keys(cache.teamMap);
+  const groupKeys = seasonInfo.shownGroups
+    ? seasonInfo.shownGroups.filter(g => allGroups.includes(g))
+    : allGroups.sort();
+  const isMultiGroup = groupKeys.length > 1;
+
+  const globalMatchDateSet = new Set<string>();
+  const allTeamCssClasses: string[] = [];
+  const boxCon = refs.boxContainer;
+  {
+    boxCon.replaceChildren();
+    // Multi-group graphs are laid out as stacked block rows (column); single-group
+    // keeps the original single horizontal row.
+    boxCon.classList.toggle('blockrows', isMultiGroup);
+  }
+
+  // Block-row wrapping state (multi-group only): accumulate team counts and wrap to
+  // a new .group_block_row once the next group would exceed maxRowTeams.
+  let currentBlockRow: HTMLElement | null = null;
+  let currentRowTeams = 0;
+
+  // Prepare ranking table container.
+  const sortableDiv = refs.sortableTable;
+  sortableDiv.innerHTML = '';
+
+  // Collect per-group results for cross-group comparison (populated during loop).
+  const allGroupResults: Record<string, GroupRenderResult> = {};
+
+  for (const groupKey of groupKeys) {
+    const singleGroupData = cache.teamMap[groupKey];
+    if (!singleGroupData) continue;
+
+    // For multi-group: use per-group team count from config.
+    // promotionCount is kept as-is (group-stage competitions advance a fixed number per group).
+    // relegationCount is zeroed because relegation is never decided per-group.
+    const groupTeamCount = seasonInfo.groupTeamCount?.[groupKey] ?? seasonInfo.teamCount;
+    const perGroupInfo: LeagueSeasonInfo = isMultiGroup
+      ? { ...seasonInfo, teamCount: groupTeamCount, relegationCount: 0 }
+      : seasonInfo;
+
+    const { groupData, sortedTeams } = prepareRenderData({
+      groupData: singleGroupData, seasonInfo: perGroupInfo, targetDate, sortKey, matchSortKey,
+    });
+
+    for (const team of sortedTeams) allTeamCssClasses.push(teamCssClass(team));
+
+    if (boxCon) {
+      const { fragment, matchDates } = renderBarGraph(
+        groupData, sortedTeams, perGroupInfo,
+        targetDate, disp, bottomFirst, state.heightUnit, hasPk, hasEx,
+        controlState.viewer.displayTimezone || undefined,
+      );
+      for (const d of matchDates) globalMatchDateSet.add(d);
+
+      if (isMultiGroup) {
+        // Wrap each group's graph in a flex container with a label.
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('group_wrapper');
+        const label = document.createElement('div');
+        label.classList.add('group_label');
+        label.textContent = t('graph.group', { key: groupKey });
+        wrapper.appendChild(label);
+        wrapper.appendChild(fragment);
+
+        // Start a new block row when the current one would overflow maxRowTeams.
+        // Use the actual rendered column count (sortedTeams.length), not the config
+        // team count. Wrapping happens only at group boundaries (a group is never split).
+        const rowTeams = sortedTeams.length;
+        if (currentBlockRow === null
+            || (currentRowTeams > 0 && currentRowTeams + rowTeams > seasonInfo.maxRowTeams)) {
+          currentBlockRow = document.createElement('div');
+          currentBlockRow.classList.add('group_block_row');
+          boxCon.appendChild(currentBlockRow);
+          currentRowTeams = 0;
+        }
+        currentBlockRow.appendChild(wrapper);
+        currentRowTeams += rowTeams;
+      } else {
+        boxCon.appendChild(fragment);
+      }
+    }
+
+    // Ranking table: one table per group (or single table for single-group).
+    if (sortableDiv) {
+      const table = document.createElement('table');
+      table.className = 'ranktable';
+      if (!isMultiGroup) table.id = 'ranktable';
+      if (isMultiGroup) {
+        const caption = document.createElement('caption');
+        caption.textContent = `Group ${groupKey}`;
+        table.appendChild(caption);
+      }
+      table.appendChild(document.createElement('thead'));
+      sortableDiv.appendChild(table);
+      const rankData = makeRankData(groupData, sortedTeams, perGroupInfo, disp, hasPk, hasEx);
+      makeRankTable(table, rankData, hasPk, hasEx, perGroupInfo.promotionLabel, controlState.viewer.hiddenColumns);
+    }
+
+    // Collect for cross-group comparison.
+    if (isMultiGroup && seasonInfo.crossGroupStanding) {
+      allGroupResults[groupKey] = { sortedTeams, groupData };
+    }
+  }
+
+  // Cross-group standing comparison table (after all per-group tables).
+  if (sortableDiv && seasonInfo.crossGroupStanding && Object.keys(allGroupResults).length > 1) {
+    const cgs = seasonInfo.crossGroupStanding;
+    const maxPt = getMaxPointsPerGame(seasonInfo.pointSystem);
+    const rows = buildCrossGroupRows(allGroupResults, cgs, disp, targetDate, maxPt);
+    if (rows.length > 0) {
+      sortableDiv.appendChild(document.createElement('hr'));
+      sortableDiv.appendChild(makeCrossGroupTable(rows, cgs, controlState.viewer.hiddenColumns));
+    }
+  }
+
+  setScale(boxCon, refs.scaleSlider.value);
+  const globalMatchDates = [...globalMatchDateSet].sort();
+  resetDateSlider(globalMatchDates, targetDate);
+
+  // Update season notes from season_map config.
+  refs.seasonNotes.replaceChildren();
+  for (const text of seasonInfo.notes) {
+    const li = document.createElement('li');
+    li.textContent = text;
+    refs.seasonNotes.appendChild(li);
+  }
+
+  // Update data source link from season_map config.
+  if (seasonInfo.dataSource) {
+    const a = document.createElement('a');
+    a.href = seasonInfo.dataSource.url;
+    a.textContent = seasonInfo.dataSource.label;
+    refs.dataSourceSection.replaceChildren(t('status.dataSource'), a);
+  } else {
+    refs.dataSourceSection.replaceChildren();
+  }
+
+  // I3: Warn about teams with undefined CSS colors.
+  const undefinedTeams = findTeamsWithoutColor(allTeamCssClasses);
+  if (undefinedTeams.length > 0) {
+    showWarning(t('warn.undefinedColor', { teams: undefinedTeams.join(', ') }));
+  } else {
+    showWarning(null);
+  }
+}
+
+function loadAndRender(): void {
+  if (!activeSeasonMap || !activeSelection) return;
+  const renderVersion = ++state.renderVersion;
+  const seasonMap = activeSeasonMap;
+  const { competition, season } = activeSelection;
+  const csvKey      = `${competition}/${season}`;
+
+  const targetDate = normalizeTargetDate(viewContext.shared.targetDate) ?? dateFormat(new Date(), '/');
+
+  const sortKey      = controlState.league.teamSortKey;
+  const matchSortKey = getMatchSortKey(controlState.league.matchSortKey);
+  const bottomFirst  = isBottomFirst(controlState.league.matchSortKey);
+  const disp         = sortKey.startsWith('disp_');
+
+  const found = findCompetition(seasonMap, competition);
+  if (!found || !found.competition.seasons[season]) {
+    setStatus(t('status.noSeason', { competition, season }));
+    return;
+  }
+
+  const leagueDisplay = resolveLeagueSeasonInfo(
+    found.family,
+    found.competition,
+    found.competition.seasons[season],
+    found.familyKey,
+  ).leagueDisplay;
+
+  savePrefs({
+    teamSortKey: sortKey,
+    matchSortKey: controlState.league.matchSortKey,
+  });
+
+  const filename = getCsvFilename(competition, season);
+
+  if (state.teamMapCache?.key === csvKey) {
+    renderFromCache(state.teamMapCache, seasonMap, competition, season, targetDate, sortKey, matchSortKey, bottomFirst, disp);
+    showTimestamp(filename);
+    setStatus(t('status.cached', { league: leagueDisplay, season }));
+    return;
+  }
+
+  const cachebuster = Math.floor(Date.now() / 1000 / CACHE_BUST_WINDOW_SEC);
+  setStatus(t('status.loading'));
+
+  Papa.parse<RawMatchRow>(filename + '?_=' + cachebuster, {
+    header: true,
+    skipEmptyLines: 'greedy',
+    download: true,
+    complete: (results) => {
+      if (renderVersion !== state.renderVersion) return;
+      const entry = found.competition.seasons[season];
+      const seasonInfo = resolveLeagueSeasonInfo(found.family, found.competition, entry, found.familyKey);
+      const teamMap = parseCsvResults(
+        results.data,
+        results.meta.fields ?? [],
+        seasonInfo.teams,
+        DEFAULT_GROUP,
+        seasonInfo.pointSystem,
+        seasonInfo.timezone,
+      );
+      const fields = results.meta.fields ?? [];
+      const hasPk = fields.includes('home_pk_score');
+      const hasEx = fields.includes('home_score_ex');
+      // Source TZ is available when the CSV carries a per-row column or the season sets one.
+      const hasTimezone = fields.includes('timezone') || Boolean(seasonInfo.timezone);
+
+      const newCache = { key: csvKey, teamMap, teamCount: seasonInfo.teamCount, hasPk, hasEx, hasTimezone };
+      state.teamMapCache = newCache;
+
+      renderFromCache(newCache, seasonMap, competition, season, targetDate, sortKey, matchSortKey, bottomFirst, disp);
+      showTimestamp(filename);
+      setStatus(t('status.loaded', { league: leagueDisplay, season, rows: results.data.length }));
+    },
+    error: (err: unknown) => {
+      if (renderVersion !== state.renderVersion) return;
+      setStatus(t('status.error', { detail: String(err) }));
+    },
+  });
+}
+
+// ---- Initialization & event wiring ------------------------------------
+
+export function initLeagueView(ids: LeagueViewIds, ctx: LeagueViewContext): LeagueViewHandle {
+  refs = resolveRefs(ids);
+  viewContext = ctx;
+  const prefs = loadPrefs();
+  controlState = createControlStateFromPrefs(prefs, ctx.shared);
+  state.heightUnit = getHeightUnit();
+  void loadTimestampMap().then(() => {
+    if (activeSelection) showTimestamp(getCsvFilename(
+      activeSelection.competition,
+      activeSelection.season,
+    ));
+  });
+
+  populateFixedSelect(refs.teamSort, getTeamSortOptions());
+  populateFixedSelect(refs.matchSort, getMatchSortOptions());
+  populateFixedSelect(refs.displayTimezone, getDisplayTzOptions());
+  refs.teamSort.value = controlState.league.teamSortKey;
+  refs.matchSort.value = controlState.league.matchSortKey;
+  refs.displayTimezone.value = controlState.viewer.displayTimezone;
+  refs.spaceColor.value = controlState.league.spaceColor;
+
+  populateColumnToggleList(controlState.viewer.hiddenColumns, (columnId, checked) => {
+    if (checked) controlState.viewer.hiddenColumns.delete(columnId);
+    else controlState.viewer.hiddenColumns.add(columnId);
+    savePrefs({ hiddenColumns: [...controlState.viewer.hiddenColumns] });
+    loadAndRender();
+  });
+
+  refs.targetDate.addEventListener('change', () => {
+    ctx.shared.targetDate = normalizeTargetDate(refs.targetDate.value);
+    ctx.onViewerChange();
+    loadAndRender();
+  });
+  refs.teamSort.addEventListener('change', () => {
+    controlState.league.teamSortKey = refs.teamSort.value;
+    loadAndRender();
+  });
+  refs.matchSort.addEventListener('change', () => {
+    controlState.league.matchSortKey = refs.matchSort.value;
+    loadAndRender();
+  });
+
+  const updateFromSlider = (): void => {
+    const date = getSliderDate(state.currentMatchDates, parseInt(refs.dateSlider.value, 10));
+    if (!date) return;
+    refs.targetDate.value = toInputDate(date);
+    ctx.shared.targetDate = normalizeTargetDate(date);
+    ctx.onViewerChange();
+    loadAndRender();
+  };
+  refs.dateSlider.addEventListener('change', updateFromSlider);
+  refs.dateSlider.addEventListener('input', () => {
+    const date = getSliderDate(state.currentMatchDates, parseInt(refs.dateSlider.value, 10));
+    if (date) refs.targetDate.value = toInputDate(date);
+  });
+  refs.dateSliderDown.addEventListener('click', () => {
+    refs.dateSlider.value = String(Math.max(0, parseInt(refs.dateSlider.value, 10) - 1));
+    updateFromSlider();
+  });
+  refs.dateSliderUp.addEventListener('click', () => {
+    refs.dateSlider.value = String(
+      Math.min(parseInt(refs.dateSlider.max, 10), parseInt(refs.dateSlider.value, 10) + 1),
+    );
+    updateFromSlider();
+  });
+  refs.dateSliderReset.addEventListener('click', () => {
+    const today = dateFormat(new Date(), '/');
+    refs.targetDate.value = toInputDate(today);
+    ctx.shared.targetDate = today;
+    ctx.onViewerChange();
+    loadAndRender();
+  });
+
+  refs.scaleSlider.addEventListener('input', () => {
+    ctx.shared.scale = parseFloat(refs.scaleSlider.value);
+    setScale(refs.boxContainer, refs.scaleSlider.value);
+    ctx.onViewerChange();
+  });
+  refs.futureOpacity.addEventListener('input', () => {
+    ctx.shared.futureOpacity = parseFloat(refs.futureOpacity.value);
+    setFutureOpacity(refs.futureOpacity.value);
+    ctx.onViewerChange();
+  });
+  refs.spaceColor.addEventListener('input', () => {
+    controlState.league.spaceColor = refs.spaceColor.value;
+    setSpace(refs.spaceColor.value);
+    savePrefs({ spaceColor: refs.spaceColor.value });
+  });
+  refs.displayTimezone.addEventListener('change', () => {
+    controlState.viewer.displayTimezone = refs.displayTimezone.value;
+    savePrefs({ displayTimezone: refs.displayTimezone.value });
+    loadAndRender();
+  });
+
+  return {
+    activate(seasonMap, selection) {
+      const selectionChanged = activeSelection?.competition !== selection.competition
+        || activeSelection?.season !== selection.season;
+      activeSeasonMap = seasonMap;
+      activeSelection = selection;
+      if (selectionChanged) state.teamMapCache = null;
+
+      const previousScale = ctx.shared.scale;
+      const clampedScale = clampToSlider(previousScale, refs.scaleSlider);
+      refs.scaleSlider.value = String(clampedScale);
+      ctx.shared.scale = parseFloat(refs.scaleSlider.value);
+      if (ctx.shared.scale !== previousScale) ctx.onViewerChange();
+      controlState.viewer.scale = ctx.shared.scale;
+      refs.futureOpacity.value = String(ctx.shared.futureOpacity);
+      controlState.viewer.futureOpacity = ctx.shared.futureOpacity;
+      controlState.viewer.targetDate = ctx.shared.targetDate;
+      refs.targetDate.value = toInputDate(ctx.shared.targetDate) || dateFormat(new Date(), '-');
+      setFutureOpacity(refs.futureOpacity.value, false);
+      if (prefs.spaceColor) setSpace(controlState.league.spaceColor, false);
+      loadAndRender();
+    },
+    deactivate() {
+      // League view currently has no transient UI state to clean up.
+    },
+  };
+}

--- a/frontend/src/matches-app.ts
+++ b/frontend/src/matches-app.ts
@@ -1,0 +1,236 @@
+// Unified league / bracket viewer orchestrator.
+
+import {
+  findCompetition,
+  loadSeasonMap,
+  resolveCompetitionViewType,
+} from './config/season-map';
+import {
+  BRACKET_NAMESPACED_IDS,
+  initBracketView,
+  populateBracketSeasonPulldown,
+} from './bracket-view';
+import {
+  initLeagueView,
+  LEAGUE_NAMESPACED_IDS,
+} from './league-view';
+import { clearPrefs, loadPrefs, savePrefs } from './storage/local-storage';
+import type {
+  SeasonMap,
+  ViewType,
+} from './types/season';
+import {
+  createSharedViewerControlState,
+  normalizeTargetDate,
+  readUrlParams,
+  restoreLocaleAndApplyI18n,
+  writeUrlParams,
+} from './view-bootstrap';
+import { t } from './i18n';
+import {
+  resolveInitialCompetition,
+  resolveInitialSeason,
+  shouldShowTimezone,
+} from './matches-orchestration';
+
+interface CompetitionOption {
+  competitionKey: string;
+  viewType: ViewType;
+}
+
+function getCompetitionOptions(seasonMap: SeasonMap): CompetitionOption[] {
+  const options: CompetitionOption[] = [];
+  for (const family of Object.values(seasonMap)) {
+    for (const [competitionKey, competition] of Object.entries(family.competitions)) {
+      try {
+        options.push({
+          competitionKey,
+          viewType: resolveCompetitionViewType(family, competition),
+        });
+      } catch (error) {
+        console.warn(`Skipping competition "${competitionKey}":`, error);
+      }
+    }
+  }
+  return options;
+}
+
+function populateCompetitionPulldown(
+  seasonMap: SeasonMap,
+  select: HTMLSelectElement,
+): void {
+  select.replaceChildren();
+  const validKeys = new Set(getCompetitionOptions(seasonMap).map(option => option.competitionKey));
+  const multiFamily = Object.keys(seasonMap).length > 1;
+
+  for (const [familyKey, family] of Object.entries(seasonMap)) {
+    const competitions = Object.entries(family.competitions)
+      .filter(([competitionKey]) => validKeys.has(competitionKey));
+    if (competitions.length === 0) continue;
+
+    if (multiFamily) {
+      const separator = document.createElement('option');
+      separator.disabled = true;
+      separator.textContent = `── ${family.display_name ?? familyKey} `;
+      select.appendChild(separator);
+    }
+    for (const [competitionKey, competition] of competitions) {
+      const option = document.createElement('option');
+      option.value = competitionKey;
+      option.textContent = competition.league_display ?? competitionKey;
+      option.dataset.viewType = resolveCompetitionViewType(family, competition);
+      select.appendChild(option);
+    }
+  }
+}
+
+function populateLeagueSeasonPulldown(
+  seasonMap: SeasonMap,
+  competition: string,
+  select: HTMLSelectElement,
+): void {
+  select.replaceChildren();
+  const found = findCompetition(seasonMap, competition);
+  if (!found) return;
+  for (const season of Object.keys(found.competition.seasons).sort().reverse()) {
+    const option = document.createElement('option');
+    option.value = season;
+    option.textContent = season;
+    select.appendChild(option);
+  }
+}
+
+function selectedViewType(select: HTMLSelectElement): ViewType | undefined {
+  return select.selectedOptions[0]?.dataset.viewType as ViewType | undefined;
+}
+
+function persistSharedViewerState(
+  shared: ReturnType<typeof createSharedViewerControlState>,
+): void {
+  shared.targetDate = normalizeTargetDate(shared.targetDate);
+  savePrefs({
+    scale: String(shared.scale),
+    futureOpacity: String(shared.futureOpacity),
+    targetDate: shared.targetDate ?? undefined,
+  });
+}
+
+async function main(): Promise<void> {
+  const prefs = loadPrefs();
+  const savedLocale = restoreLocaleAndApplyI18n(prefs.locale);
+  const status = document.getElementById('league_status_msg');
+
+  let seasonMap: SeasonMap;
+  try {
+    seasonMap = await loadSeasonMap();
+  } catch (error) {
+    if (status) status.textContent = t('status.seasonMapError');
+    console.error('Failed to load season map:', error);
+    return;
+  }
+
+  const viewRoot = document.getElementById('view_root');
+  const competitionSelect = document.getElementById('competition_key') as HTMLSelectElement | null;
+  const seasonSelect = document.getElementById('season_key') as HTMLSelectElement | null;
+  const timezoneLabel = document.getElementById('display_timezone_label');
+  if (!viewRoot || !competitionSelect || !seasonSelect) {
+    throw new Error('Unified viewer shell is incomplete');
+  }
+
+  const shared = createSharedViewerControlState(prefs);
+  if (prefs.targetDate && prefs.targetDate !== shared.targetDate) {
+    savePrefs({ targetDate: shared.targetDate ?? undefined });
+  }
+  const context = {
+    shared,
+    onViewerChange: () => persistSharedViewerState(shared),
+  };
+  const leagueView = initLeagueView(LEAGUE_NAMESPACED_IDS, context);
+  const bracketView = initBracketView(BRACKET_NAMESPACED_IDS, context);
+  const handles = { league: leagueView, bracket: bracketView };
+
+  populateCompetitionPulldown(seasonMap, competitionSelect);
+  const url = readUrlParams();
+  let competition = resolveInitialCompetition(seasonMap, url, prefs);
+  if (!Array.from(competitionSelect.options).some(option => option.value === competition)) {
+    competition = competitionSelect.options[0]?.value ?? '';
+  }
+  competitionSelect.value = competition;
+
+  let activeViewType: ViewType | undefined;
+
+  const populateSeasons = (viewType: ViewType): void => {
+    if (viewType === 'bracket') {
+      populateBracketSeasonPulldown(seasonMap, competitionSelect.value, seasonSelect);
+    } else {
+      populateLeagueSeasonPulldown(seasonMap, competitionSelect.value, seasonSelect);
+    }
+  };
+
+  const activate = (viewType: ViewType): void => {
+    const selection = {
+      competition: competitionSelect.value,
+      season: seasonSelect.value,
+    };
+    if (activeViewType && activeViewType !== viewType) {
+      handles[activeViewType].deactivate();
+    }
+    if (activeViewType !== viewType) {
+      viewRoot.dataset.active = viewType;
+      if (timezoneLabel && viewType === 'bracket') {
+        timezoneLabel.hidden = !shouldShowTimezone(viewType, false);
+      }
+    }
+    activeViewType = viewType;
+    writeUrlParams(selection.competition, selection.season);
+    savePrefs(selection);
+    handles[viewType].activate(seasonMap, selection);
+  };
+
+  const initialViewType = selectedViewType(competitionSelect);
+  if (!initialViewType) throw new Error('No valid competition is configured');
+  populateSeasons(initialViewType);
+  seasonSelect.value = resolveInitialSeason(
+    seasonMap,
+    competition,
+    url,
+    prefs,
+    Array.from(seasonSelect.options).map(option => option.value),
+  );
+
+  competitionSelect.addEventListener('change', () => {
+    const viewType = selectedViewType(competitionSelect);
+    if (!viewType) return;
+    populateSeasons(viewType);
+    seasonSelect.value = resolveInitialSeason(
+      seasonMap,
+      competitionSelect.value,
+      {},
+      loadPrefs(),
+      Array.from(seasonSelect.options).map(option => option.value),
+    );
+    activate(viewType);
+  });
+  seasonSelect.addEventListener('change', () => {
+    const viewType = selectedViewType(competitionSelect);
+    if (viewType) activate(viewType);
+  });
+
+  const localeSelect = document.getElementById('locale_key') as HTMLSelectElement | null;
+  if (localeSelect) {
+    if (savedLocale) localeSelect.value = savedLocale;
+    localeSelect.addEventListener('change', () => {
+      savePrefs({ locale: localeSelect.value });
+      location.reload();
+    });
+  }
+  document.getElementById('reset_prefs')?.addEventListener('click', () => {
+    clearPrefs();
+    location.assign(location.pathname);
+  });
+
+  // Leave pending only after season_map and the initial view have been resolved.
+  activate(initialViewType);
+}
+
+main().catch(console.error);

--- a/frontend/src/matches-orchestration.ts
+++ b/frontend/src/matches-orchestration.ts
@@ -1,0 +1,43 @@
+import { findCompetition } from './config/season-map';
+import type { SeasonMap, ViewType } from './types/season';
+
+export interface InitialSelectionSource {
+  competition?: string;
+  season?: string;
+}
+
+export function resolveInitialCompetition(
+  seasonMap: SeasonMap,
+  url: InitialSelectionSource,
+  prefs: InitialSelectionSource,
+  defaultCompetition: string = 'J1',
+): string {
+  for (const value of [url.competition, prefs.competition, defaultCompetition]) {
+    if (value && findCompetition(seasonMap, value)) return value;
+  }
+  return '';
+}
+
+export function resolveInitialSeason(
+  seasonMap: SeasonMap,
+  competition: string,
+  url: InitialSelectionSource,
+  prefs: InitialSelectionSource,
+  availableSeasons?: readonly string[],
+): string {
+  const found = findCompetition(seasonMap, competition);
+  if (!found) return '';
+  const available = new Set(
+    availableSeasons ?? Object.keys(found.competition.seasons),
+  );
+  for (const value of [url.season, prefs.season]) {
+    if (value && available.has(value)) return value;
+  }
+  return availableSeasons?.[0]
+    ?? Object.keys(found.competition.seasons).sort().reverse()[0]
+    ?? '';
+}
+
+export function shouldShowTimezone(viewType: ViewType, hasTimezone: boolean): boolean {
+  return viewType === 'league' && hasTimezone;
+}

--- a/frontend/src/matches.html
+++ b/frontend/src/matches.html
@@ -45,6 +45,7 @@
     <span data-i18n="label.displayTz"></span>
     <select id="display_timezone"></select>
   </label>
+  <button id="reset_prefs" data-i18n="btn.resetPrefs"></button>
 </section>
 
 <!-- View switch: Phase 2 orchestrator will set #view_root[data-active] to toggle which view is shown -->
@@ -97,7 +98,6 @@
     <span data-i18n="label.spaceColor"></span>
     <input type="color" id="space_color" value="#000000"/>
   </label>
-  <button id="reset_prefs" data-i18n="btn.resetPrefs"></button>
   <details id="column_toggle_section">
     <summary data-i18n="label.columnToggle"></summary>
     <div id="column_toggle_list"><!-- populated by app.ts --></div>
@@ -189,7 +189,7 @@
 
 </main>
 
-<!-- Phase 2: load the view orchestrator module here (app.ts / tournament-app.ts logic extraction) -->
+<script type="module" src="./matches-app.ts"></script>
 
 </body>
 </html>

--- a/frontend/src/matches.html
+++ b/frontend/src/matches.html
@@ -48,7 +48,7 @@
 </section>
 
 <!-- View switch: Phase 2 orchestrator will set #view_root[data-active] to toggle which view is shown -->
-<div id="view_root" data-active="league">
+<div id="view_root" data-active="pending">
 
 <div id="league_view">
 

--- a/frontend/src/storage/local-storage.ts
+++ b/frontend/src/storage/local-storage.ts
@@ -8,7 +8,7 @@ const STORAGE_KEY = 'jleague_viewer_prefs';
 export interface ViewerPrefs {
   competition?: string;
   season?: string;
-  targetDate?: string;   // YYYY/MM/DD (CSV date format) or YYYY-MM-DD (HTML date input)
+  targetDate?: string;   // Canonical YYYY/MM/DD (CSV date format)
   teamSortKey?: string;
   matchSortKey?: string;
   futureOpacity?: string;

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -32,8 +32,11 @@ import { inferRoundFilter } from './bracket/round-filter-inference';
 import { renderBracketInto, unpinTooltip } from './bracket/bracket-renderer';
 import { loadPrefs, savePrefs } from './storage/local-storage';
 import type { ViewerPrefs } from './storage/local-storage';
-import { t, applyI18nAttributes, setLocale } from './i18n';
-import type { Locale } from './i18n';
+import { t } from './i18n';
+import {
+  readUrlParams, writeUrlParams, restoreLocaleAndApplyI18n, createSharedViewerControlState,
+} from './view-bootstrap';
+import type { SharedViewerControlState } from './view-bootstrap';
 import type { BracketNode } from './bracket/bracket-types';
 
 // ---- State ------------------------------------------------------------------
@@ -50,11 +53,7 @@ interface BracketState {
   season: string;
 }
 
-interface ViewerControlState {
-  scale: number;
-  futureOpacity: number;
-  targetDate: string | null;
-}
+type ViewerControlState = SharedViewerControlState;
 
 interface BracketControlState {
   layout: 'horizontal' | 'vertical';
@@ -96,11 +95,7 @@ let controlState: ControlState = {
 
 function createControlStateFromPrefs(prefs: ViewerPrefs): ControlState {
   return {
-    viewer: {
-      scale: prefs.scale ? parseFloat(prefs.scale) : 1,
-      futureOpacity: prefs.futureOpacity ? parseFloat(prefs.futureOpacity) : 0.2,
-      targetDate: prefs.targetDate ?? null,
-    },
+    viewer: createSharedViewerControlState(prefs, { futureOpacity: 0.2 }),
     bracket: {
       layout: 'horizontal',
       roundStart: prefs.roundStart ?? null,
@@ -216,23 +211,6 @@ function populateSeasonPulldown(seasonMap: SeasonMap, competition: string): void
     opt.textContent = s;
     sel.appendChild(opt);
   }
-}
-
-// ---- URL params ------------------------------------------------------------
-
-function readUrlParams(): { competition: string; season?: string } {
-  const params = new URLSearchParams(location.search);
-  return {
-    competition: params.get('competition') ?? '',
-    season: params.get('season') ?? undefined,
-  };
-}
-
-function writeUrlParams(competition: string, season: string): void {
-  const url = new URL(location.href);
-  url.searchParams.set('competition', competition);
-  url.searchParams.set('season', season);
-  history.replaceState(null, '', url.toString());
 }
 
 // ---- Round start helpers ---------------------------------------------------
@@ -839,9 +817,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
 // ---- Initialization --------------------------------------------------------
 
 async function main(): Promise<void> {
-  const savedLocale = loadPrefs().locale;
-  if (savedLocale === 'ja' || savedLocale === 'en') setLocale(savedLocale as Locale);
-  applyI18nAttributes();
+  const savedLocale = restoreLocaleAndApplyI18n(loadPrefs().locale);
 
   let seasonMap: SeasonMap;
   try {

--- a/frontend/src/tournament-app.ts
+++ b/frontend/src/tournament-app.ts
@@ -1,977 +1,127 @@
-// Tournament bracket viewer entry point.
-//
-// Loads season_map.yaml, filters to bracket-enabled competitions,
-// and renders a CSS bracket for the selected season.
-// Provides date slider, opacity, zoom, and layout controls.
+// Standalone tournament bracket viewer entry point.
 
-import Papa from 'papaparse';
-import type { RawMatchRow } from './types/match';
-import type {
-  SeasonMap,
-  BracketBlock,
-  AggregateTiebreakCriterion,
-  RawSeasonEntry,
-  TournamentSeasonInfo,
-} from './types/season';
+import type { SeasonMap } from './types/season';
 import {
-  loadSeasonMap, getCsvFilename, findCompetition, resolveTournamentSeasonInfo,
+  findCompetition,
   getCompetitionViewTypes,
+  loadSeasonMap,
 } from './config/season-map';
 import {
-  PRESEASON_SENTINEL,
-  formatSliderDate,
-  getLastMatchDate,
-  getSliderDate,
-  resolveTargetDate,
-  syncSliderToTargetDate,
-} from './core/date-slider';
-import { buildBracket, maskBracketForDate } from './bracket/bracket-data';
-import { extractTeamsFromBracketOrder, inferBracketOrderFromRows } from './bracket/bracket-order-inference';
-import { normalizeBracketRoundLabel } from './bracket/round-label';
-import { inferRoundFilter } from './bracket/round-filter-inference';
-import { renderBracketInto, unpinTooltip } from './bracket/bracket-renderer';
-import { loadPrefs, savePrefs } from './storage/local-storage';
-import type { ViewerPrefs } from './storage/local-storage';
-import { t } from './i18n';
-import {
-  readUrlParams, writeUrlParams, restoreLocaleAndApplyI18n, createSharedViewerControlState,
+  createSharedViewerControlState,
+  readUrlParams,
+  restoreLocaleAndApplyI18n,
+  writeUrlParams,
 } from './view-bootstrap';
-import type { SharedViewerControlState } from './view-bootstrap';
-import type { BracketNode } from './bracket/bracket-types';
+import {
+  BRACKET_STANDALONE_IDS,
+  initBracketView,
+  populateBracketSeasonPulldown,
+} from './bracket-view';
+import { loadPrefs, savePrefs } from './storage/local-storage';
+import { t } from './i18n';
 
-// ---- State ------------------------------------------------------------------
-
-interface BracketState {
-  csvRows: RawMatchRow[];
-  bracketOrder: (string | null)[];
-  seasonInfo: TournamentSeasonInfo;
-  fullRoot: BracketNode;        // full tree built from bracketOrder
-  roundsByDepth: string[];      // round labels root-to-leaf (e.g. ['決勝戦','準決勝','準々決勝','ラウンド16'])
-  allRounds: string[];          // all CSV rounds in chronological order
-  bracketBlocks?: BracketBlock[];  // multi-section definitions from season_map
-  matchDates: string[];         // sorted unique dates from CSV
-  season: string;
-}
-
-type ViewerControlState = SharedViewerControlState;
-
-interface BracketControlState {
-  layout: 'horizontal' | 'vertical';
-  roundStart: string | null;
-}
-
-interface ControlState {
-  viewer: ViewerControlState;
-  bracket: BracketControlState;
-}
-
-interface SingleBracketRenderInput {
-  rows: RawMatchRow[];
-  order: (string | null)[];
-  aggregateTiebreakOrder: AggregateTiebreakCriterion[];
-  targetDate: string | null;
-  lastDate: string;
-  cssFiles: string[];
-}
-
-const MULTI_SECTION_VALUE = '__multi_section__';
-
-let currentState: BracketState | null = null;
-
-/** Cache buildBracket results to avoid redundant rebuilds on slider/layout changes. */
-let bracketCache = new Map<string, BracketNode>();
-
-let controlState: ControlState = {
-  viewer: {
-    scale: 1,
-    futureOpacity: 0.2,
-    targetDate: null,
-  },
-  bracket: {
-    layout: 'horizontal',
-    roundStart: null,
-  },
-};
-
-function createControlStateFromPrefs(prefs: ViewerPrefs): ControlState {
-  return {
-    viewer: createSharedViewerControlState(prefs, { futureOpacity: 0.2 }),
-    bracket: {
-      layout: 'horizontal',
-      roundStart: prefs.roundStart ?? null,
-    },
-  };
-}
-
-// ---- DOM helpers -----------------------------------------------------------
-
-function getSelectValue(id: string): string {
-  return (document.getElementById(id) as HTMLSelectElement).value;
-}
-
-function setStatus(msg: string): void {
-  const el = document.getElementById('status_msg');
-  if (el) el.textContent = msg;
-}
-
-// ---- Match date collection --------------------------------------------------
-
-function collectMatchDates(rows: RawMatchRow[]): string[] {
-  const dates = new Set<string>();
-  for (const r of rows) {
-    if (r.match_date) dates.add(r.match_date);
-  }
-  const sorted = Array.from(dates).sort();
-  // Prepend sentinel so slider index 0 = "before any match"
-  sorted.unshift(PRESEASON_SENTINEL);
-  return sorted;
-}
-
-function resolveSeasonBracketOrder(
-  entry: RawSeasonEntry,
-  inferredOrder?: (string | null)[],
-): (string | null)[] | undefined {
-  const explicitOrder = entry.bracket_order;
-  if (explicitOrder != null && explicitOrder.length > 0) {
-    return explicitOrder;
-  }
-
-  const legacyOrder = entry.teams;
-  if (legacyOrder != null && legacyOrder.length > 0) {
-    return legacyOrder;
-  }
-
-  const sectionOrder = entry.bracket_blocks?.flatMap((section) => section.bracket_order ?? []);
-  if (sectionOrder != null && sectionOrder.length > 0) {
-    return sectionOrder;
-  }
-
-  return inferredOrder;
-}
-
-function resolveSectionBracketOrders(
-  sections: BracketBlock[],
-  seasonTeams: string[],
-): BracketBlock[] {
-  return sections.map((section) => (
-    section.bracket_order && section.bracket_order.length > 0
-      ? section
-      : { ...section, bracket_order: seasonTeams }
-  ));
-}
-
-function hasBracketMetadata(entry: RawSeasonEntry): boolean {
-  return entry.bracket_order != null
-    || entry.bracket_blocks != null
-    || (entry.teams?.length ?? 0) > 0
-    || entry.bracket_round_start != null;
-}
-
-// ---- Dropdown population ---------------------------------------------------
-
-function populateCompetitionPulldown(seasonMap: SeasonMap): void {
-  const sel = document.getElementById('competition_key') as HTMLSelectElement;
-  sel.innerHTML = '';
+function populateCompetitionPulldown(
+  seasonMap: SeasonMap,
+  select: HTMLSelectElement,
+): void {
+  select.replaceChildren();
   const families = Object.entries(seasonMap);
   const multiFamily = families.length > 1;
   for (const [familyKey, family] of families) {
-    const bracketComps = Object.entries(family.competitions)
-      .filter(([, comp]) => getCompetitionViewTypes(family, comp).includes('bracket'));
-    if (bracketComps.length === 0) continue;
-
+    const competitions = Object.entries(family.competitions)
+      .filter(([, competition]) => getCompetitionViewTypes(family, competition).includes('bracket'));
+    if (competitions.length === 0) continue;
     if (multiFamily) {
-      const sep = document.createElement('option');
-      sep.disabled = true;
-      sep.textContent = `── ${family.display_name ?? familyKey} `;
-      sel.appendChild(sep);
+      const separator = document.createElement('option');
+      separator.disabled = true;
+      separator.textContent = `── ${family.display_name ?? familyKey} `;
+      select.appendChild(separator);
     }
-    for (const [compKey, comp] of bracketComps) {
-      const opt = document.createElement('option');
-      opt.value = compKey;
-      opt.textContent = comp.league_display ?? compKey;
-      sel.appendChild(opt);
-    }
-  }
-}
-
-function populateSeasonPulldown(seasonMap: SeasonMap, competition: string): void {
-  const sel = document.getElementById('season_key') as HTMLSelectElement;
-  sel.innerHTML = '';
-  const found = findCompetition(seasonMap, competition);
-  if (!found) return;
-  const seasons = Object.keys(found.competition.seasons)
-    .filter(s => {
-      const e = found.competition.seasons[s];
-      return hasBracketMetadata(e);
-    })
-    .sort().reverse();
-  for (const s of seasons) {
-    const opt = document.createElement('option');
-    opt.value = s;
-    opt.textContent = s;
-    sel.appendChild(opt);
-  }
-}
-
-// ---- Round start helpers ---------------------------------------------------
-
-/** Collect round labels at each tree depth via BFS (root → leaf). */
-function collectRoundsByDepth(node: BracketNode): string[] {
-  const rounds: string[] = [];
-  let level: BracketNode[] = [node];
-  while (level.length > 0) {
-    const roundName = level.find(n => n.round)?.round ?? '';
-    if (roundName) rounds.push(roundName);
-    const next: BracketNode[] = [];
-    for (const n of level) {
-      for (const child of n.children) {
-        if (child) next.push(child);
-      }
-    }
-    level = next;
-  }
-  return rounds;
-}
-
-/** Collect unique normalized KO rounds from the built bracket tree in play order. */
-function collectBracketRounds(node: BracketNode): string[] {
-  return collectRoundsByDepth(node)
-    .map(r => normalizeBracketRoundLabel(r))
-    .reverse();
-}
-
-/** Filter rows by round using raw or normalized bracket labels. */
-function filterRowsByRounds(rows: RawMatchRow[], roundFilter: string[]): RawMatchRow[] {
-  const rawSet = new Set(roundFilter);
-  const normalizedSet = new Set(roundFilter.map(r => normalizeBracketRoundLabel(r)));
-  return rows.filter((r) => {
-    const round = r.round ?? '';
-    return rawSet.has(round) || normalizedSet.has(normalizeBracketRoundLabel(round));
-  });
-}
-
-/** Apply default_round_filter to sections that lack their own round_filter. */
-function resolveSectionRoundFilters(
-  sections: BracketBlock[], defaultRoundFilter?: string[],
-): BracketBlock[] {
-  if (!defaultRoundFilter || defaultRoundFilter.length === 0) return sections;
-  return sections.map(s =>
-    s.round_filter ? s : { ...s, round_filter: defaultRoundFilter },
-  );
-}
-
-/** Infer round_filter for sections still without one after default resolution. */
-function inferMissingSectionRoundFilters(
-  sections: BracketBlock[], rows: RawMatchRow[],
-): BracketBlock[] {
-  return sections.map(s => {
-    if (s.round_filter) return s;
-    const inferred = inferRoundFilter(rows, s.bracket_order ?? [], s.matchup_pairs);
-    return inferred ? { ...s, round_filter: inferred } : s;
-  });
-}
-
-function collectBracketSourceRows(rows: RawMatchRow[], sections?: BracketBlock[]): RawMatchRow[] {
-  if (!sections || sections.length === 0) return rows;
-  const merged: RawMatchRow[] = [];
-  const seen = new Set<string>();
-  for (const section of sections) {
-    const sectionRows = section.round_filter
-      ? filterRowsByRounds(rows, section.round_filter)
-      : rows;
-    for (const row of sectionRows) {
-      const key = [
-        row.match_number ?? '',
-        row.match_date ?? '',
-        row.home_team ?? '',
-        row.away_team ?? '',
-        row.round ?? '',
-        row.leg ?? '',
-        row.stadium ?? '',
-      ].join('|');
-      if (seen.has(key)) continue;
-      seen.add(key);
-      merged.push(row);
-    }
-  }
-  return merged;
-}
-
-/** Collect unique rounds from CSV in chronological order. */
-function collectRoundsFromCsv(rows: RawMatchRow[]): string[] {
-  const seen = new Set<string>();
-  const rounds: string[] = [];
-  const sorted = [...rows].sort(
-    (a, b) => (a.match_date ?? '').localeCompare(b.match_date ?? ''),
-  );
-  for (const row of sorted) {
-    const normalized = row.round ? normalizeBracketRoundLabel(row.round) : '';
-    if (normalized && !seen.has(normalized)) {
-      seen.add(normalized);
-      rounds.push(normalized);
-    }
-  }
-  return rounds;
-}
-
-export const __testables = {
-  createControlStateFromPrefs,
-  resolveSeasonBracketOrder,
-  resolveSectionBracketOrders,
-  filterRowsByRounds,
-  resolveSectionRoundFilters,
-  inferMissingSectionRoundFilters,
-  collectBracketSourceRows,
-  collectRoundsFromCsv,
-  resolveInclusiveBracketOrder,
-  shouldRenderMultiSectionView,
-};
-
-/** Collect winners at a given tree depth (in bracket positional order). */
-function collectWinnersAtDepth(
-  node: BracketNode, depth: number,
-): (string | null)[] {
-  if (depth === 0) return [node.winner];
-  const results: (string | null)[] = [];
-  for (const child of node.children) {
-    if (child) results.push(...collectWinnersAtDepth(child, depth - 1));
-  }
-  return results;
-}
-
-/**
- * Extend bracket order backward by one round.
- * For each team, find their match in the given round and expand to [home, away].
- * Teams that entered at a later round (no match found) become [team, null] (bye).
- */
-function extendBracketBackward(
-  order: (string | null)[],
-  rows: RawMatchRow[],
-  round: string,
-): (string | null)[] {
-  const extended: (string | null)[] = [];
-  for (const team of order) {
-    if (!team) {
-      extended.push(null, null);
-      continue;
-    }
-    const match = rows.find(r =>
-      normalizeBracketRoundLabel(r.round ?? '') === round
-        && (r.home_team === team || r.away_team === team),
-    );
-    if (match) {
-      extended.push(match.home_team, match.away_team);
-    } else {
-      // Team entered at a later round (bye)
-      extended.push(team, null);
-    }
-  }
-  return extended;
-}
-
-function populateRoundStartPulldown(
-  allRounds: string[], defaultRound?: string,
-  hasSections?: boolean,
-  explicitOptions?: string[],
-): void {
-  const sel = document.getElementById('round_start_key') as HTMLSelectElement;
-  if (!sel) return;
-  sel.innerHTML = '';
-  sel.disabled = false;
-
-  const options = explicitOptions ?? [
-    ...(hasSections ? [MULTI_SECTION_VALUE] : []),
-    ...allRounds,
-  ];
-
-  for (const round of options) {
-    const opt = document.createElement('option');
-    opt.value = round;
-    opt.textContent = round === MULTI_SECTION_VALUE ? t('label.multiSection') : round;
-    sel.appendChild(opt);
-  }
-
-  if (explicitOptions && explicitOptions.length === 1) {
-    sel.value = explicitOptions[0];
-    sel.disabled = true;
-  } else if (defaultRound && options.includes(defaultRound)) {
-    sel.value = defaultRound;
-  } else if (options.includes(MULTI_SECTION_VALUE)) {
-    sel.value = MULTI_SECTION_VALUE;
-  } else if (options.length > 0) {
-    sel.value = options[0];
-  }
-}
-
-/** Resolve bracket order for the single-tree ("inclusive") bracket view. */
-function resolveInclusiveBracketOrder(
-  state: Pick<BracketState, 'fullRoot' | 'bracketOrder' | 'roundsByDepth' | 'allRounds' | 'csvRows'>,
-  selectedRoundStart: string | null,
-): (string | null)[] {
-  const { fullRoot, bracketOrder, roundsByDepth, allRounds, csvRows } = state;
-  const selected = selectedRoundStart ?? '';
-  const leafRound = roundsByDepth[roundsByDepth.length - 1];
-  const leafIdx = allRounds.indexOf(leafRound);
-  const selectedIdx = allRounds.indexOf(selected);
-  if (selectedIdx < 0) return bracketOrder;
-
-  if (selectedIdx === leafIdx) {
-    // Same as configured leaf → original bracket order
-    return bracketOrder;
-  } else if (selectedIdx > leafIdx) {
-    // Later round → collapse using bracket tree
-    const treeDepthIdx = roundsByDepth.indexOf(selected);
-    if (treeDepthIdx < 0) return bracketOrder;
-    return collectWinnersAtDepth(fullRoot, treeDepthIdx + 1);
-  } else {
-    // Earlier round → extend backward from leaf
-    let order: (string | null)[] = [...bracketOrder];
-    for (let i = leafIdx - 1; i >= selectedIdx; i--) {
-      order = extendBracketBackward(order, csvRows, allRounds[i]);
-    }
-    return order;
-  }
-}
-
-// ---- Bracket rendering with date filter ------------------------------------
-
-function getTargetDate(): string | null {
-  return controlState.viewer.targetDate;
-}
-
-/** Check whether the selection should render bracket sections independently. */
-function shouldRenderMultiSectionView(
-  bracketBlocks: BracketBlock[] | undefined,
-  roundStart: string | null,
-): boolean {
-  return roundStart === MULTI_SECTION_VALUE && bracketBlocks != null;
-}
-
-/**
- * Build and render a bracket tree (with date mask) into a container.
- * Uses cache to avoid redundant buildBracket calls on slider/layout changes.
- */
-function buildAndRenderBracket(
-  container: HTMLElement,
-  input: SingleBracketRenderInput,
-): void {
-  const { rows, order, aggregateTiebreakOrder, targetDate, lastDate, cssFiles } = input;
-  if (order.length < 2) return;
-  const cacheKey = JSON.stringify(order);
-  let fullRoot = bracketCache.get(cacheKey);
-  if (!fullRoot) {
-    fullRoot = buildBracket(rows, order, aggregateTiebreakOrder);
-    bracketCache.set(cacheKey, fullRoot);
-  }
-  const root = (targetDate && targetDate < lastDate)
-    ? maskBracketForDate(fullRoot, targetDate) : fullRoot;
-  renderBracketInto(container, root, cssFiles, controlState.bracket.layout);
-}
-
-function createSingleBracketRenderInput(
-  state: Pick<BracketState, 'csvRows' | 'seasonInfo' | 'matchDates'>,
-  order: (string | null)[],
-): SingleBracketRenderInput | null {
-  if (order.length < 2 || state.matchDates.length === 0) return null;
-  return {
-    rows: state.csvRows,
-    order,
-    aggregateTiebreakOrder: state.seasonInfo.aggregateTiebreakOrder,
-    targetDate: getTargetDate(),
-    lastDate: state.matchDates[state.matchDates.length - 1],
-    cssFiles: state.seasonInfo.cssFiles,
-  };
-}
-
-function createInclusiveBracketRenderInput(
-  state: Pick<
-  BracketState,
-  'csvRows' | 'seasonInfo' | 'matchDates' |
-  'fullRoot' | 'bracketOrder' | 'roundsByDepth' | 'allRounds'
-  >,
-): SingleBracketRenderInput | null {
-  const order = resolveInclusiveBracketOrder(state, controlState.bracket.roundStart);
-  return createSingleBracketRenderInput(state, order);
-}
-
-/**
- * Render multi-section view: each BracketBlock becomes an independent
- * collapsible bracket, all sharing the same CSV and date filter.
- */
-function renderMultiSections(): void {
-  if (!currentState?.bracketBlocks) return;
-  const container = document.getElementById('bracket_container');
-  if (!container) return;
-
-  // Save open/closed state of existing sections before re-render
-  const prevOpen = new Map<string, boolean>();
-  for (const d of Array.from(container.querySelectorAll<HTMLDetailsElement>('.bracket-section'))) {
-    const label = d.querySelector('.bracket-section-summary')?.textContent ?? '';
-    if (label) prevOpen.set(label, d.open);
-  }
-
-  container.replaceChildren();
-
-  // Toggle-all button
-  const toggleBtn = document.createElement('button');
-  toggleBtn.id = 'toggle_section_all';
-  toggleBtn.textContent = t('btn.collapseAll');
-  toggleBtn.addEventListener('click', () => {
-    const allDetails = container.querySelectorAll<HTMLDetailsElement>('.bracket-section');
-    const anyOpen = Array.from(allDetails).some(d => d.open);
-    for (const d of Array.from(allDetails)) d.open = !anyOpen;
-    toggleBtn.textContent = anyOpen ? t('btn.expandAll') : t('btn.collapseAll');
-    applyScale();
-  });
-  container.appendChild(toggleBtn);
-
-  for (const section of currentState.bracketBlocks) {
-    const sectionOrder = section.bracket_order ?? [];
-    if (sectionOrder.length < 2) continue;
-
-    // Pre-filter CSV rows by round_filter if specified
-    const rows = section.round_filter
-      ? filterRowsByRounds(currentState.csvRows, section.round_filter)
-      : currentState.csvRows;
-
-    // Create collapsible section
-    const details = document.createElement('details');
-    details.classList.add('bracket-section');
-    // Restore previous open state; default to open for new sections
-    details.open = prevOpen.get(section.label) ?? true;
-    details.addEventListener('toggle', () => {
-      applyScale();
-    });
-    const summary = document.createElement('summary');
-    summary.classList.add('bracket-section-summary');
-    summary.textContent = section.label;
-    details.appendChild(summary);
-
-    // Bracket wrapper (needed as container for adjustBracketPositions)
-    const sectionWrapper = document.createElement('div');
-    sectionWrapper.classList.add('bracket-section-content');
-    details.appendChild(sectionWrapper);
-
-    // Append to DOM before rendering (getBoundingClientRect needs layout)
-    container.appendChild(details);
-
-    if (section.matchup_pairs) {
-      // Matchup pairs: split bracket_order into pairs and render each independently
-      const order = sectionOrder;
-      for (let i = 0; i < order.length; i += 2) {
-        const pair = order.slice(i, i + 2);
-        if (pair.every(t => t == null)) continue;
-        const input = createSingleBracketRenderInput(
-          { ...currentState, csvRows: rows },
-          pair,
-        );
-        if (input) buildAndRenderBracket(sectionWrapper, input);
-      }
-    } else {
-      const input = createSingleBracketRenderInput(
-        { ...currentState, csvRows: rows },
-        sectionOrder,
-      );
-      if (input) buildAndRenderBracket(sectionWrapper, input);
+    for (const [competitionKey, competition] of competitions) {
+      const option = document.createElement('option');
+      option.value = competitionKey;
+      option.textContent = competition.league_display ?? competitionKey;
+      select.appendChild(option);
     }
   }
 }
-
-/** Render the single-tree ("inclusive") bracket view. */
-function renderInclusiveBracket(container: HTMLElement): void {
-  if (!currentState) return;
-  const input = createInclusiveBracketRenderInput(currentState);
-  if (!input) return;
-  container.replaceChildren();
-  buildAndRenderBracket(container, input);
-}
-
-function renderWithDateFilter(): void {
-  if (!currentState) return;
-  const container = document.getElementById('bracket_container');
-  if (!container) return;
-
-  // Dismiss any pinned tooltip before re-render (DOM will be replaced)
-  unpinTooltip();
-
-  // Multi-section mode: render each section as its own bracket block.
-  if (shouldRenderMultiSectionView(currentState.bracketBlocks, controlState.bracket.roundStart)) {
-    renderMultiSections();
-    return;
-  }
-
-  // Inclusive mode: resolve one effective bracket order, then render it as one tree.
-  renderInclusiveBracket(container);
-}
-
-/** Sync viewer control targetDate from slider position. */
-function syncTargetDateFromSlider(): void {
-  if (!currentState) return;
-  const slider = document.getElementById('date_slider') as HTMLInputElement | null;
-  if (!slider) return;
-  controlState.viewer.targetDate = getSliderDate(currentState.matchDates, parseInt(slider.value, 10));
-}
-
-/** Align slider position to the kept target date without overwriting the target itself. */
-function syncSliderFromTargetDate(): void {
-  if (!currentState) return;
-  const slider = document.getElementById('date_slider') as HTMLInputElement | null;
-  syncSliderToTargetDate(slider, currentState.matchDates, controlState.viewer.targetDate);
-}
-
-/** Update display label from current slider position + kept target date. */
-function updateSliderDisplay(): void {
-  if (!currentState) return;
-  const slider = document.getElementById('date_slider') as HTMLInputElement | null;
-  const display = document.getElementById('post_date_slider');
-  if (!slider || !display) return;
-  const sliderDate = getSliderDate(currentState.matchDates, parseInt(slider.value, 10)) ?? '';
-  const targetDate = resolveTargetDate(currentState.matchDates, controlState.viewer.targetDate) ?? sliderDate;
-  display.textContent = formatSliderDate(sliderDate, targetDate);
-}
-
-// ---- Controls: opacity, scale, layout --------------------------------------
-
-/** Apply futureOpacity from controlState to all .bracket-future elements. */
-function applyFutureOpacity(): void {
-  const container = document.getElementById('bracket_container');
-  if (!container) return;
-  const value = String(controlState.viewer.futureOpacity);
-  for (const el of Array.from(container.querySelectorAll('.bracket-future'))) {
-    (el as HTMLElement).style.opacity = value;
-  }
-  const display = document.getElementById('current_opacity');
-  if (display) display.textContent = value;
-}
-
-/** Keep layout height in sync with the visual scale of the bracket container. */
-function syncBracketContainerHeight(container: HTMLElement): void {
-  container.style.height = 'auto';
-  const rawHeight = container.scrollHeight;
-  if (rawHeight > 0) {
-    container.style.height = `${rawHeight * controlState.viewer.scale}px`;
-  }
-}
-
-/** Apply scale from controlState to bracket container. */
-function applyScale(): void {
-  const container = document.getElementById('bracket_container');
-  if (!container) return;
-  const value = String(controlState.viewer.scale);
-  container.style.transform = `scale(${value})`;
-  container.style.transformOrigin = 'top left';
-  syncBracketContainerHeight(container);
-  const display = document.getElementById('current_scale');
-  if (display) display.textContent = value;
-}
-
-// ---- Render pipeline -------------------------------------------------------
-
-const CACHE_BUST_WINDOW_SEC = 300;
-
-function loadAndRender(seasonMap: SeasonMap): void {
-  const competition = getSelectValue('competition_key');
-  const season = getSelectValue('season_key');
-  if (!competition || !season) return;
-
-  const found = findCompetition(seasonMap, competition);
-  if (!found || !found.competition.seasons[season]) {
-    setStatus(t('status.noSeason', { competition, season }));
-    return;
-  }
-
-  const entry = found.competition.seasons[season];
-
-  writeUrlParams(competition, season);
-  savePrefs({ competition, season });
-
-  const filename = getCsvFilename(competition, season);
-  const cachebuster = Math.floor(Date.now() / 1000 / CACHE_BUST_WINDOW_SEC);
-  setStatus(t('status.loading'));
-
-  Papa.parse<RawMatchRow>(filename + '?_=' + cachebuster, {
-    header: true,
-    skipEmptyLines: 'greedy',
-    download: true,
-    complete: (results) => {
-      const inferredOrder = inferBracketOrderFromRows(results.data);
-      const seasonTeams = entry.teams && entry.teams.length > 0
-        ? entry.teams
-        : (inferredOrder ? extractTeamsFromBracketOrder(inferredOrder) : []);
-      const rawSections = entry.bracket_blocks
-        ? resolveSectionBracketOrders(entry.bracket_blocks, seasonTeams)
-        : undefined;
-      const resolvedEntry = {
-        ...entry,
-        teams: seasonTeams,
-        team_count: entry.team_count ?? (seasonTeams.length > 0 ? seasonTeams.length : undefined),
-        bracket_blocks: rawSections,
-      };
-      const tournamentSeasonInfo = resolveTournamentSeasonInfo(
-        found.family, found.competition, resolvedEntry, found.familyKey,
-      );
-      const bracketOrder = resolveSeasonBracketOrder(entry, inferredOrder);
-      if (!bracketOrder || bracketOrder.length === 0) {
-        setStatus('No bracket data for this season.');
-        return;
-      }
-      const resolved = rawSections
-        ? resolveSectionRoundFilters(rawSections, entry.default_round_filter)
-        : undefined;
-      const bracketBlocks = resolved
-        ? inferMissingSectionRoundFilters(resolved, results.data)
-        : undefined;
-      const bracketRows = collectBracketSourceRows(results.data, bracketBlocks);
-      const matchDates = collectMatchDates(bracketRows);
-
-      // Build full tree to extract round structure and pre-populate cache
-      const fullRoot = buildBracket(
-        bracketRows,
-        bracketOrder,
-        tournamentSeasonInfo.aggregateTiebreakOrder,
-      );
-      bracketCache = new Map();
-      bracketCache.set(JSON.stringify(bracketOrder), fullRoot);
-      const roundsByDepth = collectRoundsByDepth(fullRoot);
-      const bracketRounds = collectBracketRounds(fullRoot);
-      const allRounds = bracketBlocks
-        ? bracketRounds
-        : collectRoundsFromCsv(bracketRows).filter(r => bracketRounds.includes(r));
-
-      currentState = {
-        csvRows: bracketRows,
-        bracketOrder,
-        seasonInfo: tournamentSeasonInfo,
-        fullRoot,
-        roundsByDepth,
-        allRounds,
-        bracketBlocks,
-        matchDates,
-        season,
-      };
-
-      // Populate round start dropdown (with multi-section option if sections exist)
-      populateRoundStartPulldown(
-        allRounds,
-        tournamentSeasonInfo.defaultRoundStart,
-        bracketBlocks != null,
-        tournamentSeasonInfo.roundStartOptions,
-      );
-
-      // Sync round start: restore from controlState or pick up dropdown default
-      const roundSel = document.getElementById('round_start_key') as HTMLSelectElement | null;
-      if (roundSel && controlState.bracket.roundStart) {
-        const normalizedSelected = normalizeBracketRoundLabel(controlState.bracket.roundStart);
-        const hasOption = Array.from(roundSel.options).some(o => o.value === normalizedSelected);
-        if (hasOption) {
-          roundSel.value = normalizedSelected;
-          controlState.bracket.roundStart = normalizedSelected;
-        } else {
-          controlState.bracket.roundStart = roundSel.value;
-        }
-      } else if (roundSel) {
-        controlState.bracket.roundStart = roundSel.value;
-      }
-
-      // Set up date slider and sync viewer control targetDate
-      const slider = document.getElementById('date_slider') as HTMLInputElement | null;
-      if (slider && matchDates.length > 0) {
-        slider.min = '0';
-        if (!controlState.viewer.targetDate) {
-          controlState.viewer.targetDate = getLastMatchDate(matchDates);
-        }
-        syncSliderFromTargetDate();
-      }
-
-      renderWithDateFilter();
-      updateSliderDisplay();
-      applyFutureOpacity();
-      applyScale();
-
-      // Update season notes + bracket-specific notes
-      const notesEl = document.getElementById('season_notes');
-      if (notesEl) {
-        notesEl.replaceChildren();
-        const bracketNotes = [
-          t('bracketNote.aggregateScore'),
-          t('bracketNote.etIncluded'),
-          t('bracketNote.pkAnnotation'),
-        ];
-        for (const text of [...tournamentSeasonInfo.notes, ...bracketNotes]) {
-          const li = document.createElement('li');
-          li.textContent = text;
-          notesEl.appendChild(li);
-        }
-      }
-
-      setStatus(t('status.loaded', {
-        league: tournamentSeasonInfo.leagueDisplay, season, rows: bracketRows.length,
-      }));
-    },
-    error: (err: unknown) => {
-      setStatus(t('status.error', { detail: String(err) }));
-    },
-  });
-}
-
-// ---- Initialization --------------------------------------------------------
 
 async function main(): Promise<void> {
-  const savedLocale = restoreLocaleAndApplyI18n(loadPrefs().locale);
+  const prefs = loadPrefs();
+  const savedLocale = restoreLocaleAndApplyI18n(prefs.locale);
+  const status = document.getElementById('status_msg');
 
   let seasonMap: SeasonMap;
   try {
     seasonMap = await loadSeasonMap();
-  } catch (err) {
-    setStatus(t('status.seasonMapError'));
-    console.error('Failed to load season map:', err);
+  } catch (error) {
+    if (status) status.textContent = t('status.seasonMapError');
+    console.error('Failed to load season map:', error);
     return;
   }
 
-  populateCompetitionPulldown(seasonMap);
+  const competitionSelect = document.getElementById('competition_key') as HTMLSelectElement;
+  const seasonSelect = document.getElementById('season_key') as HTMLSelectElement;
+  populateCompetitionPulldown(seasonMap, competitionSelect);
 
   const urlParams = readUrlParams();
-  const prefs = loadPrefs();
-
-  // Initialize control state from saved preferences
-  controlState = createControlStateFromPrefs(prefs);
-
-  const competitionSel = document.getElementById('competition_key') as HTMLSelectElement;
-  const initCompetition = (urlParams.competition && findCompetition(seasonMap, urlParams.competition))
+  const initialCompetition = (urlParams.competition && findCompetition(seasonMap, urlParams.competition))
     ? urlParams.competition
     : (prefs.competition && findCompetition(seasonMap, prefs.competition))
-    ? prefs.competition
-    : competitionSel.options[0]?.value ?? '';
-  competitionSel.value = initCompetition;
+      ? prefs.competition
+      : competitionSelect.options[0]?.value ?? '';
+  competitionSelect.value = initialCompetition;
+  populateBracketSeasonPulldown(seasonMap, initialCompetition, seasonSelect);
 
-  populateSeasonPulldown(seasonMap, initCompetition);
-
-  const seasonSel = document.getElementById('season_key') as HTMLSelectElement;
-  const found = findCompetition(seasonMap, initCompetition);
-  const initSeason = (urlParams.season && found?.competition.seasons[urlParams.season])
+  const found = findCompetition(seasonMap, initialCompetition);
+  const initialSeason = (urlParams.season && found?.competition.seasons[urlParams.season])
     ? urlParams.season
     : (prefs.season && found?.competition.seasons[prefs.season])
-    ? prefs.season
-    : seasonSel.options[0]?.value ?? '';
-  seasonSel.value = initSeason;
+      ? prefs.season
+      : seasonSelect.options[0]?.value ?? '';
+  seasonSelect.value = initialSeason;
 
-  // Locale selector
-  const localeSel = document.getElementById('locale_key') as HTMLSelectElement | null;
-  if (localeSel) {
-    if (savedLocale) localeSel.value = savedLocale;
-    localeSel.addEventListener('change', () => {
-      savePrefs({ locale: localeSel.value });
+  const shared = createSharedViewerControlState(prefs, { futureOpacity: 0.2 });
+  if (prefs.targetDate && prefs.targetDate !== shared.targetDate) {
+    savePrefs({ targetDate: shared.targetDate ?? undefined });
+  }
+  const bracketView = initBracketView(BRACKET_STANDALONE_IDS, {
+    shared,
+    onViewerChange() {
+      savePrefs({
+        scale: String(shared.scale),
+        futureOpacity: String(shared.futureOpacity),
+        targetDate: shared.targetDate ?? undefined,
+      });
+    },
+  });
+
+  const activate = (): void => {
+    const selection = {
+      competition: competitionSelect.value,
+      season: seasonSelect.value,
+    };
+    writeUrlParams(selection.competition, selection.season);
+    savePrefs(selection);
+    bracketView.activate(seasonMap, selection);
+  };
+
+  competitionSelect.addEventListener('change', () => {
+    populateBracketSeasonPulldown(seasonMap, competitionSelect.value, seasonSelect);
+    activate();
+  });
+  seasonSelect.addEventListener('change', activate);
+
+  const localeSelect = document.getElementById('locale_key') as HTMLSelectElement | null;
+  if (localeSelect) {
+    if (savedLocale) localeSelect.value = savedLocale;
+    localeSelect.addEventListener('change', () => {
+      savePrefs({ locale: localeSelect.value });
       location.reload();
     });
   }
 
-  // ---- Sync DOM sliders from controlState ----------------------------------
-
-  const opacitySlider = document.getElementById('future_opacity') as HTMLInputElement | null;
-  if (opacitySlider) opacitySlider.value = String(controlState.viewer.futureOpacity);
-
-  const scaleSlider = document.getElementById('scale_slider') as HTMLInputElement | null;
-  if (scaleSlider) scaleSlider.value = String(controlState.viewer.scale);
-
-  // ---- Date slider events --------------------------------------------------
-
-  const dateSlider = document.getElementById('date_slider') as HTMLInputElement | null;
-  if (dateSlider) {
-    dateSlider.addEventListener('input', () => {
-      syncTargetDateFromSlider();
-      updateSliderDisplay();
-    });
-    dateSlider.addEventListener('change', () => {
-      syncTargetDateFromSlider();
-      updateSliderDisplay();
-      renderWithDateFilter();
-      applyFutureOpacity();
-      savePrefs({ targetDate: controlState.viewer.targetDate ?? undefined });
-    });
-
-    document.getElementById('date_slider_down')?.addEventListener('click', () => {
-      dateSlider.value = String(Math.max(0, parseInt(dateSlider.value, 10) - 1));
-      syncTargetDateFromSlider();
-      updateSliderDisplay();
-      renderWithDateFilter();
-      applyFutureOpacity();
-      savePrefs({ targetDate: controlState.viewer.targetDate ?? undefined });
-    });
-    document.getElementById('date_slider_up')?.addEventListener('click', () => {
-      dateSlider.value = String(Math.min(
-        parseInt(dateSlider.max, 10), parseInt(dateSlider.value, 10) + 1,
-      ));
-      syncTargetDateFromSlider();
-      updateSliderDisplay();
-      renderWithDateFilter();
-      applyFutureOpacity();
-      savePrefs({ targetDate: controlState.viewer.targetDate ?? undefined });
-    });
-    document.getElementById('date_slider_reset')?.addEventListener('click', () => {
-      if (!currentState) return;
-      controlState.viewer.targetDate = getLastMatchDate(currentState.matchDates);
-      syncSliderFromTargetDate();
-      updateSliderDisplay();
-      renderWithDateFilter();
-      applyFutureOpacity();
-      savePrefs({ targetDate: controlState.viewer.targetDate ?? undefined });
-    });
-  }
-
-  // ---- Opacity slider events -----------------------------------------------
-
-  if (opacitySlider) {
-    opacitySlider.addEventListener('input', () => {
-      controlState.viewer.futureOpacity = parseFloat(opacitySlider.value);
-      applyFutureOpacity();
-      savePrefs({ futureOpacity: opacitySlider.value });
-    });
-  }
-
-  // ---- Scale slider events -------------------------------------------------
-
-  if (scaleSlider) {
-    scaleSlider.addEventListener('input', () => {
-      controlState.viewer.scale = parseFloat(scaleSlider.value);
-      applyScale();
-      savePrefs({ scale: scaleSlider.value });
-    });
-  }
-
-  // ---- Layout toggle events ------------------------------------------------
-
-  const layoutSel = document.getElementById('layout_toggle') as HTMLSelectElement | null;
-  if (layoutSel) {
-    layoutSel.addEventListener('change', () => {
-      controlState.bracket.layout = layoutSel.value as 'horizontal' | 'vertical';
-      // Full re-render to recompute positions and connectors per section
-      renderWithDateFilter();
-      applyFutureOpacity();
-    });
-  }
-
-  // ---- Round start change events --------------------------------------------
-
-  document.getElementById('round_start_key')?.addEventListener('change', () => {
-    controlState.bracket.roundStart = getSelectValue('round_start_key');
-    renderWithDateFilter();
-    applyFutureOpacity();
-    savePrefs({ roundStart: controlState.bracket.roundStart });
-  });
-
-  // ---- Competition/season change events ------------------------------------
-
-  competitionSel.addEventListener('change', () => {
-    populateSeasonPulldown(seasonMap, competitionSel.value);
-    loadAndRender(seasonMap);
-  });
-  document.getElementById('season_key')?.addEventListener('change', () => {
-    loadAndRender(seasonMap);
-  });
-
-  loadAndRender(seasonMap);
+  activate();
 }
 
-if (typeof document !== 'undefined') {
-  main().catch(console.error);
-}
+main().catch(console.error);

--- a/frontend/src/view-bootstrap.ts
+++ b/frontend/src/view-bootstrap.ts
@@ -52,6 +52,22 @@ export interface SharedViewerControlDefaults {
   futureOpacity?: number;
 }
 
+export function normalizeTargetDate(value: string | null | undefined): string | null {
+  if (value == null || value === '') return null;
+  return value.replace(/-/g, '/');
+}
+
+export function toInputDate(value: string | null | undefined): string {
+  return normalizeTargetDate(value)?.replace(/\//g, '-') ?? '';
+}
+
+export function clampToSlider(value: number, slider: HTMLInputElement): number {
+  const min = slider.min === '' ? Number.NEGATIVE_INFINITY : Number(slider.min);
+  const max = slider.max === '' ? Number.POSITIVE_INFINITY : Number(slider.max);
+  const finiteValue = Number.isFinite(value) ? value : Number(slider.value);
+  return Math.min(max, Math.max(min, finiteValue));
+}
+
 export function createSharedViewerControlState(
   prefs: ViewerPrefs,
   defaults: SharedViewerControlDefaults = {},
@@ -59,6 +75,6 @@ export function createSharedViewerControlState(
   return {
     scale: prefs.scale ? parseFloat(prefs.scale) : (defaults.scale ?? 1),
     futureOpacity: prefs.futureOpacity ? parseFloat(prefs.futureOpacity) : (defaults.futureOpacity ?? 0.1),
-    targetDate: prefs.targetDate ?? null,
+    targetDate: normalizeTargetDate(prefs.targetDate),
   };
 }

--- a/frontend/src/view-bootstrap.ts
+++ b/frontend/src/view-bootstrap.ts
@@ -1,0 +1,64 @@
+// Shared initialization helpers used by league-view / bracket-view (and the
+// matches-app orchestrator): URL param read/write, locale restore + i18n
+// application, and the viewer-level (scale/futureOpacity/targetDate) slice of
+// control state that both views derive from the same ViewerPrefs shape.
+
+import type { ViewerPrefs } from './storage/local-storage';
+import { setLocale, applyI18nAttributes } from './i18n';
+import type { Locale } from './i18n';
+
+// ---- URL parameter management ------------------------------------------
+
+export function readUrlParams(): { competition: string; season?: string } {
+  const params = new URLSearchParams(location.search);
+  return {
+    competition: params.get('competition') ?? '',
+    season: params.get('season') ?? undefined,
+  };
+}
+
+export function writeUrlParams(competition: string, season: string): void {
+  const url = new URL(location.href);
+  url.searchParams.set('competition', competition);
+  url.searchParams.set('season', season);
+  history.replaceState(null, '', url.toString());
+}
+
+// ---- Locale restore + i18n ----------------------------------------------
+
+/**
+ * Restore locale from a saved pref value (if it is a known Locale) and apply
+ * data-i18n attributes. Must run before any t()/applyI18nAttributes() calls.
+ * Returns the restored Locale, or undefined if the saved value was absent/invalid.
+ */
+export function restoreLocaleAndApplyI18n(savedLocale: string | undefined): Locale | undefined {
+  const locale = (savedLocale === 'ja' || savedLocale === 'en') ? savedLocale as Locale : undefined;
+  if (locale) setLocale(locale);
+  applyI18nAttributes();
+  return locale;
+}
+
+// ---- Shared viewer control state -----------------------------------------
+
+export interface SharedViewerControlState {
+  scale: number;
+  futureOpacity: number;
+  targetDate: string | null;
+}
+
+/** Defaults differ slightly between views (e.g. bracket's default futureOpacity is 0.2). */
+export interface SharedViewerControlDefaults {
+  scale?: number;
+  futureOpacity?: number;
+}
+
+export function createSharedViewerControlState(
+  prefs: ViewerPrefs,
+  defaults: SharedViewerControlDefaults = {},
+): SharedViewerControlState {
+  return {
+    scale: prefs.scale ? parseFloat(prefs.scale) : (defaults.scale ?? 1),
+    futureOpacity: prefs.futureOpacity ? parseFloat(prefs.futureOpacity) : (defaults.futureOpacity ?? 0.1),
+    targetDate: prefs.targetDate ?? null,
+  };
+}


### PR DESCRIPTION
Refs #270

> このPRは `feature/issue-268-merge-league-tournament-view` への統合PRです。`main` への統合は親Issue #268の完了PRで行います。

## Summary
- League / Bracketのロジックを`init`・`activate`・`deactivate`契約のViewモジュールへ抽出
- season map、URL、locale、共有viewer stateを統合オーケストレータで管理
- Competitionの`view_type`に応じて同一ページ内でViewを切り替え、旧standaloneページは薄いラッパー化
- Bracket構造変更後の表示高さを再計測し、season notesとの重なりを解消

## Changes
| Commit | Description |
|--------|-------------|
| `fc3f2d9` | 共有bootstrap helperを抽出 |
| `5b037a0` | 日付・scale・view typeの共有契約を強化 |
| `964ebc9` | League View lifecycle moduleを抽出 |
| `3c6e024` | Bracket View lifecycle moduleを抽出 |
| `3e7a1e9` | 統合オーケストレータ、shell配線、テストを追加 |

## Test plan
- [x] `npm test` passed: 567 tests (frontend/)
- [x] `npm run typecheck` passed (frontend/)
- [x] `npm run build` succeeded for all 3 entries (frontend/)
- [x] `j_points.html` / `tournament.html` regressionなしを目視確認
- [x] `matches.html`でLeague / Bracket切替、初期pending、日付共有、scale clamp、timezone、resetを確認
- [x] 表示開始ラウンド変更時にBracket高さが追従し、notesと重ならないことを確認

Generated with Codex