### PR TITLE
Normalize tournament season config to always use bracket_blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,7 @@ uv run python scripts/check_type_sync.py
   - `'ex-win-2'` (1999–2002): 90分勝3/延長勝2/分1/負0
   - `'pk-win2-loss1'` (2026特別大会): 勝3/PK勝2/PK負1/負0
 - **SeasonEntry バリデーション**: 必須キー (`team_count`, `promotion_count`, `relegation_count`, `teams`) の欠落・型不正は即エラー。未知のオプショナルキーは Warning で無視
+- **Tournament 設定の正本は `bracket_blocks`** (#287): 1 ブロック season でも `bracket_blocks` で書く。エントリレベル `bracket_order` は廃止。tournament の `teams` は派生値 (block の `bracket_order` から bye `~` を除去) で season_map に書かない (書くと Warning)。包括ツリー (単一ツリー表示) の主 block は「非 matchup block が単独ならそれ、複数なら `inclusive_tree: true` の block」で解決し、主 block がなければ multi-section 表示のみ (J1PO/J2J3PO 等)。authored 構造を持たない大会 (EmperorsCup) は CSV から全推定
 - **ルール説明ノート自動生成** (`config/rule-notes.ts`): `pointSystem` が `'standard'` 以外、または `tiebreakOrder` がデフォルト (`['goal_diff', 'goal_get']`) と異なる場合、`resolveSeasonInfo()` が note 配列末尾にルール説明を自動追加。メッセージは辞書オブジェクトで管理し、将来の多言語化に備える (locale 引数 + `Record<Locale, ...>` への拡張で対応可能)
 - **スコアアノテーション規則 (リーグ・トーナメント共通)**: メインスコア (`homeGoal`/`awayGoal`) は常に ET 込みの最終結果。`formatScore` が `(PKn)` / `(ETn)` アノテーションを付加。PK がある場合は PK のみ表示 (ET 後も同点なので ET スコアに情報価値なし)。単試合・H&A aggregate 共通ロジック
   - **単試合**: CSV の `home_pk_score`/`away_pk_score`/`home_score_ex`/`away_score_ex` をそのままマッピング

--- a/docs/yaml/season_map.yaml
+++ b/docs/yaml/season_map.yaml
@@ -658,11 +658,10 @@ jleague:
         url: https://www.jleague.jp/special/2026specialseason/j1/
       seasons:
         '2026':
-          team_count: 20
-          teams: [神戸, 鹿島, Ｃ大阪, FC東京, 町田, 名古屋, 広島, 川崎Ｆ, Ｇ大阪, 東京Ｖ, 岡山, 浦和, 横浜FM, 清水, 柏, 京都, 長崎, 水戸, 福岡, 千葉]
           round_start_options: [__multi_section__]
           bracket_blocks:
           - label: 順位決定戦
+            bracket_order: [神戸, 鹿島, Ｃ大阪, FC東京, 町田, 名古屋, 広島, 川崎Ｆ, Ｇ大阪, 東京Ｖ, 岡山, 浦和, 横浜FM, 清水, 柏, 京都, 長崎, 水戸, 福岡, 千葉]
             matchup_pairs: true
           note: East n位 vs West n位 のホーム&アウェイ2戦制。合算で勝者が奇数位・敗者が偶数位。
     J2J3PO:
@@ -673,8 +672,6 @@ jleague:
         url: https://www.jleague.jp/special/2026specialseason/j2-j3/
       seasons:
         '2026':
-          team_count: 40
-          teams: [仙台, 富山, 宮崎, 甲府, 鹿児島, 秋田, 新潟, 札幌, 徳島, いわき, 鳥栖, 湘南, 横浜FC, 山口, 大宮, 高知, 相模原, 熊本, 藤枝, 愛媛, 鳥取, 岐阜, 金沢, 群馬, 奈良, 松本, 大分, 山形, 栃木Ｃ, 滋賀, FC大阪, 磐田, 福島, 琉球, 今治, 八戸, 長野, 讃岐, 栃木SC, 北九州]
           round_start_options: [__multi_section__]
           bracket_blocks:
           - label: 1〜4位
@@ -749,84 +746,80 @@ jleague:
       team_count: 8
       seasons:
         '1992':
-          team_count: 4
-          teams: [Ｖ川崎, 鹿島, 清水, 名古屋]
           bracket_round_start: 準決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [Ｖ川崎, 鹿島, 清水, 名古屋]
           shown_groups: [A]
           group_team_count: 10
           note: 予選は単一リーグ。
         '1993':
-          team_count: 4
-          teams: [Ｖ川崎, 横浜Ｆ, Ｇ大阪, 清水]
           bracket_round_start: 準決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [Ｖ川崎, 横浜Ｆ, Ｇ大阪, 清水]
           shown_groups: [A, B]
           group_team_count:
             A: 7
             B: 6
           note: 'Wikipedia group labels: A=Ｖ川崎/Ｇ大阪/鹿島/柏/市原/平塚/広島, B=清水/横浜Ｆ/磐田/名古屋/横浜M/浦和.'
         '1994':
-          team_count: 14
-          teams: [Ｖ川崎, 名古屋, 市原, Ｇ大阪, 広島, 鹿島, 浦和, 清水, 柏, 横浜M, 横浜Ｆ, Ｃ大阪, 磐田, 平塚]
-          bracket_order: [Ｖ川崎, ~, 名古屋, 市原, Ｇ大阪, 広島, 鹿島, 浦和, 清水, ~, 柏, 横浜M, 横浜Ｆ, Ｃ大阪, 磐田, 平塚]
+          bracket_blocks:
+          - label: 決勝トーナメント
+            bracket_order: [Ｖ川崎, ~, 名古屋, 市原, Ｇ大阪, 広島, 鹿島, 浦和, 清水, ~, 柏, 横浜M, 横浜Ｆ, Ｃ大阪, 磐田, 平塚]
           bracket_round_start: 1回戦
         '1996':
-          team_count: 4
-          teams: [柏, Ｖ川崎, 清水, 平塚]
           bracket_round_start: 準決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [柏, Ｖ川崎, 清水, 平塚]
           shown_groups: [A, B]
           group_team_count: 8
           note: 'Wikipedia group labels: A=柏/平塚/広島/横浜M/磐田/Ｇ大阪/浦和/京都, B=清水/Ｖ川崎/横浜Ｆ/市原/鹿島/Ｃ大阪/名古屋/福岡.'
         '1997':
-          teams: [市原, 名古屋, 鹿島, 札幌, 磐田, 浦和, 柏, 横浜Ｆ]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [市原, 名古屋, 鹿島, 札幌, 磐田, 浦和, 柏, 横浜Ｆ]
           shown_groups: [A, B, C, D, E]
           group_team_count: 4
           note: 'Wikipedia group labels: A=市原/清水/平塚/B仙台, B=札幌/Ｖ川崎/Ｇ大阪/横浜M, C=鹿島/浦和/Ｃ大阪/鳥栖, D=柏/名古屋/広島/神戸, E=横浜Ｆ/磐田/京都/福岡.'
         '1998':
-          team_count: 4
-          teams: [清水, 磐田, 市原, 鹿島]
           bracket_round_start: 準決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [清水, 磐田, 市原, 鹿島]
           shown_groups: [A, B, C, D]
           group_team_count: 5
           note: 'Wikipedia group labels: A=磐田/浦和/Ｖ川崎/広島/B仙台, B=鹿島/柏/福岡/横浜M/Ｃ大阪, C=清水/川崎Ｆ/Ｇ大阪/横浜Ｆ/札幌, D=市原/名古屋/平塚/神戸/京都.'
         '1999':
-          team_count: 26
-          teams: [磐田, 福岡, 札幌, 柏, 新潟, Ｃ大阪, 鳥栖, 清水, 京都, 山形, 名古屋, Ｖ川崎, 甲府, 市原, 神戸, Ｆ東京, 横浜FM, 大宮, 広島, 仙台, 鹿島, Ｇ大阪, 川崎Ｆ, 浦和, 平塚, 大分]
-          bracket_order: [磐田, ~, 福岡, 札幌, 柏, 新潟, Ｃ大阪, 鳥栖, 清水, ~, 京都, 山形, 名古屋, ~, Ｖ川崎, 甲府, 市原, ~, 神戸, Ｆ東京, 横浜FM, 大宮, 広島, 仙台, 鹿島, ~, Ｇ大阪, 川崎Ｆ, 浦和, ~, 平塚, 大分]
+          bracket_blocks:
+          - label: 決勝トーナメント
+            bracket_order: [磐田, ~, 福岡, 札幌, 柏, 新潟, Ｃ大阪, 鳥栖, 清水, ~, 京都, 山形, 名古屋, ~, Ｖ川崎, 甲府, 市原, ~, 神戸, Ｆ東京, 横浜FM, 大宮, 広島, 仙台, 鹿島, ~, Ｇ大阪, 川崎Ｆ, 浦和, ~, 平塚, 大分]
           bracket_round_start: 1回戦
         '2000':
-          team_count: 27
-          teams: [柏, 浦和, 川崎Ｆ, Ｖ川崎, 鳥栖, 仙台, Ｃ大阪, Ｆ東京, 京都, 新潟, 磐田, 札幌, Ｇ大阪, 鹿島, 福岡, 湘南, 広島, 山形, 横浜FM, 甲府, 名古屋, 市原, 大分, 水戸, 清水, 神戸, 大宮]
-          bracket_order: [柏, ~, 浦和, 川崎Ｆ, Ｖ川崎, 鳥栖, 仙台, Ｃ大阪, Ｆ東京, ~, 京都, 新潟, 磐田, ~, 札幌, Ｇ大阪, 鹿島, ~, 福岡, 湘南, 広島, 山形, 横浜FM, 甲府, 名古屋, ~, 市原, 大分, 水戸, 清水, 神戸, 大宮]
+          bracket_blocks:
+          - label: 決勝トーナメント
+            bracket_order: [柏, ~, 浦和, 川崎Ｆ, Ｖ川崎, 鳥栖, 仙台, Ｃ大阪, Ｆ東京, ~, 京都, 新潟, 磐田, ~, 札幌, Ｇ大阪, 鹿島, ~, 福岡, 湘南, 広島, 山形, 横浜FM, 甲府, 名古屋, ~, 市原, 大分, 水戸, 清水, 神戸, 大宮]
           bracket_round_start: 1回戦
         '2001':
-          team_count: 28
-          teams: [鹿島, 柏, 湘南, 浦和, 山形, Ｇ大阪, 京都, 清水, 市原, 大宮, 札幌, 大分, Ｃ大阪, 磐田, 川崎Ｆ, 東京Ｖ, 横浜FC, 横浜FM, 水戸, 福岡, 仙台, 名古屋, 神戸, 鳥栖, 甲府, Ｆ東京, 広島, 新潟]
-          bracket_order: [鹿島, ~, 柏, 湘南, 浦和, 山形, Ｇ大阪, 京都, 清水, ~, 市原, 大宮, 札幌, 大分, Ｃ大阪, 磐田, 川崎Ｆ, ~, 東京Ｖ, 横浜FC, 横浜FM, 水戸, 福岡, 仙台, 名古屋, ~, 神戸, 鳥栖, 甲府, Ｆ東京, 広島, 新潟]
+          bracket_blocks:
+          - label: 決勝トーナメント
+            bracket_order: [鹿島, ~, 柏, 湘南, 浦和, 山形, Ｇ大阪, 京都, 清水, ~, 市原, 大宮, 札幌, 大分, Ｃ大阪, 磐田, 川崎Ｆ, ~, 東京Ｖ, 横浜FC, 横浜FM, 水戸, 福岡, 仙台, 名古屋, ~, 神戸, 鳥栖, 甲府, Ｆ東京, 広島, 新潟]
           bracket_round_start: 1回戦
         '2002':
-          teams: [磐田, 鹿島, 市原, 清水, Ｆ東京, Ｇ大阪, 浦和, 柏]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [磐田, 鹿島, 市原, 清水, Ｆ東京, Ｇ大阪, 浦和, 柏]
           shown_groups: [A, B, C, D]
           group_team_count: 4
           note: 'Wikipedia group labels: A=磐田/柏/仙台/札幌, B=Ｆ東京/清水/東京Ｖ/神戸, C=市原/Ｇ大阪/横浜FM/京都, D=浦和/鹿島/名古屋/広島.'
         '2003':
-          teams: [磐田, 横浜FM, 名古屋, 鹿島, Ｆ東京, 浦和, Ｇ大阪, 清水]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [磐田, 横浜FM, 名古屋, 鹿島, Ｆ東京, 浦和, Ｇ大阪, 清水]
           shown_groups: [A, B, C, D]
           group_team_count:
             A: 4
@@ -835,27 +828,27 @@ jleague:
             D: 3
           note: 'Wikipedia group labels: A=磐田/浦和/東京Ｖ/神戸, B=Ｆ東京/横浜FM/仙台/柏, C=Ｇ大阪/Ｃ大阪/市原, D=名古屋/京都/大分. 鹿島と清水はACL出場のため準々決勝から参加.'
         '2004':
-          teams: [Ｆ東京, Ｇ大阪, 東京Ｖ, 清水, 名古屋, 鹿島, 浦和, 横浜FM]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [Ｆ東京, Ｇ大阪, 東京Ｖ, 清水, 名古屋, 鹿島, 浦和, 横浜FM]
           shown_groups: [A, B, C, D]
           group_team_count: 4
           note: 'Wikipedia group labels: A=東京Ｖ/横浜FM/広島/Ｃ大阪, B=名古屋/Ｇ大阪/新潟/磐田, C=浦和/清水/市原/大分, D=Ｆ東京/鹿島/柏/神戸.'
         '2005':
-          teams: [磐田, 千葉, 浦和, 清水, 横浜FM, 大宮, Ｇ大阪, Ｃ大阪]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [磐田, 千葉, 浦和, 清水, 横浜FM, 大宮, Ｇ大阪, Ｃ大阪]
           shown_groups: [A, B, C, D]
           group_team_count: 4
           note: 公式トーナメント図で順序確認。ACL出場の磐田、横浜FMは準々決勝から参加.
         '2006':
-          teams: [磐田, 横浜FM, Ｇ大阪, 鹿島, 千葉, Ｃ大阪, 川崎Ｆ, 浦和]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [磐田, 横浜FM, Ｇ大阪, 鹿島, 千葉, Ｃ大阪, 川崎Ｆ, 浦和]
           shown_groups: [A, B, C, D]
           group_team_count:
             A: 4
@@ -864,12 +857,12 @@ jleague:
             D: 5
           note: 公式トーナメント図で順序確認。ACL出場のＧ大阪は準々決勝から参加。GS通過はA1=浦和, A2=横浜FM, B1=川崎Ｆ, B2=鹿島, C1=千葉, D1=Ｃ大阪, D2=磐田.
         '2007':
-          teams: [Ｇ大阪, 浦和, 川崎Ｆ, 甲府, Ｆ東京, 横浜FM, 鹿島, 広島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           round_start_options: [__multi_section__]
           bracket_blocks:
           - label: 準々決勝
+            bracket_order: [Ｇ大阪, 浦和, 川崎Ｆ, 甲府, Ｆ東京, 横浜FM, 鹿島, 広島]
             matchup_pairs: true
           - label: 準決勝・決勝
             bracket_order: [川崎Ｆ, 横浜FM, 鹿島, Ｇ大阪]
@@ -878,34 +871,33 @@ jleague:
           group_team_count: 4
           note: 公式トーナメント図で順序確認。ACL出場のＧ大阪、浦和は準々決勝から参加。準決勝は準々決勝後の組み替えに合わせて別セクション化.
         '2008':
-          teams: [大分, Ｆ東京, 名古屋, 千葉, 横浜FM, Ｇ大阪, 清水, 鹿島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [大分, Ｆ東京, 名古屋, 千葉, 横浜FM, Ｇ大阪, 清水, 鹿島]
           shown_groups: [A, B, C, D]
           group_team_count: 4
           note: 公式トーナメント図で順序確認。ACL出場の横浜FM、清水は準々決勝から参加.
         '2009':
-          teams: [名古屋, Ｆ東京, 清水, 浦和, 横浜FM, Ｇ大阪, 川崎Ｆ, 鹿島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [名古屋, Ｆ東京, 清水, 浦和, 横浜FM, Ｇ大阪, 川崎Ｆ, 鹿島]
           shown_groups: [A, B]
           group_team_count: 7
           note: 公式トーナメント図で順序確認。ACL出場の鹿島、川崎Ｆ、Ｇ大阪、名古屋は準々決勝から参加.
         '2010':
-          teams: [川崎Ｆ, 鹿島, 仙台, 磐田, Ｇ大阪, 広島, 清水, Ｆ東京]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [川崎Ｆ, 鹿島, 仙台, 磐田, Ｇ大阪, 広島, 清水, Ｆ東京]
           shown_groups: [A, B]
           group_team_count: 7
           note: 公式トーナメント図で順序確認。ACL出場の鹿島、川崎Ｆ、清水、Ｇ大阪は準々決勝から参加.
         '2011':
-          teams: [Ｃ大阪, 浦和, Ｇ大阪, 磐田, 名古屋, 新潟, 鹿島, 横浜FM]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
@@ -918,45 +910,46 @@ jleague:
           - label: 鹿島ブロック
             bracket_order: [鹿島, ~, ~, ~, 川崎Ｆ, 広島, 神戸, 横浜FM]
           - label: 決勝トーナメント
+            bracket_order: [Ｃ大阪, 浦和, Ｇ大阪, 磐田, 名古屋, 新潟, 鹿島, 横浜FM]
+            inclusive_tree: true
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2011年は純粋KOで、1回戦・2回戦はH&A、準々決勝以降は単試合。途中合流シードを表すため、準々決勝進出決定ブロックと決勝トーナメントを分離している.
         '2012':
-          teams: [名古屋, 清水, Ｆ東京, 仙台, 柏, Ｇ大阪, Ｃ大阪, 鹿島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [名古屋, 清水, Ｆ東京, 仙台, 柏, Ｇ大阪, Ｃ大阪, 鹿島]
           note: 公式トーナメント図で順序確認。準々決勝・準決勝はH&A、決勝は単試合。清水, 仙台, Ｃ大阪, 鹿島はGL上位通過チームのため図中に順位注記あり.
         '2013':
-          teams: [浦和, Ｃ大阪, 仙台, 川崎Ｆ, 横浜FM, 鹿島, 柏, 広島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [浦和, Ｃ大阪, 仙台, 川崎Ｆ, 横浜FM, 鹿島, 柏, 広島]
           note: 公式トーナメント図で順序確認。準々決勝・準決勝はH&A、決勝は単試合.
         '2014':
-          teams: [浦和, 広島, 柏, 横浜FM, 川崎Ｆ, Ｃ大阪, Ｇ大阪, 神戸]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [浦和, 広島, 柏, 横浜FM, 川崎Ｆ, Ｃ大阪, Ｇ大阪, 神戸]
           note: 公式トーナメント図で順序確認。準々決勝・準決勝はH&A、決勝は単試合。浦和, 柏, Ｇ大阪, 神戸は図中にGL順位注記あり.
         '2015':
-          teams: [鹿島, FC東京, 神戸, 柏, 名古屋, Ｇ大阪, 浦和, 新潟]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [鹿島, FC東京, 神戸, 柏, 名古屋, Ｇ大阪, 浦和, 新潟]
           note: 公式トーナメント図で順序確認。2015年もH&Aはアウェイゴール適用。名古屋-Ｇ大阪は2戦合計得点・アウェイゴール数ともに並んだため延長・PK決着。鹿島, 神戸, 名古屋, 新潟は図中にGL順位注記あり.
         '2016':
-          teams: [横浜FM, 大宮, Ｇ大阪, 広島, 浦和, 神戸, 福岡, FC東京]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: 決勝トーナメント
+            bracket_order: [横浜FM, 大宮, Ｇ大阪, 広島, 浦和, 神戸, 福岡, FC東京]
           note: 公式トーナメント図で順序確認。準々決勝・準決勝はH&A、決勝は単試合。横浜FM, 大宮, 神戸, 福岡は図中にGL順位注記あり.
         '2017':
-          teams: [Ｇ大阪, 神戸, 浦和, Ｃ大阪, FC東京, 川崎Ｆ, 鹿島, 仙台]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
@@ -964,10 +957,10 @@ jleague:
             bracket_order: [FC東京, 広島, Ｃ大阪, 札幌]
             matchup_pairs: true
           - label: ノックアウトステージ
+            bracket_order: [Ｇ大阪, 神戸, 浦和, Ｃ大阪, FC東京, 川崎Ｆ, 鹿島, 仙台]
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2017年はプレーオフステージ後にノックアウトステージへ進む構造。準々決勝・準決勝はH&A、決勝は単試合。図中注記はACL=Ｇ大阪/浦和/川崎Ｆ/鹿島, A1=仙台, A2=FC東京, A3=札幌, B1=神戸, B2=Ｃ大阪, B3=広島.
         '2018':
-          teams: [Ｃ大阪, 湘南, 柏, 甲府, 横浜FM, Ｇ大阪, 川崎Ｆ, 鹿島]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
@@ -975,10 +968,10 @@ jleague:
             bracket_order: [仙台, 湘南, 磐田, Ｇ大阪, 浦和, 甲府, 神戸, 横浜FM]
             matchup_pairs: true
           - label: プライムステージ
+            bracket_order: [Ｃ大阪, 湘南, 柏, 甲府, 横浜FM, Ｇ大阪, 川崎Ｆ, 鹿島]
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2018年は4組×4GS後に4ペアのプレーオフステージを実施。準々決勝・準決勝はH&A、決勝は単試合。図中注記はACL=Ｃ大阪/柏/川崎Ｆ/鹿島, A1=仙台, A2=横浜FM, B1=磐田, B2=甲府, C1=浦和, C2=Ｇ大阪, D1=神戸, D2=湘南.
         '2019':
-          teams: [広島, 札幌, FC東京, Ｇ大阪, 鹿島, 浦和, 名古屋, 川崎Ｆ]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
@@ -986,16 +979,16 @@ jleague:
             bracket_order: [札幌, 磐田, 仙台, 名古屋, Ｃ大阪, FC東京, Ｇ大阪, 長崎]
             matchup_pairs: true
           - label: プライムステージ
+            bracket_order: [広島, 札幌, FC東京, Ｇ大阪, 鹿島, 浦和, 名古屋, 川崎Ｆ]
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2019年は4組×4GS後に4ペアのプレーオフステージを実施。準々決勝・準決勝はH&A、決勝は単試合。図中注記はACL=広島/鹿島/川崎Ｆ, A1=札幌, A2=長崎, B1=仙台, B2=FC東京, C1=Ｃ大阪, C2=名古屋, D1=Ｇ大阪, D2=磐田.
         '2020':
-          teams: [札幌, 横浜FM, Ｃ大阪, 柏, 神戸, 川崎Ｆ, FC東京, 名古屋]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: プライムステージ
+            bracket_order: [札幌, 横浜FM, Ｃ大阪, 柏, 神戸, 川崎Ｆ, FC東京, 名古屋]
           note: 公式トーナメント図で順序確認。2020年は短縮開催のためプライムステージの準々決勝・準決勝・決勝をすべて単試合で実施。図中注記はC1=札幌, ACL=横浜FM/神戸/FC東京, B1=Ｃ大阪, D1=柏, A1=川崎Ｆ, A2=名古屋.
         '2021':
-          teams: [FC東京, 札幌, 鹿島, 名古屋, Ｇ大阪, Ｃ大阪, 川崎Ｆ, 浦和]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
@@ -1003,10 +996,10 @@ jleague:
             bracket_order: [鹿島, 清水, FC東京, 湘南, 浦和, 神戸, 横浜FM, 札幌]
             matchup_pairs: true
           - label: プライムステージ
+            bracket_order: [FC東京, 札幌, 鹿島, 名古屋, Ｇ大阪, Ｃ大阪, 川崎Ｆ, 浦和]
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2021年は4組×4GS後に4ペアのプレーオフステージを実施。プライムステージの準々決勝・準決勝はH&A、決勝は単試合。図中注記はA1=鹿島, A2=札幌, B1=FC東京, B2=神戸, C1=浦和, C2=湘南, D1=横浜FM, D2=清水, ACL=名古屋/Ｇ大阪/Ｃ大阪/川崎Ｆ.
         '2022':
-          teams: [浦和, 名古屋, 川崎Ｆ, Ｃ大阪, 横浜FM, 広島, 福岡, 神戸]
           aggregate_tiebreak_order: [away_goals, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
@@ -1014,16 +1007,16 @@ jleague:
             bracket_order: [福岡, 鹿島, 札幌, 広島, 名古屋, 京都, Ｃ大阪, 湘南]
             matchup_pairs: true
           - label: プライムステージ
+            bracket_order: [浦和, 名古屋, 川崎Ｆ, Ｃ大阪, 横浜FM, 広島, 福岡, 神戸]
             bracket_round_start: 準々決勝
           note: 公式トーナメント図で順序確認。2022年は4組×4GS後に4ペアのプレーオフステージを実施。プライムステージの準々決勝・準決勝はH&A、決勝は単試合。図中注記はACL=浦和/川崎Ｆ/横浜FM/神戸, A1=鹿島, A2=Ｃ大阪, B1=広島, B2=名古屋, C1=京都, C2=札幌, D1=湘南, D2=福岡.
         '2023':
-          teams: [鹿島, 名古屋, 福岡, FC東京, 浦和, Ｇ大阪, 横浜FM, 札幌]
           bracket_round_start: 準々決勝
           bracket_blocks:
           - label: プライムステージ
+            bracket_order: [鹿島, 名古屋, 福岡, FC東京, 浦和, Ｇ大阪, 横浜FM, 札幌]
           note: 公式トーナメント図で順序確認。2023年は5組×4GS後にプライムステージの準々決勝・準決勝をH&A、決勝を単試合で実施。図中注記はD2=鹿島, C1=名古屋, D1=福岡, E2=FC東京, B1=浦和, E1=Ｇ大阪, A1=横浜FM, A2=札幌.
         '2024':
-          teams: [新潟, 町田, 川崎Ｆ, 甲府, 名古屋, 広島, 横浜FM, 札幌]
           aggregate_tiebreak_order: [wins, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
@@ -1052,9 +1045,9 @@ jleague:
             matchup_pairs: true
           - label: プライムラウンド
             bracket_order: [広島, 名古屋, 札幌, 横浜FM, 甲府, 川崎Ｆ, 町田, 新潟]
+            inclusive_tree: true
           note: 公式トーナメント図と 2024 entry spec で順序確認。2024年は1stラウンド10ブロック、プレーオフラウンド5ペア、プライムラウンドで構成。H&A 判定は勝利数→得失点差→延長→PK を使用する.
         '2025':
-          teams: [横浜FC, 神戸, 湘南, 広島, 浦和, 川崎Ｆ, 横浜FM, 柏]
           aggregate_tiebreak_order: [wins, penalties]
           bracket_round_start: 準々決勝
           bracket_blocks:
@@ -1077,6 +1070,7 @@ jleague:
             matchup_pairs: true
           - label: プライムラウンド
             bracket_order: [柏, 横浜FM, 川崎Ｆ, 浦和, 広島, 湘南, 神戸, 横浜FC]
+            inclusive_tree: true
           note: 公式トーナメント図で順序確認。2025年は1stラウンド7ブロック、プレーオフラウンド4ペア、プライムラウンドで構成。H&A 判定は勝利数→得失点差→延長→PK。図中注記はACL=横浜FM/川崎Ｆ/神戸, CWC=浦和.
 national:
   display_name: ナショナルチーム
@@ -1124,13 +1118,12 @@ national:
         url: https://www.jfa.jp/national_team/samuraiblue/worldcup_2026/
       seasons:
         '2026':
-          # Anchor shared with the main block so the inclusive full tree (built
-          # from this top-level order) stays a clean 32-team / power-of-two tree.
-          bracket_order: &wc_ko_main [ドイツ, A/B/C/D/F3位, グループI1位, C/D/F/G/H3位, グループA2位, グループB2位, グループF1位, グループC2位, グループK2位, グループL2位, グループH1位, グループJ2位, アメリカ, B/E/F/I/J3位, グループG1位, A/E/H/I/J3位, グループC1位, グループF2位, グループE2位, グループI2位, メキシコ, C/E/F/H/I3位, グループL1位, E/H/I/J/K3位, グループJ1位, グループH2位, グループD2位, グループG2位, グループB1位, E/F/G/I/J3位, グループK1位, D/E/I/J/L3位]
           bracket_blocks:
           - label: 決勝トーナメント
             round_filter: [ラウンド32, ラウンド16, 準々決勝, 準決勝, 決勝戦]
-            bracket_order: *wc_ko_main
+            bracket_order: [ドイツ, A/B/C/D/F3位, グループI1位, C/D/F/G/H3位, グループA2位, グループB2位, グループF1位, グループC2位, グループK2位, グループL2位, グループH1位, グループJ2位, アメリカ, B/E/F/I/J3位, グループG1位, A/E/H/I/J3位, グループC1位, グループF2位, グループE2位, グループI2位, メキシコ, C/E/F/H/I3位, グループL1位, E/H/I/J/K3位, グループJ1位, グループH2位, グループD2位, グループG2位, グループB1位, E/F/G/I/J3位, グループK1位, D/E/I/J/L3位]
+            # Inclusive full-tree order (clean 32-team power-of-two); ３位決定戦 stays a separate block.
+            inclusive_tree: true
           - label: ３位決定戦
             round_filter: [３位決定戦]
             bracket_order: [No.101の敗者, No.102の敗者]
@@ -1451,14 +1444,17 @@ we:
       view_type: [bracket]
       seasons:
         22-23:
-          team_count: 2
-          teams: [浦和, 東京NB]
+          bracket_blocks:
+          - label: 決勝トーナメント
+            bracket_order: [浦和, 東京NB]
           bracket_round_start: 決勝
         23-24:
-          team_count: 2
-          teams: [S広島R, 新潟L]
+          bracket_blocks:
+          - label: 決勝トーナメント
+            bracket_order: [S広島R, 新潟L]
           bracket_round_start: 決勝
         24-25:
-          team_count: 4
-          teams: [S広島R, 浦和, I神戸, 新潟L]
+          bracket_blocks:
+          - label: 決勝トーナメント
+            bracket_order: [S広島R, 浦和, I神戸, 新潟L]
           bracket_round_start: 準決勝

--- a/frontend/src/__tests__/tournament/bracket-view.test.ts
+++ b/frontend/src/__tests__/tournament/bracket-view.test.ts
@@ -47,16 +47,16 @@ describe('bracket-view helpers', () => {
       expect(order).toEqual(['ExplicitA', null, 'ExplicitB']);
     });
 
-    test('falls back to teams when explicit bracket_order is absent', () => {
+    test('ignores teams: tournament order comes from blocks, not the team list', () => {
       const order = __testables.resolveSeasonBracketOrder({
         team_count: 4, promotion_count: 0, relegation_count: 0,
         teams: ['LegacyA', 'LegacyB', 'LegacyC', 'LegacyD'],
       });
 
-      expect(order).toEqual(['LegacyA', 'LegacyB', 'LegacyC', 'LegacyD']);
+      expect(order).toBeUndefined();
     });
 
-    test('derives default global order from bracket_blocks when teams is empty', () => {
+    test('returns undefined for multiple tree blocks without an inclusive_tree marker', () => {
       const order = __testables.resolveSeasonBracketOrder({
         team_count: 4, promotion_count: 0, relegation_count: 0,
         teams: [],
@@ -66,7 +66,7 @@ describe('bracket-view helpers', () => {
         ],
       });
 
-      expect(order).toEqual(['A1', 'A2', 'B1', null, 'B2']);
+      expect(order).toBeUndefined();
     });
 
     test('returns undefined when no source bracket order exists', () => {
@@ -90,18 +90,14 @@ describe('bracket-view helpers', () => {
       expect(order).toEqual(['A', null, 'B', 'C']);
     });
 
-    test('prefers inferred order over derived teams populated later in load flow', () => {
+    test('uses inferred order even when teams is present', () => {
       const inferredOrder = ['A', null, 'B', 'C'];
-      const originalEntry = {
+      const entry = {
         team_count: 4, promotion_count: 0, relegation_count: 0,
-      };
-      const resolvedEntry = {
-        ...originalEntry,
         teams: ['A', 'B', 'C'],
       };
 
-      expect(__testables.resolveSeasonBracketOrder(originalEntry, inferredOrder)).toEqual(inferredOrder);
-      expect(__testables.resolveSeasonBracketOrder(resolvedEntry)).toEqual(['A', 'B', 'C']);
+      expect(__testables.resolveSeasonBracketOrder(entry, inferredOrder)).toEqual(inferredOrder);
     });
 
     test('prefers a sole non-matchup block order over teams', () => {
@@ -169,40 +165,6 @@ describe('bracket-view helpers', () => {
     test('returns undefined for missing or empty block list', () => {
       expect(__testables.resolveMainBlockOrder(undefined)).toBeUndefined();
       expect(blocks([])).toBeUndefined();
-    });
-  });
-
-  describe('resolveSectionBracketOrders', () => {
-    test('fills missing section bracket_order from season teams', () => {
-      const resolved = __testables.resolveSectionBracketOrders(
-        [{ label: '決勝トーナメント' }],
-        ['TeamA', 'TeamB', 'TeamC', 'TeamD'],
-      );
-
-      expect(resolved[0].bracket_order).toEqual(['TeamA', 'TeamB', 'TeamC', 'TeamD']);
-    });
-
-    test('preserves explicit section bracket_order', () => {
-      const resolved = __testables.resolveSectionBracketOrders(
-        [{ label: '決勝トーナメント', bracket_order: ['X', 'Y'] }],
-        ['TeamA', 'TeamB', 'TeamC', 'TeamD'],
-      );
-
-      expect(resolved[0].bracket_order).toEqual(['X', 'Y']);
-    });
-
-    test('fills only sections missing bracket_order and preserves explicit multi-block sections', () => {
-      const resolved = __testables.resolveSectionBracketOrders(
-        [
-          { label: 'プレーオフステージ', bracket_order: ['P1', 'P2'], matchup_pairs: true },
-          { label: 'プライムステージ', bracket_round_start: '準々決勝' },
-        ],
-        ['TeamA', 'TeamB', 'TeamC', 'TeamD'],
-      );
-
-      expect(resolved[0].bracket_order).toEqual(['P1', 'P2']);
-      expect(resolved[1].bracket_order).toEqual(['TeamA', 'TeamB', 'TeamC', 'TeamD']);
-      expect(resolved[1].bracket_round_start).toBe('準々決勝');
     });
   });
 

--- a/frontend/src/__tests__/tournament/bracket-view.test.ts
+++ b/frontend/src/__tests__/tournament/bracket-view.test.ts
@@ -36,15 +36,17 @@ function makeNode(overrides: Partial<BracketNode> = {}): BracketNode {
 
 describe('bracket-view helpers', () => {
   describe('resolveSeasonBracketOrder', () => {
-    test('uses explicit bracket_order with highest priority', () => {
-      const order = __testables.resolveSeasonBracketOrder({
-        team_count: 4, promotion_count: 0, relegation_count: 0,
-        teams: ['LegacyA', 'LegacyB'],
-        bracket_order: ['ExplicitA', null, 'ExplicitB'],
-        bracket_blocks: [{ label: 'S1', bracket_order: ['SectionA', 'SectionB'] }],
-      });
+    test('uses the main block order with highest priority', () => {
+      const order = __testables.resolveSeasonBracketOrder(
+        {
+          team_count: 4, promotion_count: 0, relegation_count: 0,
+          teams: ['LegacyA', 'LegacyB'],
+          bracket_blocks: [{ label: 'S1', bracket_order: ['SectionA', 'SectionB'] }],
+        },
+        ['InferredA', 'InferredB'],
+      );
 
-      expect(order).toEqual(['ExplicitA', null, 'ExplicitB']);
+      expect(order).toEqual(['SectionA', 'SectionB']);
     });
 
     test('ignores teams: tournament order comes from blocks, not the team list', () => {

--- a/frontend/src/__tests__/tournament/bracket-view.test.ts
+++ b/frontend/src/__tests__/tournament/bracket-view.test.ts
@@ -103,6 +103,73 @@ describe('bracket-view helpers', () => {
       expect(__testables.resolveSeasonBracketOrder(originalEntry, inferredOrder)).toEqual(inferredOrder);
       expect(__testables.resolveSeasonBracketOrder(resolvedEntry)).toEqual(['A', 'B', 'C']);
     });
+
+    test('prefers a sole non-matchup block order over teams', () => {
+      const order = __testables.resolveSeasonBracketOrder({
+        teams: ['LegacyA', 'LegacyB'],
+        bracket_blocks: [
+          { label: '決勝トーナメント', bracket_order: ['A', null, 'B', 'C'] },
+        ],
+      });
+
+      expect(order).toEqual(['A', null, 'B', 'C']);
+    });
+
+    test('prefers the inclusive_tree-marked block order over teams and flatMap', () => {
+      const order = __testables.resolveSeasonBracketOrder({
+        teams: ['LegacyA', 'LegacyB'],
+        bracket_blocks: [
+          { label: 'フィーダー', bracket_order: ['F1', 'F2', 'A', 'B'] },
+          { label: '決勝トーナメント', bracket_order: ['A', 'B', 'C', 'D'], inclusive_tree: true },
+        ],
+      });
+
+      expect(order).toEqual(['A', 'B', 'C', 'D']);
+    });
+  });
+
+  describe('resolveMainBlockOrder', () => {
+    const blocks = (list: BracketBlock[]) => __testables.resolveMainBlockOrder(list);
+
+    test('returns the order of a sole block', () => {
+      expect(blocks([{ label: 'S', bracket_order: ['A', 'B'] }])).toEqual(['A', 'B']);
+    });
+
+    test('returns undefined for a sole block without order', () => {
+      expect(blocks([{ label: 'S' }])).toBeUndefined();
+    });
+
+    test('excludes matchup_pairs blocks from main candidacy', () => {
+      expect(blocks([
+        { label: 'プレーオフ', bracket_order: ['P1', 'P2'], matchup_pairs: true },
+        { label: 'プライム', bracket_order: ['A', 'B', 'C', 'D'] },
+      ])).toEqual(['A', 'B', 'C', 'D']);
+    });
+
+    test('returns undefined when multiple candidates lack an inclusive_tree marker', () => {
+      expect(blocks([
+        { label: 'ブロック1', bracket_order: ['A', 'B'] },
+        { label: 'ブロック2', bracket_order: ['C', 'D'] },
+      ])).toBeUndefined();
+    });
+
+    test('returns the inclusive_tree-marked block among multiple candidates', () => {
+      expect(blocks([
+        { label: '決勝トーナメント', bracket_order: ['A', 'B', 'C', 'D'], inclusive_tree: true },
+        { label: '３位決定戦', bracket_order: ['X', 'Y'] },
+      ])).toEqual(['A', 'B', 'C', 'D']);
+    });
+
+    test('returns undefined when only matchup_pairs blocks exist', () => {
+      expect(blocks([
+        { label: '順位決定戦', bracket_order: ['A', 'B', 'C', 'D'], matchup_pairs: true },
+      ])).toBeUndefined();
+    });
+
+    test('returns undefined for missing or empty block list', () => {
+      expect(__testables.resolveMainBlockOrder(undefined)).toBeUndefined();
+      expect(blocks([])).toBeUndefined();
+    });
   });
 
   describe('resolveSectionBracketOrders', () => {

--- a/frontend/src/bracket-view.ts
+++ b/frontend/src/bracket-view.ts
@@ -266,22 +266,11 @@ function resolveSeasonBracketOrder(
   entry: RawSeasonEntry,
   inferredOrder?: (string | null)[],
 ): (string | null)[] | undefined {
-  const explicitOrder = entry.bracket_order;
-  if (explicitOrder != null && explicitOrder.length > 0) {
-    return explicitOrder;
-  }
-
-  const mainBlockOrder = resolveMainBlockOrder(entry.bracket_blocks);
-  if (mainBlockOrder != null) {
-    return mainBlockOrder;
-  }
-
-  return inferredOrder;
+  return resolveMainBlockOrder(entry.bracket_blocks) ?? inferredOrder;
 }
 
 function hasBracketMetadata(entry: RawSeasonEntry): boolean {
-  return entry.bracket_order != null
-    || entry.bracket_blocks != null
+  return entry.bracket_blocks != null
     || entry.bracket_round_start != null;
 }
 

--- a/frontend/src/bracket-view.ts
+++ b/frontend/src/bracket-view.ts
@@ -25,7 +25,7 @@ import {
   syncSliderToTargetDate,
 } from './core/date-slider';
 import { buildBracket, maskBracketForDate } from './bracket/bracket-data';
-import { extractTeamsFromBracketOrder, inferBracketOrderFromRows } from './bracket/bracket-order-inference';
+import { inferBracketOrderFromRows } from './bracket/bracket-order-inference';
 import { normalizeBracketRoundLabel } from './bracket/round-label';
 import { inferRoundFilter } from './bracket/round-filter-inference';
 import { renderBracketInto, unpinTooltip } from './bracket/bracket-renderer';
@@ -276,34 +276,12 @@ function resolveSeasonBracketOrder(
     return mainBlockOrder;
   }
 
-  const legacyOrder = entry.teams;
-  if (legacyOrder != null && legacyOrder.length > 0) {
-    return legacyOrder;
-  }
-
-  const sectionOrder = entry.bracket_blocks?.flatMap((section) => section.bracket_order ?? []);
-  if (sectionOrder != null && sectionOrder.length > 0) {
-    return sectionOrder;
-  }
-
   return inferredOrder;
-}
-
-function resolveSectionBracketOrders(
-  sections: BracketBlock[],
-  seasonTeams: string[],
-): BracketBlock[] {
-  return sections.map((section) => (
-    section.bracket_order && section.bracket_order.length > 0
-      ? section
-      : { ...section, bracket_order: seasonTeams }
-  ));
 }
 
 function hasBracketMetadata(entry: RawSeasonEntry): boolean {
   return entry.bracket_order != null
     || entry.bracket_blocks != null
-    || (entry.teams?.length ?? 0) > 0
     || entry.bracket_round_start != null;
 }
 
@@ -436,7 +414,6 @@ export const __testables = {
   createControlStateFromPrefs,
   resolveMainBlockOrder,
   resolveSeasonBracketOrder,
-  resolveSectionBracketOrders,
   filterRowsByRounds,
   resolveSectionRoundFilters,
   inferMissingSectionRoundFilters,
@@ -810,26 +787,17 @@ function loadAndRender(seasonMap: SeasonMap): void {
     download: true,
     complete: (results) => {
       const inferredOrder = inferBracketOrderFromRows(results.data);
-      const seasonTeams = entry.teams && entry.teams.length > 0
-        ? entry.teams
-        : (inferredOrder ? extractTeamsFromBracketOrder(inferredOrder) : []);
-      const rawSections = entry.bracket_blocks
-        ? resolveSectionBracketOrders(entry.bracket_blocks, seasonTeams)
-        : undefined;
-      const resolvedEntry = {
-        ...entry,
-        teams: seasonTeams,
-        team_count: entry.team_count ?? (seasonTeams.length > 0 ? seasonTeams.length : undefined),
-        bracket_blocks: rawSections,
-      };
+      const rawSections = entry.bracket_blocks;
       const tournamentSeasonInfo = resolveTournamentSeasonInfo(
-        found.family, found.competition, resolvedEntry, found.familyKey,
+        found.family, found.competition, entry, found.familyKey,
       );
-      const bracketOrder = resolveSeasonBracketOrder(entry, inferredOrder);
-      if (!bracketOrder || bracketOrder.length === 0) {
+      const seasonOrder = resolveSeasonBracketOrder(entry, inferredOrder);
+      const hasInclusiveTree = seasonOrder != null && seasonOrder.length > 0;
+      if (!hasInclusiveTree && !(rawSections && rawSections.length > 0)) {
         setStatus('No bracket data for this season.');
         return;
       }
+      const bracketOrder = seasonOrder ?? [];
       const resolved = rawSections
         ? resolveSectionRoundFilters(rawSections, entry.default_round_filter)
         : undefined;
@@ -840,13 +808,14 @@ function loadAndRender(seasonMap: SeasonMap): void {
       const matchDates = collectMatchDates(bracketRows);
 
       // Build full tree to extract round structure and pre-populate cache.
-      // Multi-section-only competitions (e.g. matchup pairs across disjoint
-      // ties, which form no single power-of-two tree) have no inclusive tree,
-      // so skip the inclusive build — renderMultiSections builds each block's
-      // tree independently.
-      const multiSectionOnly =
+      // Multi-section-only competitions (matchup pairs across disjoint ties,
+      // or multiple tree blocks with no inclusive_tree main block) have no
+      // inclusive tree, so skip the inclusive build — renderMultiSections
+      // builds each block's tree independently.
+      const multiSectionOnly = !hasInclusiveTree || (
         tournamentSeasonInfo.roundStartOptions?.length === 1 &&
-        tournamentSeasonInfo.roundStartOptions[0] === MULTI_SECTION_VALUE;
+        tournamentSeasonInfo.roundStartOptions[0] === MULTI_SECTION_VALUE
+      );
       const fullRoot = multiSectionOnly
         ? EMPTY_BRACKET_ROOT
         : buildBracket(
@@ -855,7 +824,11 @@ function loadAndRender(seasonMap: SeasonMap): void {
           tournamentSeasonInfo.aggregateTiebreakOrder,
         );
       bracketCache = new Map();
-      bracketCache.set(JSON.stringify(bracketOrder), fullRoot);
+      // Don't cache the placeholder root: a section sharing the same order as
+      // the season order (e.g. the main block itself) must build its own tree.
+      if (!multiSectionOnly) {
+        bracketCache.set(JSON.stringify(bracketOrder), fullRoot);
+      }
       const roundsByDepth = collectRoundsByDepth(fullRoot);
       const bracketRounds = collectBracketRounds(fullRoot);
       const allRounds = bracketBlocks

--- a/frontend/src/bracket-view.ts
+++ b/frontend/src/bracket-view.ts
@@ -243,6 +243,25 @@ function collectMatchDates(rows: RawMatchRow[]): string[] {
   return sorted;
 }
 
+/**
+ * Resolve the season-wide inclusive tree order from bracket_blocks: the
+ * bracket_order of the "main" block (the tree that crowns the champion).
+ * Matchup-pairs blocks form no tree and are never main. A sole non-matchup
+ * block is implicitly main; among several, `inclusive_tree: true` marks it.
+ * Returns undefined when no main block resolves (multi-section-only seasons).
+ */
+function resolveMainBlockOrder(
+  blocks: BracketBlock[] | undefined,
+): (string | null)[] | undefined {
+  if (!blocks || blocks.length === 0) return undefined;
+  const candidates = blocks.filter((block) => !block.matchup_pairs);
+  const main = candidates.length === 1
+    ? candidates[0]
+    : candidates.find((block) => block.inclusive_tree);
+  const order = main?.bracket_order;
+  return order != null && order.length > 0 ? order : undefined;
+}
+
 function resolveSeasonBracketOrder(
   entry: RawSeasonEntry,
   inferredOrder?: (string | null)[],
@@ -250,6 +269,11 @@ function resolveSeasonBracketOrder(
   const explicitOrder = entry.bracket_order;
   if (explicitOrder != null && explicitOrder.length > 0) {
     return explicitOrder;
+  }
+
+  const mainBlockOrder = resolveMainBlockOrder(entry.bracket_blocks);
+  if (mainBlockOrder != null) {
+    return mainBlockOrder;
   }
 
   const legacyOrder = entry.teams;
@@ -410,6 +434,7 @@ function collectRoundsFromCsv(rows: RawMatchRow[]): string[] {
 
 export const __testables = {
   createControlStateFromPrefs,
+  resolveMainBlockOrder,
   resolveSeasonBracketOrder,
   resolveSectionBracketOrders,
   filterRowsByRounds,

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -84,7 +84,6 @@ export interface SeasonEntryOptions {
   data_source?: DataSource;
   promotion_label?: string;
   aggregate_tiebreak_order?: AggregateTiebreakCriterion[];
-  bracket_order?: (string | null)[];
   bracket_round_start?: string;
   round_start_options?: string[];
   default_round_filter?: string[];

--- a/frontend/src/types/season.ts
+++ b/frontend/src/types/season.ts
@@ -50,6 +50,10 @@ export interface BracketBlock {
   bracket_round_start?: string;     // Override start round for this section
   matchup_pairs?: boolean;          // Render as independent matchup pairs (no elimination tree)
   bracket_pairing_orders?: number[][]; // Per level reorder of child matches before pairing
+  // Marks the block whose bracket_order is the season-wide inclusive tree order.
+  // Needed only when multiple non-matchup blocks exist (e.g. feeder blocks +
+  // final tournament); a sole non-matchup block is implicitly the main tree.
+  inclusive_tree?: boolean;
 }
 
 // Optional properties that can appear at family, competition, or season level.

--- a/scripts/check_type_sync.py
+++ b/scripts/check_type_sync.py
@@ -171,7 +171,7 @@ def check_point_system_values() -> list[str]:
 
 
 def check_view_type_consistency() -> list[str]:
-    """Check that bracket_order entries have view_type including 'bracket'."""
+    """Check that bracket_blocks entries have view_type including 'bracket'."""
     import yaml
     errors: list[str] = []
     season_map_path = PROJECT_ROOT / 'docs' / 'yaml' / 'season_map.yaml'
@@ -192,11 +192,11 @@ def check_view_type_consistency() -> list[str]:
                 resolved_vt = comp_vt | set(entry.get('view_type', []))
                 if not resolved_vt:
                     resolved_vt = {'league'}
-                has_bracket = entry.get('bracket_order') or entry.get('bracket_blocks')
+                has_bracket = entry.get('bracket_blocks')
                 if has_bracket and 'bracket' not in resolved_vt:
                     errors.append(
                         f"{family_key}/{comp_key}/{season_key}: "
-                        f"bracket_order exists but view_type {sorted(resolved_vt)} "
+                        f"bracket_blocks exists but view_type {sorted(resolved_vt)} "
                         f"does not include 'bracket'")
     return errors
 

--- a/src/match_utils.py
+++ b/src/match_utils.py
@@ -130,11 +130,19 @@ class SeasonEntry:
         'group_team_count', 'max_row_teams',
         'note', 'data_source', 'promotion_label',
         'aggregate_tiebreak_order',
-        'bracket_order', 'bracket_round_start', 'round_start_options',
+        'bracket_round_start', 'round_start_options',
         'default_round_filter', 'bracket_blocks',
         'bracket_pairing_orders',
         'view_type',
         'timezone',
+    }
+
+    # Keys allowed inside a bracket_blocks item. The block-level bracket_order
+    # is the single source of tournament structure (entry-level bracket_order
+    # and teams are not used for tournaments).
+    BRACKET_BLOCK_KEYS: set[str] = {
+        'label', 'bracket_order', 'round_filter', 'bracket_round_start',
+        'matchup_pairs', 'bracket_pairing_orders', 'inclusive_tree',
     }
 
     KNOWN_KEYS: set[str] = REQUIRED_KEYS | COMPETITION_DEFAULTABLE_KEYS | OPTIONAL_KEYS
@@ -245,6 +253,48 @@ class SeasonEntry:
         ps = self.options.get('point_system')
         if ps is not None and ps not in POINT_SYSTEM_VALUES:
             logger.warning("Season '%s': unknown point_system: '%s'", season_key, ps)
+
+        if teams and view_types == ['bracket']:
+            logger.warning(
+                "Season '%s': teams is derived for tournament seasons; "
+                "write the order into bracket_blocks instead", season_key)
+        self._validate_bracket_blocks(season_key, self.options.get('bracket_blocks'))
+
+    def _validate_bracket_blocks(self, season_key: str, blocks: Any) -> None:
+        """Validate bracket_blocks structure and inclusive_tree consistency.
+
+        Raises:
+            TypeError: If blocks is not a list of dicts with a str label.
+        """
+        if blocks is None:
+            return
+        if not isinstance(blocks, list):
+            raise TypeError(
+                f"Season '{season_key}': bracket_blocks must be list, "
+                f"got {type(blocks).__name__}")
+        marked = 0
+        for i, block in enumerate(blocks):
+            if not isinstance(block, dict) or not isinstance(block.get('label'), str):
+                raise TypeError(
+                    f"Season '{season_key}': bracket_blocks[{i}] must be "
+                    f"a dict with a str 'label'")
+            unknown = set(block.keys()) - self.BRACKET_BLOCK_KEYS
+            if unknown:
+                logger.warning(
+                    "Season '%s': bracket_blocks[%d] (%s): unknown keys: %s",
+                    season_key, i, block['label'], unknown)
+            if block.get('inclusive_tree'):
+                if block.get('matchup_pairs'):
+                    logger.warning(
+                        "Season '%s': bracket_blocks[%d] (%s): inclusive_tree "
+                        "on a matchup_pairs block has no effect",
+                        season_key, i, block['label'])
+                else:
+                    marked += 1
+        if marked > 1:
+            logger.warning(
+                "Season '%s': multiple bracket_blocks marked inclusive_tree; "
+                "only one main tree block is allowed", season_key)
 
 
 class MatchUtils:

--- a/tests/test_match_utils.py
+++ b/tests/test_match_utils.py
@@ -1,4 +1,7 @@
+import logging
+
 import pandas as pd
+import pytest
 
 from match_utils import assign_bracket_section_no, normalize_round_label
 
@@ -93,3 +96,80 @@ def test_assign_bracket_section_no_recalculates_single_leg_round_order():
 
     assert actual['section_no'].tolist() == [-3, -3, -2, -1]
     assert actual['match_index_in_section'].tolist() == [2, 1, 1, 1]
+
+
+# ---- SeasonEntry bracket_blocks validation ---------------------------------
+
+def _bracket_entry(options):
+    from match_utils import SeasonEntry
+    return SeasonEntry('2026', options, competition_view_types=['bracket'])
+
+
+def test_season_entry_warns_on_teams_for_tournament_season(caplog):
+    with caplog.at_level(logging.WARNING, logger='match_utils'):
+        _bracket_entry({'teams': ['A', 'B']})
+    assert 'teams is derived for tournament seasons' in caplog.text
+
+
+def test_season_entry_allows_teams_for_league_season(caplog):
+    from match_utils import SeasonEntry
+    with caplog.at_level(logging.WARNING, logger='match_utils'):
+        SeasonEntry(
+            '2026',
+            {'team_count': 2, 'promotion_count': 0, 'relegation_count': 0,
+             'teams': ['A', 'B']},
+            competition_view_types=['league'])
+    assert caplog.text == ''
+
+
+def test_season_entry_warns_on_entry_level_bracket_order(caplog):
+    with caplog.at_level(logging.WARNING, logger='match_utils'):
+        _bracket_entry({'bracket_order': ['A', 'B']})
+    assert 'unknown option keys' in caplog.text
+
+
+def test_season_entry_warns_on_unknown_bracket_block_key(caplog):
+    with caplog.at_level(logging.WARNING, logger='match_utils'):
+        _bracket_entry({'bracket_blocks': [
+            {'label': '決勝トーナメント', 'bracket_order': ['A', 'B'], 'typo_key': 1},
+        ]})
+    assert 'unknown keys' in caplog.text
+    assert 'typo_key' in caplog.text
+
+
+def test_season_entry_warns_on_inclusive_tree_with_matchup_pairs(caplog):
+    with caplog.at_level(logging.WARNING, logger='match_utils'):
+        _bracket_entry({'bracket_blocks': [
+            {'label': 'ペア', 'bracket_order': ['A', 'B'],
+             'matchup_pairs': True, 'inclusive_tree': True},
+        ]})
+    assert 'has no effect' in caplog.text
+
+
+def test_season_entry_warns_on_multiple_inclusive_tree_blocks(caplog):
+    with caplog.at_level(logging.WARNING, logger='match_utils'):
+        _bracket_entry({'bracket_blocks': [
+            {'label': 'ブロック1', 'bracket_order': ['A', 'B'], 'inclusive_tree': True},
+            {'label': 'ブロック2', 'bracket_order': ['C', 'D'], 'inclusive_tree': True},
+        ]})
+    assert 'multiple bracket_blocks marked inclusive_tree' in caplog.text
+
+
+def test_season_entry_accepts_valid_bracket_blocks(caplog):
+    with caplog.at_level(logging.WARNING, logger='match_utils'):
+        _bracket_entry({'bracket_blocks': [
+            {'label': 'フィーダー', 'bracket_order': ['A', 'B']},
+            {'label': '決勝トーナメント', 'bracket_order': ['A', 'C'],
+             'inclusive_tree': True},
+        ]})
+    assert caplog.text == ''
+
+
+def test_season_entry_rejects_non_list_bracket_blocks():
+    with pytest.raises(TypeError, match='bracket_blocks must be list'):
+        _bracket_entry({'bracket_blocks': {'label': 'X'}})
+
+
+def test_season_entry_rejects_block_without_label():
+    with pytest.raises(TypeError, match="dict with a str 'label'"):
+        _bracket_entry({'bracket_blocks': [{'bracket_order': ['A', 'B']}]})


### PR DESCRIPTION
Fixes #287

## Summary

- Tournament シーズンの season_map 設定の正本を `bracket_blocks` に一本化 (エントリレベル `bracket_order` と tournament `teams` によるブラケット順指定を廃止)
- 包括ツリー (単一ツリー表示) の主 block は「非 matchup block が単独ならそれ、複数なら新設の `inclusive_tree: true` マーカーの block」で解決。主 block がないシーズン (J1PO/J2J3PO 等) は multi-section 表示に自動フォールバック
- season_map.yaml の 39 エントリを移行 (JLeagueCup 1992〜2025 / WC_KO 2026 / WE_Cup_KO / J1PO / J2J3PO)。公式図検証済みの順序は一字一句そのまま block 側へ移動
- Python 側に `bracket_blocks` スキーマ検証 (label 必須・未知キー警告・`inclusive_tree` 重複/矛盾警告) と bracket 専用シーズンでの `teams` 明記警告を追加
- EmperorsCup 型の CSV 完全推定シーズンは従来どおり authored 構造なしのまま

補足: JLeagueCup 2024/2025 の包括ツリーの葉配置は従来の `teams` ミラー順から公式トーナメント図順に変わります (対戦カードは同一、公式図に揃う改善方向の変化)。

## Changes

| Commit | Description |
| ------ | ----------- |
| `04ab332` | `inclusive_tree` マーカーと主 block 解決 (`resolveMainBlockOrder`) を additive に追加 |
| `79ea109` | season_map.yaml 移行 (39 エントリ、`teams`/エントリレベル `bracket_order` を block 側へ) |
| `c1301f8` | `teams`/flatMap フォールバック削除、主 block なしシーズンの multi-section 自動フォールバック |
| `8136fb0` | エントリレベル `bracket_order` を型から削除 (Python→TS 型同期)、block スキーマ検証追加 |
| `a269f7e` | CLAUDE.md に設計決定を記録 |

## Test plan

- [x] `uv run pytest` passed (133、うち新規 9)
- [x] `npx vitest run` passed (575) (frontend/)
- [x] `npm run typecheck` passed (frontend/)
- [x] `npm run build` succeeded (frontend/)
- [x] `uv run python scripts/check_type_sync.py` / `check_point_system_csv.py` passed
- [x] E2E: 標準 86 + full-render 270 全通過。移行対象 9 シーズン (JLeagueCup 1994/1999/2007/2011/2017/2024, WE_Cup_KO 24-25, J1PO/J2J3PO 2026) の描画をスクリーンショットで目視確認

Generated with Claude Fable 5