### PR TITLE
Migrate E2E tests to the unified matches.html viewer

### DIFF
--- a/frontend/e2e/basic-render.spec.ts
+++ b/frontend/e2e/basic-render.spec.ts
@@ -3,7 +3,7 @@ import { waitForRender, assertInvariants } from './helpers/invariants';
 
 test.describe('T1: Basic Rendering', () => {
   test('default page load renders bar graph and rank table', async ({ page }) => {
-    await page.goto('/j_points.html');
+    await page.goto('/matches.html');
     await waitForRender(page);
 
     // Bar graph has team columns
@@ -22,26 +22,26 @@ test.describe('T1: Basic Rendering', () => {
   });
 
   test('status message shows row count', async ({ page }) => {
-    await page.goto('/j_points.html');
+    await page.goto('/matches.html');
     await waitForRender(page);
 
-    const statusText = await page.locator('#status_msg').textContent();
+    const statusText = await page.locator('#league_status_msg').textContent();
     expect(statusText).toMatch(/\d+\s*行/);
   });
 
   test('date slider is initialized', async ({ page }) => {
-    await page.goto('/j_points.html');
+    await page.goto('/matches.html');
     await waitForRender(page);
 
-    const sliderMax = await page.locator('#date_slider').getAttribute('max');
+    const sliderMax = await page.locator('#league_date_slider').getAttribute('max');
     expect(Number(sliderMax)).toBeGreaterThan(0);
 
-    const postLabel = await page.locator('#post_date_slider').textContent();
+    const postLabel = await page.locator('#league_post_date_slider').textContent();
     expect(postLabel?.trim().length).toBeGreaterThan(0);
   });
 
   test('timestamp is displayed', async ({ page }) => {
-    await page.goto('/j_points.html');
+    await page.goto('/matches.html');
     await waitForRender(page);
 
     const timestamp = await page.locator('#data_timestamp').textContent();

--- a/frontend/e2e/bracket-render.spec.ts
+++ b/frontend/e2e/bracket-render.spec.ts
@@ -2,14 +2,14 @@ import { test, expect } from './helpers/test-base';
 
 /** Wait for bracket to render (status message shows loaded count). */
 async function waitForBracketRender(page: import('@playwright/test').Page): Promise<void> {
-  await page.locator('#status_msg').filter({ hasText: /\d+/ }).waitFor({ timeout: 15000 });
+  await page.locator('#bracket_status_msg').filter({ hasText: /\d+/ }).waitFor({ timeout: 15000 });
   await page.locator('.bracket-match').first().waitFor({ timeout: 5000 });
 }
 
 test.describe('Bracket rendering — connectors and layout', () => {
   test.beforeEach(async ({ page }) => {
     // EmperorsCup 2025: simple bracket tree (R16 onward)
-    await page.goto('/tournament.html?competition=EmperorsCup&season=2025');
+    await page.goto('/matches.html?competition=EmperorsCup&season=2025');
     await waitForBracketRender(page);
   });
 
@@ -26,7 +26,7 @@ test.describe('Bracket rendering — connectors and layout', () => {
     const beforeSolid = await solid.count();
     expect(beforeSolid).toBeGreaterThan(0);
 
-    const slider = page.locator('#date_slider');
+    const slider = page.locator('#bracket_date_slider');
     await slider.fill('0');
     await slider.dispatchEvent('change');
     await page.locator('.bracket-match').first().waitFor({ timeout: 5000 });
@@ -75,7 +75,7 @@ test.describe('Bracket rendering — connectors and layout', () => {
 test.describe('Bracket rendering — multi-section @full-render', { tag: '@full-render' }, () => {
   test('multi-section mode renders separate section containers', async ({ page }) => {
     // JLeagueCup 2025 has bracket_blocks (1回戦, 2回戦, プレーオフ, プライム)
-    await page.goto('/tournament.html?competition=JLeagueCup&season=2025');
+    await page.goto('/matches.html?competition=JLeagueCup&season=2025');
     await waitForBracketRender(page);
 
     // Switch to multi-section mode
@@ -95,7 +95,7 @@ test.describe('Bracket rendering — multi-section @full-render', { tag: '@full-
   });
 
   test('matchup_pairs blocks render as pair-based brackets', async ({ page }) => {
-    await page.goto('/tournament.html?competition=JLeagueCup&season=2025');
+    await page.goto('/matches.html?competition=JLeagueCup&season=2025');
     await waitForBracketRender(page);
 
     // Switch to multi-section mode
@@ -116,7 +116,7 @@ test.describe('Bracket rendering — multi-section @full-render', { tag: '@full-
 
   test('WC2026 knockout renders main draw and third-place blocks', async ({ page }) => {
     // WC_KO 2026 defaults to multi-section (bracket_blocks present).
-    await page.goto('/tournament.html?competition=WC_KO&season=2026');
+    await page.goto('/matches.html?competition=WC_KO&season=2026');
     await waitForBracketRender(page);
 
     const summaries = await page.locator('.bracket-section-summary').allTextContents();

--- a/frontend/e2e/bracket-tooltip.spec.ts
+++ b/frontend/e2e/bracket-tooltip.spec.ts
@@ -2,14 +2,14 @@ import { test, expect } from './helpers/test-base';
 
 /** Wait for bracket to render (status message shows loaded count). */
 async function waitForBracketRender(page: import('@playwright/test').Page): Promise<void> {
-  await page.locator('#status_msg').filter({ hasText: /\d+/ }).waitFor({ timeout: 15000 });
+  await page.locator('#bracket_status_msg').filter({ hasText: /\d+/ }).waitFor({ timeout: 15000 });
   // Wait for at least one match card to appear
   await page.locator('.bracket-match').first().waitFor({ timeout: 5000 });
 }
 
 test.describe('Bracket tooltip pin/unpin', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/tournament.html?competition=JLeagueCup&season=2025');
+    await page.goto('/matches.html?competition=JLeagueCup&season=2025');
     await waitForBracketRender(page);
   });
 
@@ -81,7 +81,7 @@ test.describe('Bracket tooltip pin/unpin', () => {
 
     // Change date slider → re-render → pin dismissed
     // (tooltip may reappear unpinned if cursor hovers a new card after re-render)
-    const slider = page.locator('#date_slider');
+    const slider = page.locator('#bracket_date_slider');
     const max = Number(await slider.getAttribute('max'));
     if (max > 0) {
       await slider.fill(String(max - 1));

--- a/frontend/e2e/date-slider.spec.ts
+++ b/frontend/e2e/date-slider.spec.ts
@@ -4,7 +4,7 @@ import { waitForRender, assertInvariants } from './helpers/invariants';
 test.describe('T4: Date Slider', () => {
   test.beforeEach(async ({ page }) => {
     // Use a completed season so slider has full range
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
   });
 
@@ -12,8 +12,8 @@ test.describe('T4: Date Slider', () => {
     const dateBefore = await page.locator('#target_date').inputValue();
 
     // Set slider to position 5 (early in the season)
-    await page.locator('#date_slider').fill('5');
-    await page.locator('#date_slider').dispatchEvent('change');
+    await page.locator('#league_date_slider').fill('5');
+    await page.locator('#league_date_slider').dispatchEvent('change');
     await waitForRender(page);
 
     const dateAfter = await page.locator('#target_date').inputValue();
@@ -23,24 +23,24 @@ test.describe('T4: Date Slider', () => {
 
   test('up/down buttons adjust slider', async ({ page }) => {
     // Set slider to middle
-    const max = Number(await page.locator('#date_slider').getAttribute('max'));
+    const max = Number(await page.locator('#league_date_slider').getAttribute('max'));
     const mid = Math.floor(max / 2);
-    await page.locator('#date_slider').fill(String(mid));
-    await page.locator('#date_slider').dispatchEvent('change');
+    await page.locator('#league_date_slider').fill(String(mid));
+    await page.locator('#league_date_slider').dispatchEvent('change');
     await waitForRender(page);
 
     // Click up button
-    await page.locator('#date_slider_up').click();
+    await page.locator('#league_date_slider_up').click();
     await waitForRender(page);
-    const valAfterUp = Number(await page.locator('#date_slider').inputValue());
+    const valAfterUp = Number(await page.locator('#league_date_slider').inputValue());
     expect(valAfterUp).toBe(mid + 1);
     await assertInvariants(page);
   });
 
   test('early date causes future boxes to appear', async ({ page }) => {
     // Set slider to position 1 (very early — only first match date)
-    await page.locator('#date_slider').fill('1');
-    await page.locator('#date_slider').dispatchEvent('change');
+    await page.locator('#league_date_slider').fill('1');
+    await page.locator('#league_date_slider').dispatchEvent('change');
     await waitForRender(page);
 
     // There should be future boxes (matches after the early cutoff)
@@ -51,8 +51,8 @@ test.describe('T4: Date Slider', () => {
 
   test('reset button returns to latest date', async ({ page }) => {
     // Move slider to early position
-    await page.locator('#date_slider').fill('1');
-    await page.locator('#date_slider').dispatchEvent('change');
+    await page.locator('#league_date_slider').fill('1');
+    await page.locator('#league_date_slider').dispatchEvent('change');
     await waitForRender(page);
 
     // Click reset
@@ -60,8 +60,8 @@ test.describe('T4: Date Slider', () => {
     await waitForRender(page);
 
     // Slider should be at max
-    const max = await page.locator('#date_slider').getAttribute('max');
-    const val = await page.locator('#date_slider').inputValue();
+    const max = await page.locator('#league_date_slider').getAttribute('max');
+    const val = await page.locator('#league_date_slider').inputValue();
     expect(Number(val)).toBeGreaterThanOrEqual(Number(max) - 1);
     await assertInvariants(page);
   });

--- a/frontend/e2e/dropdown.spec.ts
+++ b/frontend/e2e/dropdown.spec.ts
@@ -3,7 +3,7 @@ import { waitForRender, assertInvariants } from './helpers/invariants';
 
 test.describe('T2: Dropdown Interaction', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
   });
 
@@ -14,7 +14,7 @@ test.describe('T2: Dropdown Interaction', () => {
     );
 
     // Switch to a different group that has different competitions
-    const competitionOptions = await page.locator('#competition_key option').evaluateAll(
+    const competitionOptions = await page.locator('#competition_key option[data-view-type="league"]').evaluateAll(
       (opts) => opts.map((o) => (o as HTMLOptionElement).value),
     );
 

--- a/frontend/e2e/full-render.spec.ts
+++ b/frontend/e2e/full-render.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './helpers/test-base';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import yaml from 'js-yaml';
@@ -20,16 +20,24 @@ const __dirname = dirname(__filename);
 
 interface SeasonMap {
   [group: string]: {
+    view_type?: string | string[];
     competitions: {
       [competition: string]: {
-        seasons: { [season: string]: unknown[] };
+        view_type?: string | string[];
+        seasons: { [season: string]: unknown };
       };
     };
   };
 }
 
+function includesLeagueView(...values: Array<string | string[] | undefined>): boolean {
+  const configured = values.flatMap(value => value == null ? [] : [value].flat());
+  return configured.length === 0 || configured.includes('league');
+}
+
 function loadSeasonEntries(): Array<{ competition: string; season: string }> {
   const yamlPath = resolve(__dirname, '../../docs/yaml/season_map.yaml');
+  const csvDir = resolve(__dirname, '../../docs/csv');
   const data: SeasonMap = yaml.load(readFileSync(yamlPath, 'utf-8')) as SeasonMap;
   const entries: Array<{ competition: string; season: string }> = [];
 
@@ -37,7 +45,9 @@ function loadSeasonEntries(): Array<{ competition: string; season: string }> {
     if (!group.competitions) continue;
     for (const [competition, comp] of Object.entries(group.competitions)) {
       if (!comp.seasons) continue;
+      if (!includesLeagueView(group.view_type, comp.view_type)) continue;
       for (const season of Object.keys(comp.seasons)) {
+        if (!existsSync(resolve(csvDir, `${season}_allmatch_result-${competition}.csv`))) continue;
         entries.push({ competition, season });
       }
     }
@@ -50,14 +60,8 @@ const allEntries = loadSeasonEntries();
 test.describe('@full-render: All seasons invariant check', () => {
   for (const { competition, season } of allEntries) {
     test(`${competition} ${season}`, async ({ page }) => {
-      await page.goto(`/j_points.html?competition=${competition}&season=${season}`);
-      try {
-        await waitForRender(page);
-      } catch {
-        // Some seasons may have no CSV data yet — skip gracefully
-        test.skip();
-        return;
-      }
+      await page.goto(`/matches.html?competition=${competition}&season=${season}`);
+      await waitForRender(page);
       await assertInvariants(page);
 
       // I3: no team color warning

--- a/frontend/e2e/helpers/invariants.ts
+++ b/frontend/e2e/helpers/invariants.ts
@@ -2,12 +2,12 @@ import { expect, type Page, type Locator } from '@playwright/test';
 
 /**
  * Wait for the bar graph to finish rendering after a data-changing action.
- * Waits until #box_container has at least one team column and #status_msg
+ * Waits until #box_container has at least one team column and #league_status_msg
  * no longer shows the loading indicator.
  */
 export async function waitForRender(page: Page): Promise<void> {
   // Wait for status message to stop showing loading text
-  await page.locator('#status_msg').filter({ hasNotText: '読み込み中' }).waitFor({ timeout: 15000 });
+  await page.locator('#league_status_msg').filter({ hasNotText: '読み込み中' }).waitFor({ timeout: 15000 });
   // Wait for at least one team column to appear
   await page.locator('#box_container [id$="_column"]').first().waitFor({ timeout: 15000 });
 }

--- a/frontend/e2e/multi-group.spec.ts
+++ b/frontend/e2e/multi-group.spec.ts
@@ -3,7 +3,7 @@ import { waitForRender, assertInvariants } from './helpers/invariants';
 
 test.describe('T6: Multi-Group Rendering', () => {
   test('WE Cup 25-26 renders 3 groups (A/B/C)', async ({ page }) => {
-    await page.goto('/j_points.html?competition=WE_Cup&season=25-26');
+    await page.goto('/matches.html?competition=WE_Cup&season=25-26');
     await waitForRender(page);
 
     // group_wrapper elements for A, B, C
@@ -38,7 +38,7 @@ test.describe('T6: Multi-Group Rendering', () => {
   });
 
   test('single-group season has no group_wrapper', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     const groups = page.locator('#box_container .group_wrapper');
@@ -52,7 +52,7 @@ test.describe('T6: Multi-Group Rendering', () => {
   });
 
   test('WC_GS 2026 renders 12 groups with no interior point column', async ({ page }) => {
-    await page.goto('/j_points.html?competition=WC_GS&season=2026');
+    await page.goto('/matches.html?competition=WC_GS&season=2026');
     await waitForRender(page);
 
     // 12 groups (A..L).

--- a/frontend/e2e/rank-table.spec.ts
+++ b/frontend/e2e/rank-table.spec.ts
@@ -3,7 +3,7 @@ import { waitForRender, assertInvariants } from './helpers/invariants';
 
 test.describe('T5: Rank Table', () => {
   test('table has expected header columns', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     const headers = await page.locator('table.ranktable thead th').evaluateAll(
@@ -20,7 +20,7 @@ test.describe('T5: Rank Table', () => {
   });
 
   test('team names do not wrap', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     const teamNames = page.locator('table.ranktable [data-rank-team-name]');
@@ -29,7 +29,7 @@ test.describe('T5: Rank Table', () => {
   });
 
   test('sortable header click changes row order', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     const teamsBefore = await page.locator('table.ranktable tbody tr').evaluateAll(
@@ -51,7 +51,7 @@ test.describe('T5: Rank Table', () => {
   });
 
   test('promotion/relegation row styling present', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     // J1 2024 has promotion and relegation zones
@@ -65,7 +65,7 @@ test.describe('T5: Rank Table', () => {
 
   test('PK columns shown for seasons with PK data', async ({ page }) => {
     // 1995A has PK data (win3all-pkloss1 system)
-    await page.goto('/j_points.html?competition=J1&season=1995A');
+    await page.goto('/matches.html?competition=J1&season=1995A');
     await waitForRender(page);
 
     const headers = await page.locator('table.ranktable thead th').evaluateAll(
@@ -77,7 +77,7 @@ test.describe('T5: Rank Table', () => {
   });
 
   test('PK columns not shown for standard seasons', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     const headers = await page.locator('table.ranktable thead th').evaluateAll(
@@ -89,7 +89,7 @@ test.describe('T5: Rank Table', () => {
   });
 
   test('unchecking a column checkbox hides the column and persists across reload', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     await page.locator('#column_toggle_section summary').click();

--- a/frontend/e2e/special-seasons.spec.ts
+++ b/frontend/e2e/special-seasons.spec.ts
@@ -3,7 +3,7 @@ import { waitForRender, assertInvariants } from './helpers/invariants';
 
 test.describe('T7: Special Point Systems', () => {
   test('victory-count (1993) has 3x box height scaling', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=1993A');
+    await page.goto('/matches.html?competition=J1&season=1993A');
     await waitForRender(page);
 
     // Numbered point boxes should be 75px (25px * scale 3) instead of default 25px
@@ -17,7 +17,7 @@ test.describe('T7: Special Point Systems', () => {
   });
 
   test('standard (2024) has default 25px box height', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     const pointBoxHeight = await page.locator('.point_column .box').first().evaluate(
@@ -29,7 +29,7 @@ test.describe('T7: Special Point Systems', () => {
   });
 
   test('graduated-win (1997) renders with invariants', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=1997A');
+    await page.goto('/matches.html?competition=J1&season=1997A');
     await waitForRender(page);
 
     // Should have ET/PK related columns in rank table
@@ -43,7 +43,7 @@ test.describe('T7: Special Point Systems', () => {
   });
 
   test('pk-win2-loss1 (2026) renders with invariants', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2026East');
+    await page.goto('/matches.html?competition=J1&season=2026East');
     await waitForRender(page);
 
     const headers = await page.locator('table.ranktable thead th').evaluateAll(
@@ -59,7 +59,7 @@ test.describe('T7: Special Point Systems', () => {
 
 test.describe('T8: Notes and Data Source Display', () => {
   test('data_source link is displayed for J1', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     const dsSection = page.locator('#data_source_section');
@@ -72,10 +72,10 @@ test.describe('T8: Notes and Data Source Display', () => {
 
   test('auto-generated rule note for non-standard point system', async ({ page }) => {
     // graduated-win should auto-generate a rule explanation note
-    await page.goto('/j_points.html?competition=J1&season=1997A');
+    await page.goto('/matches.html?competition=J1&season=1997A');
     await waitForRender(page);
 
-    const notes = page.locator('#season_notes li');
+    const notes = page.locator('#league_season_notes li');
     expect(await notes.count()).toBeGreaterThan(0);
 
     // Note content should mention point rules
@@ -89,10 +89,10 @@ test.describe('T8: Notes and Data Source Display', () => {
 
   test('manual note displayed for season with configured note', async ({ page }) => {
     // J3 2021 has a manual note about 宮崎
-    await page.goto('/j_points.html?competition=J3&season=2021');
+    await page.goto('/matches.html?competition=J3&season=2021');
     await waitForRender(page);
 
-    const notes = page.locator('#season_notes li');
+    const notes = page.locator('#league_season_notes li');
     expect(await notes.count()).toBeGreaterThan(0);
 
     const noteTexts = await notes.evaluateAll(
@@ -103,12 +103,12 @@ test.describe('T8: Notes and Data Source Display', () => {
   });
 
   test('no notes for standard season without configured note', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     // Standard point system + default tiebreak = no auto-generated notes
     // J1 group-level note exists but it's about ACL
-    const notes = page.locator('#season_notes li');
+    const notes = page.locator('#league_season_notes li');
     const count = await notes.count();
 
     // Should have the group-level ACL note but no rule-related auto-note

--- a/frontend/e2e/unified-viewer.spec.ts
+++ b/frontend/e2e/unified-viewer.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from './helpers/test-base';
+import { waitForRender } from './helpers/invariants';
+
+async function waitForBracketRender(page: import('@playwright/test').Page): Promise<void> {
+  await page.locator('#bracket_status_msg').filter({ hasText: /\d+/ }).waitFor({ timeout: 15000 });
+  await page.locator('#bracket_container .bracket-match').first().waitFor({ timeout: 10000 });
+}
+
+test.describe('Unified league and bracket viewer', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/matches.html?competition=J1&season=2024');
+    await waitForRender(page);
+  });
+
+  test('switches views in place and keeps URL selection synchronized', async ({ page }) => {
+    const initialPath = new URL(page.url()).pathname;
+    await expect(page.locator('#view_root')).toHaveAttribute('data-active', 'league');
+    await expect(page.locator('#league_view')).toBeVisible();
+    await expect(page.locator('#bracket_view')).toBeHidden();
+
+    await page.selectOption('#competition_key', 'JLeagueCup');
+    await waitForBracketRender(page);
+
+    expect(new URL(page.url()).pathname).toBe(initialPath);
+    expect(new URL(page.url()).searchParams.get('competition')).toBe('JLeagueCup');
+    await expect(page.locator('#view_root')).toHaveAttribute('data-active', 'bracket');
+    await expect(page.locator('#league_view')).toBeHidden();
+    await expect(page.locator('#bracket_view')).toBeVisible();
+
+    await page.selectOption('#competition_key', 'J1');
+    await waitForRender(page);
+
+    expect(new URL(page.url()).pathname).toBe(initialPath);
+    await expect(page.locator('#view_root')).toHaveAttribute('data-active', 'league');
+    await expect(page.locator('#league_view')).toBeVisible();
+    await expect(page.locator('#bracket_view')).toBeHidden();
+  });
+
+  test('shares viewer controls and canonical target date across views', async ({ page }) => {
+    await page.locator('#league_scale_slider').fill('0.6');
+    await page.locator('#league_scale_slider').dispatchEvent('input');
+    await page.locator('#league_future_opacity').fill('0.3');
+    await page.locator('#league_future_opacity').dispatchEvent('input');
+    await page.locator('#target_date').fill('2024-05-03');
+    await page.locator('#target_date').dispatchEvent('change');
+    await waitForRender(page);
+
+    await page.selectOption('#competition_key', 'JLeagueCup');
+    await waitForBracketRender(page);
+
+    await expect(page.locator('#bracket_scale_slider')).toHaveValue('0.6');
+    await expect(page.locator('#bracket_future_opacity')).toHaveValue('0.3');
+    const prefs = await page.evaluate(() => JSON.parse(
+      localStorage.getItem('jleague_viewer_prefs') ?? '{}',
+    ) as Record<string, string>);
+    expect(prefs.targetDate).toBe('2024/05/03');
+    expect(prefs.scale).toBe('0.6');
+    expect(prefs.futureOpacity).toBe('0.3');
+  });
+});

--- a/frontend/e2e/url-params.spec.ts
+++ b/frontend/e2e/url-params.spec.ts
@@ -3,7 +3,7 @@ import { waitForRender, assertInvariants } from './helpers/invariants';
 
 test.describe('T3: URL Parameters', () => {
   test('URL params initialize dropdowns correctly', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     const competition = await page.locator('#competition_key').inputValue();
@@ -15,7 +15,7 @@ test.describe('T3: URL Parameters', () => {
   });
 
   test('dropdown change updates URL params', async ({ page }) => {
-    await page.goto('/j_points.html?competition=J1&season=2024');
+    await page.goto('/matches.html?competition=J1&season=2024');
     await waitForRender(page);
 
     // Get available seasons and switch
@@ -33,7 +33,7 @@ test.describe('T3: URL Parameters', () => {
   });
 
   test('invalid params fall back to defaults without error', async ({ page }) => {
-    await page.goto('/j_points.html?competition=INVALID&season=INVALID');
+    await page.goto('/matches.html?competition=INVALID&season=INVALID');
     // Should still render something (falls back to first available)
     await waitForRender(page);
 


### PR DESCRIPTION
Refs #275

> このPRは `feature/issue-273-unify-build-deployment` への統合PRです。`main` への統合は親Issue #268 の完了PRで行います。

## Summary

- 既存のリーグ・ブラケットE2E specを統合ページ `matches.html` へ移行し、名前空間化後のselector (`league_*`/`bracket_*`) に更新
- リーグ大会↔ブラケット大会の切替がページ遷移なしで `#view_root[data-active]` を切り替え、URL・共有localStorage状態 (scale/futureOpacity/targetDate) を保持することを検証するE2Eを追加
- full-render suiteの列挙ロジックを修正: 統合後のseason_mapにBracket大会が同居するようになったため、League View かつ CSV 実在のシーズンのみに限定。旧try/catchのskipも撤廃し、実エラーを隠さないようにした

## Changes

| Commit | Description |
|--------|-------------|
| `3faaa9f` | 既存E2Eを統合matches.htmlシェルへ移行 |
| `0df1411` | full-render enumerationの修正 (初期年代でのgetHours未定義エラーの根本原因) |
| `0639184` | League/Bracket View切替のE2Eを追加 |

## Test plan

- [x] `npx vitest run` (567 tests) 通過
- [x] `npm run typecheck` 通過
- [x] `npm run build` 成功
- [x] Chromium 通常E2E (43 tests) 通過
- [x] WebKit 通常E2E (43 tests) 通過
- [x] full-render (131/132) 通過。唯一の失敗 `WE 25-26` はチームカラー未定義の別件のため #276 として切り出し済み
- [x] ブラウザ目視確認 (matches.html、ユーザー担当)

Generated with Claude Code