### PR TITLE
Add team colors for WE 25-26 AFC Women's CL opponents

### DIFF
--- a/docs/team_style.css
+++ b/docs/team_style.css
@@ -687,3 +687,19 @@
   color: white;
   background-color: #002060;
 }
+
+/* AFC Women's Champions League opponents (25-26, 東京NB のノックアウト対戦相手) */
+.スタリオン { /* Stallion Laguna FC (フィリピン) 赤黒 */
+  color: white;
+  background: -moz-linear-gradient(top left, #e60012, #1a1a1a 60%);
+  background: -webkit-linear-gradient(top left, #e60012, #1a1a1a 60%);
+  background: linear-gradient(to bottom right, #e60012, #1a1a1a 60%);
+}
+.メルボルン { /* Melbourne City FC (オーストラリア) シティブルー */
+  color: #002855;
+  background-color: #6cabdd;
+}
+.ネゴヒャン { /* Naegohyang Women's FC (北朝鮮) DPRK レッド */
+  color: white;
+  background-color: #d0021b;
+}


### PR DESCRIPTION
## Summary

WE 25-26 の東京NB (日テレ・東京ヴェルディベレーザ) が進出した AFC 女子チャンピオンズリーグ (節番号97-99) のノックアウト対戦相手3チームを `docs/team_style.css` に追加し、I3 不変条件の「チームカラー未定義」警告を解消。

| CSV名 | 正式名 | 国 | カラー |
| ----- | ------ | -- | ------ |
| スタリオン | Stallion Laguna FC | フィリピン | 赤×黒 (グラデーション) |
| メルボルン | Melbourne City FC | オーストラリア | シティブルー #6cabdd |
| ネゴヒャン | Naegohyang Women's FC | 北朝鮮 | DPRK レッド #d0021b |

## Verification

- WE 25-26 全15チームがCSS定義済みであることを確認
- `npx playwright test --grep @full-render --grep "WE 25-26"` が通過 (`#warning_msg` 非表示)

Closes #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)