### PR TITLE
Keep bracket-local dates out of the shared viewer target date

### DIFF
--- a/frontend/e2e/unified-viewer.spec.ts
+++ b/frontend/e2e/unified-viewer.spec.ts
@@ -57,4 +57,48 @@ test.describe('Unified league and bracket viewer', () => {
     expect(prefs.scale).toBe('0.6');
     expect(prefs.futureOpacity).toBe('0.3');
   });
+
+  // #298: the bracket view used to write values the user never picked into the
+  // shared target date, which League then displayed (and persisted).
+  test('bracket view does not pin the shared target date to its own last match day', async ({ page }) => {
+    const today = await page.evaluate(() => {
+      const d = new Date();
+      const pad = (n: number): string => String(n).padStart(2, '0');
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+    });
+
+    await page.selectOption('#competition_key', 'JLeagueCup');
+    await waitForBracketRender(page);
+
+    await page.selectOption('#competition_key', 'J1');
+    await waitForRender(page);
+
+    // The user picked no date, so League falls back to today. Before the fix
+    // the bracket had filled the shared date with the cup's final match day
+    // and League opened on that instead.
+    await expect(page.locator('#target_date')).toHaveValue(today);
+  });
+
+  test('bracket preseason slider position does not leak into the shared target date', async ({ page }) => {
+    await page.locator('#target_date').fill('2024-05-03');
+    await page.locator('#target_date').dispatchEvent('change');
+    await waitForRender(page);
+
+    await page.selectOption('#competition_key', 'JLeagueCup');
+    await waitForBracketRender(page);
+
+    await page.locator('#bracket_date_slider').fill('0');
+    await page.locator('#bracket_date_slider').dispatchEvent('change');
+    await expect(page.locator('#bracket_post_date_slider')).not.toHaveText('');
+
+    const prefs = await page.evaluate(() => JSON.parse(
+      localStorage.getItem('jleague_viewer_prefs') ?? '{}',
+    ) as Record<string, string>);
+    expect(prefs.targetDate).toBe('2024/05/03');
+
+    // Returning to League must not show a preseason (all-future) board.
+    await page.selectOption('#competition_key', 'J1');
+    await waitForRender(page);
+    await expect(page.locator('#target_date')).toHaveValue('2024-05-03');
+  });
 });

--- a/frontend/src/__tests__/tournament/bracket-view.test.ts
+++ b/frontend/src/__tests__/tournament/bracket-view.test.ts
@@ -207,6 +207,40 @@ describe('bracket-view helpers', () => {
     });
   });
 
+  describe('shared target date boundary (#298)', () => {
+    // matchDates always starts with the preseason sentinel (collectMatchDates
+    // prepends it), so index 0 is the "before any match" slider position.
+    const matchDates = ['1970/01/01', '2025/03/15', '2025/03/22', '2025/03/29'];
+
+    test('preseason position never writes to the shared target date', () => {
+      const selection = __testables.resolveSliderSelection(matchDates, 0);
+
+      expect(selection.preseason).toBe(true);
+      expect(selection.writesShared).toBe(false);
+    });
+
+    test('a real match date is written to the shared target date', () => {
+      const selection = __testables.resolveSliderSelection(matchDates, 2);
+
+      expect(selection.preseason).toBe(false);
+      expect(selection.writesShared).toBe(true);
+      expect(selection.targetDate).toBe('2025/03/22');
+    });
+
+    test('leaving the preseason position clears the flag', () => {
+      expect(__testables.resolveSliderSelection(matchDates, 1).preseason).toBe(false);
+    });
+
+    test('preseason renders at the sentinel without the shared date holding it', () => {
+      expect(__testables.effectiveTargetDate(true, null)).toBe('1970/01/01');
+      expect(__testables.effectiveTargetDate(true, '2025/03/22')).toBe('1970/01/01');
+    });
+
+    test('a null shared date stays null, so resolveTargetDate can fall back to latest', () => {
+      expect(__testables.effectiveTargetDate(false, null)).toBeNull();
+    });
+  });
+
   test('filterRowsByRounds matches both raw and normalized round labels', () => {
     const rows = [
       makeRow({ round: '準決勝 第1戦' }),

--- a/frontend/src/__tests__/tournament/bracket-view.test.ts
+++ b/frontend/src/__tests__/tournament/bracket-view.test.ts
@@ -187,6 +187,7 @@ describe('bracket-view helpers', () => {
       expect(state.bracket).toEqual({
         layout: 'horizontal',
         roundStart: '準決勝',
+        preseason: false,
       });
     });
 
@@ -201,6 +202,7 @@ describe('bracket-view helpers', () => {
       expect(state.bracket).toEqual({
         layout: 'horizontal',
         roundStart: null,
+        preseason: false,
       });
     });
   });

--- a/frontend/src/__tests__/view-bootstrap.test.ts
+++ b/frontend/src/__tests__/view-bootstrap.test.ts
@@ -3,6 +3,7 @@ import {
   clampToSlider,
   createSharedViewerControlState,
   normalizeTargetDate,
+  restoreTargetDate,
   toInputDate,
 } from '../view-bootstrap';
 
@@ -23,6 +24,24 @@ describe('viewer preference normalization', () => {
   it('migrates a legacy saved targetDate when creating shared state', () => {
     expect(createSharedViewerControlState({ targetDate: '2026-06-28' }).targetDate)
       .toBe('2026/06/28');
+  });
+});
+
+describe('restoreTargetDate', () => {
+  it('keeps a real user-chosen date', () => {
+    expect(restoreTargetDate('2026/06/28')).toBe('2026/06/28');
+  });
+
+  it.each(['1970/01/01', '1970-01-01'])(
+    'drops the preseason sentinel %s left by older builds',
+    (saved) => {
+      expect(restoreTargetDate(saved)).toBeNull();
+    },
+  );
+
+  it('drops a persisted sentinel when creating shared state', () => {
+    expect(createSharedViewerControlState({ targetDate: '1970/01/01' }).targetDate)
+      .toBeNull();
   });
 });
 

--- a/frontend/src/bracket-view.ts
+++ b/frontend/src/bracket-view.ts
@@ -409,6 +409,8 @@ function collectRoundsFromCsv(rows: RawMatchRow[]): string[] {
 
 export const __testables = {
   createControlStateFromPrefs,
+  effectiveTargetDate,
+  resolveSliderSelection,
   resolveMainBlockOrder,
   resolveSeasonBracketOrder,
   filterRowsByRounds,
@@ -528,13 +530,15 @@ function resolveInclusiveBracketOrder(
 // ---- Bracket rendering with date filter ------------------------------------
 
 /**
- * Effective date this view renders at. `preseason` is bracket-local, so it is
- * folded in here rather than being written back into the shared target date.
+ * Effective date this view renders at, folding in the bracket-local preseason
+ * flag. Pure so the shared-state boundary stays testable.
  */
+function effectiveTargetDate(preseason: boolean, targetDate: string | null): string | null {
+  return preseason ? PRESEASON_SENTINEL : targetDate;
+}
+
 function getTargetDate(): string | null {
-  return controlState.bracket.preseason
-    ? PRESEASON_SENTINEL
-    : controlState.viewer.targetDate;
+  return effectiveTargetDate(controlState.bracket.preseason, controlState.viewer.targetDate);
 }
 
 /** Check whether the selection should render bracket sections independently. */
@@ -701,20 +705,32 @@ function renderWithDateFilter(): void {
 }
 
 /**
- * Sync the target date from the slider position.
- * The preseason position stays bracket-local: it must not reach the shared
- * target date, which League also reads (#298).
+ * Decide what a slider position means for bracket-local and shared state.
+ *
+ * `writesShared: false` is the important case: the preseason position must
+ * leave the shared target date untouched, because League reads it too and a
+ * 1970 sentinel there reads as "before the season started" (#298).
  */
+function resolveSliderSelection(
+  matchDates: string[],
+  sliderIndex: number,
+): { preseason: boolean; writesShared: boolean; targetDate: string | null } {
+  const date = getSliderDate(matchDates, sliderIndex);
+  if (date === PRESEASON_SENTINEL) {
+    return { preseason: true, writesShared: false, targetDate: null };
+  }
+  return { preseason: false, writesShared: true, targetDate: date };
+}
+
+/** Sync the target date from the slider position. */
 function syncTargetDateFromSlider(): void {
   if (!currentState) return;
   const slider = refs.dateSlider;
-  const date = getSliderDate(currentState.matchDates, parseInt(slider.value, 10));
-  if (date === PRESEASON_SENTINEL) {
-    controlState.bracket.preseason = true;
-    return;
-  }
-  controlState.bracket.preseason = false;
-  controlState.viewer.targetDate = date;
+  const selection = resolveSliderSelection(
+    currentState.matchDates, parseInt(slider.value, 10),
+  );
+  controlState.bracket.preseason = selection.preseason;
+  if (selection.writesShared) controlState.viewer.targetDate = selection.targetDate;
 }
 
 /** Align slider position to the kept target date without overwriting the target itself. */

--- a/frontend/src/bracket-view.ts
+++ b/frontend/src/bracket-view.ts
@@ -19,7 +19,6 @@ import {
 import {
   PRESEASON_SENTINEL,
   formatSliderDate,
-  getLastMatchDate,
   getSliderDate,
   resolveTargetDate,
   syncSliderToTargetDate,
@@ -55,6 +54,13 @@ type ViewerControlState = SharedViewerControlState;
 interface BracketControlState {
   layout: 'horizontal' | 'vertical';
   roundStart: string | null;
+  /**
+   * Slider parked on the "before any match" position. Kept here rather than in
+   * `viewer.targetDate` because the sentinel date is a bracket-only display
+   * concept — writing it to the shared state would pin League to a preseason
+   * view too, and persist that. Deliberately not persisted (see #298).
+   */
+  preseason: boolean;
 }
 
 interface ControlState {
@@ -93,6 +99,7 @@ let controlState: ControlState = {
   bracket: {
     layout: 'horizontal',
     roundStart: null,
+    preseason: false,
   },
 };
 
@@ -105,6 +112,7 @@ function createControlStateFromPrefs(
     bracket: {
       layout: 'horizontal',
       roundStart: prefs.roundStart ?? null,
+      preseason: false,
     },
   };
 }
@@ -519,8 +527,14 @@ function resolveInclusiveBracketOrder(
 
 // ---- Bracket rendering with date filter ------------------------------------
 
+/**
+ * Effective date this view renders at. `preseason` is bracket-local, so it is
+ * folded in here rather than being written back into the shared target date.
+ */
 function getTargetDate(): string | null {
-  return controlState.viewer.targetDate;
+  return controlState.bracket.preseason
+    ? PRESEASON_SENTINEL
+    : controlState.viewer.targetDate;
 }
 
 /** Check whether the selection should render bracket sections independently. */
@@ -686,18 +700,28 @@ function renderWithDateFilter(): void {
 
 }
 
-/** Sync viewer control targetDate from slider position. */
+/**
+ * Sync the target date from the slider position.
+ * The preseason position stays bracket-local: it must not reach the shared
+ * target date, which League also reads (#298).
+ */
 function syncTargetDateFromSlider(): void {
   if (!currentState) return;
   const slider = refs.dateSlider;
-  controlState.viewer.targetDate = getSliderDate(currentState.matchDates, parseInt(slider.value, 10));
+  const date = getSliderDate(currentState.matchDates, parseInt(slider.value, 10));
+  if (date === PRESEASON_SENTINEL) {
+    controlState.bracket.preseason = true;
+    return;
+  }
+  controlState.bracket.preseason = false;
+  controlState.viewer.targetDate = date;
 }
 
 /** Align slider position to the kept target date without overwriting the target itself. */
 function syncSliderFromTargetDate(): void {
   if (!currentState) return;
   const slider = refs.dateSlider;
-  syncSliderToTargetDate(slider, currentState.matchDates, controlState.viewer.targetDate);
+  syncSliderToTargetDate(slider, currentState.matchDates, getTargetDate());
 }
 
 /** Update display label from current slider position + kept target date. */
@@ -706,7 +730,7 @@ function updateSliderDisplay(): void {
   const slider = refs.dateSlider;
   const display = refs.postDateSlider;
   const sliderDate = getSliderDate(currentState.matchDates, parseInt(slider.value, 10)) ?? '';
-  const targetDate = resolveTargetDate(currentState.matchDates, controlState.viewer.targetDate) ?? sliderDate;
+  const targetDate = resolveTargetDate(currentState.matchDates, getTargetDate()) ?? sliderDate;
   display.textContent = formatSliderDate(sliderDate, targetDate);
 }
 
@@ -863,9 +887,9 @@ function loadAndRender(seasonMap: SeasonMap): void {
       const slider = refs.dateSlider;
       if (matchDates.length > 0) {
         slider.min = '0';
-        if (!controlState.viewer.targetDate) {
-          controlState.viewer.targetDate = getLastMatchDate(matchDates);
-        }
+        // No target date means "latest"; resolveTargetDate() already falls back
+        // to the last match date for the slider, the label and the render mask,
+        // so there is nothing to write into the shared state here (#298).
         syncSliderFromTargetDate();
       }
 
@@ -942,7 +966,10 @@ export function initBracketView(
   });
   refs.dateSliderReset.addEventListener('click', () => {
     if (!currentState) return;
-    controlState.viewer.targetDate = getLastMatchDate(currentState.matchDates);
+    // null is the canonical "show latest"; writing the last match date would
+    // pin League to this competition's end date on the next view switch.
+    controlState.bracket.preseason = false;
+    controlState.viewer.targetDate = null;
     syncSliderFromTargetDate();
     updateSliderDisplay();
     renderWithDateFilter();
@@ -976,6 +1003,8 @@ export function initBracketView(
   return {
     activate(seasonMap, selection) {
       activeSelection = selection;
+      // Preseason is a transient slider position, not a restored preference.
+      controlState.bracket.preseason = false;
       refs.competition.value = selection.competition;
       refs.season.value = selection.season;
       refs.futureOpacity.value = String(controlState.viewer.futureOpacity);

--- a/frontend/src/league-view.ts
+++ b/frontend/src/league-view.ts
@@ -219,7 +219,6 @@ interface LeagueViewRefs {
 }
 
 let refs: LeagueViewRefs;
-let viewContext: LeagueViewContext;
 
 function requireElement<T extends HTMLElement>(id: string): T {
   const element = document.getElementById(id);
@@ -589,7 +588,7 @@ function loadAndRender(): void {
   const { competition, season } = activeSelection;
   const csvKey      = `${competition}/${season}`;
 
-  const targetDate = normalizeTargetDate(viewContext.shared.targetDate) ?? dateFormat(new Date(), '/');
+  const targetDate = normalizeTargetDate(controlState.viewer.targetDate) ?? dateFormat(new Date(), '/');
 
   const sortKey      = controlState.league.teamSortKey;
   const matchSortKey = getMatchSortKey(controlState.league.matchSortKey);
@@ -666,7 +665,6 @@ function loadAndRender(): void {
 
 export function initLeagueView(ids: LeagueViewIds, ctx: LeagueViewContext): LeagueViewHandle {
   refs = resolveRefs(ids);
-  viewContext = ctx;
   const prefs = loadPrefs();
   controlState = createControlStateFromPrefs(prefs, ctx.shared);
   state.heightUnit = getHeightUnit();

--- a/frontend/src/league-view.ts
+++ b/frontend/src/league-view.ts
@@ -69,19 +69,22 @@ const state: AppState = {
 
 // ---- Control state (symmetric with bracket-view.ts) --------------------
 
-interface LeagueViewerControlState extends SharedViewerControlState {
-  displayTimezone: string;  // '' = browser default; otherwise an IANA TZ name
-  hiddenColumns: Set<string>;  // rank table column data-ids hidden by the user
-}
-
 interface LeagueControlState {
   teamSortKey: string;
   matchSortKey: string;
   spaceColor: string;
+  displayTimezone: string;  // '' = browser default; otherwise an IANA TZ name
+  hiddenColumns: Set<string>;  // rank table column data-ids hidden by the user
 }
 
 interface ControlState {
-  viewer: LeagueViewerControlState;
+  /**
+   * Alias of the orchestrator's shared viewer state — NOT a copy. Writing here
+   * writes the value both views observe, so only user-chosen values belong in
+   * it (see bracket-view for the symmetric arrangement). League-specific prefs
+   * live in `league` below.
+   */
+  viewer: SharedViewerControlState;
   league: LeagueControlState;
 }
 
@@ -90,15 +93,13 @@ function createControlStateFromPrefs(
   shared: SharedViewerControlState,
 ): ControlState {
   return {
-    viewer: {
-      ...shared,
-      displayTimezone: prefs.displayTimezone ?? '',
-      hiddenColumns: new Set(prefs.hiddenColumns ?? []),
-    },
+    viewer: shared,
     league: {
       teamSortKey: prefs.teamSortKey ?? 'disp_point',
       matchSortKey: prefs.matchSortKey ?? 'old_bottom',
       spaceColor: prefs.spaceColor ?? '#cccccc',
+      displayTimezone: prefs.displayTimezone ?? '',
+      hiddenColumns: new Set(prefs.hiddenColumns ?? []),
     },
   };
 }
@@ -485,7 +486,7 @@ function renderFromCache(
       const { fragment, matchDates } = renderBarGraph(
         groupData, sortedTeams, perGroupInfo,
         targetDate, disp, bottomFirst, state.heightUnit, hasPk, hasEx,
-        controlState.viewer.displayTimezone || undefined,
+        controlState.league.displayTimezone || undefined,
       );
       for (const d of matchDates) globalMatchDateSet.add(d);
 
@@ -530,7 +531,7 @@ function renderFromCache(
       table.appendChild(document.createElement('thead'));
       sortableDiv.appendChild(table);
       const rankData = makeRankData(groupData, sortedTeams, perGroupInfo, disp, hasPk, hasEx);
-      makeRankTable(table, rankData, hasPk, hasEx, perGroupInfo.promotionLabel, controlState.viewer.hiddenColumns);
+      makeRankTable(table, rankData, hasPk, hasEx, perGroupInfo.promotionLabel, controlState.league.hiddenColumns);
     }
 
     // Collect for cross-group comparison.
@@ -546,7 +547,7 @@ function renderFromCache(
     const rows = buildCrossGroupRows(allGroupResults, cgs, disp, targetDate, maxPt);
     if (rows.length > 0) {
       sortableDiv.appendChild(document.createElement('hr'));
-      sortableDiv.appendChild(makeCrossGroupTable(rows, cgs, controlState.viewer.hiddenColumns));
+      sortableDiv.appendChild(makeCrossGroupTable(rows, cgs, controlState.league.hiddenColumns));
     }
   }
 
@@ -681,18 +682,18 @@ export function initLeagueView(ids: LeagueViewIds, ctx: LeagueViewContext): Leag
   populateFixedSelect(refs.displayTimezone, getDisplayTzOptions());
   refs.teamSort.value = controlState.league.teamSortKey;
   refs.matchSort.value = controlState.league.matchSortKey;
-  refs.displayTimezone.value = controlState.viewer.displayTimezone;
+  refs.displayTimezone.value = controlState.league.displayTimezone;
   refs.spaceColor.value = controlState.league.spaceColor;
 
-  populateColumnToggleList(controlState.viewer.hiddenColumns, (columnId, checked) => {
-    if (checked) controlState.viewer.hiddenColumns.delete(columnId);
-    else controlState.viewer.hiddenColumns.add(columnId);
-    savePrefs({ hiddenColumns: [...controlState.viewer.hiddenColumns] });
+  populateColumnToggleList(controlState.league.hiddenColumns, (columnId, checked) => {
+    if (checked) controlState.league.hiddenColumns.delete(columnId);
+    else controlState.league.hiddenColumns.add(columnId);
+    savePrefs({ hiddenColumns: [...controlState.league.hiddenColumns] });
     loadAndRender();
   });
 
   refs.targetDate.addEventListener('change', () => {
-    ctx.shared.targetDate = normalizeTargetDate(refs.targetDate.value);
+    controlState.viewer.targetDate = normalizeTargetDate(refs.targetDate.value);
     ctx.onViewerChange();
     loadAndRender();
   });
@@ -709,7 +710,7 @@ export function initLeagueView(ids: LeagueViewIds, ctx: LeagueViewContext): Leag
     const date = getSliderDate(state.currentMatchDates, parseInt(refs.dateSlider.value, 10));
     if (!date) return;
     refs.targetDate.value = toInputDate(date);
-    ctx.shared.targetDate = normalizeTargetDate(date);
+    controlState.viewer.targetDate = normalizeTargetDate(date);
     ctx.onViewerChange();
     loadAndRender();
   };
@@ -731,18 +732,18 @@ export function initLeagueView(ids: LeagueViewIds, ctx: LeagueViewContext): Leag
   refs.dateSliderReset.addEventListener('click', () => {
     const today = dateFormat(new Date(), '/');
     refs.targetDate.value = toInputDate(today);
-    ctx.shared.targetDate = today;
+    controlState.viewer.targetDate = today;
     ctx.onViewerChange();
     loadAndRender();
   });
 
   refs.scaleSlider.addEventListener('input', () => {
-    ctx.shared.scale = parseFloat(refs.scaleSlider.value);
+    controlState.viewer.scale = parseFloat(refs.scaleSlider.value);
     setScale(refs.boxContainer, refs.scaleSlider.value);
     ctx.onViewerChange();
   });
   refs.futureOpacity.addEventListener('input', () => {
-    ctx.shared.futureOpacity = parseFloat(refs.futureOpacity.value);
+    controlState.viewer.futureOpacity = parseFloat(refs.futureOpacity.value);
     setFutureOpacity(refs.futureOpacity.value);
     ctx.onViewerChange();
   });
@@ -752,7 +753,7 @@ export function initLeagueView(ids: LeagueViewIds, ctx: LeagueViewContext): Leag
     savePrefs({ spaceColor: refs.spaceColor.value });
   });
   refs.displayTimezone.addEventListener('change', () => {
-    controlState.viewer.displayTimezone = refs.displayTimezone.value;
+    controlState.league.displayTimezone = refs.displayTimezone.value;
     savePrefs({ displayTimezone: refs.displayTimezone.value });
     loadAndRender();
   });
@@ -765,16 +766,13 @@ export function initLeagueView(ids: LeagueViewIds, ctx: LeagueViewContext): Leag
       activeSelection = selection;
       if (selectionChanged) state.teamMapCache = null;
 
-      const previousScale = ctx.shared.scale;
+      const previousScale = controlState.viewer.scale;
       const clampedScale = clampToSlider(previousScale, refs.scaleSlider);
       refs.scaleSlider.value = String(clampedScale);
-      ctx.shared.scale = parseFloat(refs.scaleSlider.value);
-      if (ctx.shared.scale !== previousScale) ctx.onViewerChange();
-      controlState.viewer.scale = ctx.shared.scale;
-      refs.futureOpacity.value = String(ctx.shared.futureOpacity);
-      controlState.viewer.futureOpacity = ctx.shared.futureOpacity;
-      controlState.viewer.targetDate = ctx.shared.targetDate;
-      refs.targetDate.value = toInputDate(ctx.shared.targetDate) || dateFormat(new Date(), '-');
+      controlState.viewer.scale = parseFloat(refs.scaleSlider.value);
+      if (controlState.viewer.scale !== previousScale) ctx.onViewerChange();
+      refs.futureOpacity.value = String(controlState.viewer.futureOpacity);
+      refs.targetDate.value = toInputDate(controlState.viewer.targetDate) || dateFormat(new Date(), '-');
       setFutureOpacity(refs.futureOpacity.value, false);
       if (prefs.spaceColor) setSpace(controlState.league.spaceColor, false);
       loadAndRender();

--- a/frontend/src/view-bootstrap.ts
+++ b/frontend/src/view-bootstrap.ts
@@ -57,6 +57,21 @@ export function normalizeTargetDate(value: string | null | undefined): string | 
   return value.replace(/-/g, '/');
 }
 
+/**
+ * The bracket slider's "before any match" sentinel. Older builds wrote it into
+ * the shared target date, which pinned League to a preseason view on reload.
+ * Writing it is fixed (#298); this drops the value for anyone who already has
+ * it saved. Kept as a literal rather than importing PRESEASON_SENTINEL so this
+ * module stays free of view-layer imports.
+ */
+const PERSISTED_PRESEASON_SENTINEL = '1970/01/01';
+
+/** Restore a persisted target date, discarding values that were never user-chosen. */
+export function restoreTargetDate(value: string | null | undefined): string | null {
+  const normalized = normalizeTargetDate(value);
+  return normalized === PERSISTED_PRESEASON_SENTINEL ? null : normalized;
+}
+
 export function toInputDate(value: string | null | undefined): string {
   return normalizeTargetDate(value)?.replace(/\//g, '-') ?? '';
 }
@@ -75,6 +90,6 @@ export function createSharedViewerControlState(
   return {
     scale: prefs.scale ? parseFloat(prefs.scale) : (defaults.scale ?? 1),
     futureOpacity: prefs.futureOpacity ? parseFloat(prefs.futureOpacity) : (defaults.futureOpacity ?? 0.1),
-    targetDate: normalizeTargetDate(prefs.targetDate),
+    targetDate: restoreTargetDate(prefs.targetDate),
   };
 }


### PR DESCRIPTION
Fixes #298

## 概要

Bracket View が「ユーザーが選んでいない値」を共有 `targetDate` に書き込み、League View の表示日付を汚染していた問題を修正する。根因だった copy vs alias の非対称も解消した。

## 修正内容

### 1a. 大会最終日の自動充填を削除

Bracket が `loadAndRender()` で大会最終日を共有状態に書いていた。スライダー位置・表示ラベル・描画マスクはいずれも `resolveTargetDate()` の null fallback を通っており、書かなくても表示は等価。

### 1b. 開幕前センチネルをローカル状態化

スライダー左端の `1970/01/01` が共有状態に流れ、League が「開幕前」表示に固定されていた。Bracket ローカルの `preseason` フラグ (非永続) に切り出した。

### 3. League の viewer state を alias に統一

League は共有状態のコピーを持ち `activate()` で3項目を手動同期していた。alias に統一して手動同期を削除し、League 固有 pref (`displayTimezone` / `hiddenColumns`) は league スライスへ移動。

置換をかけた時点で手動同期3行が自己代入 (`x = x`) に潰れ、純粋なコピーバックだったことが機械的に確認できた。

### 汚染済み prefs の救済

`restoreTargetDate()` を追加し、既にセンチネルが保存されているユーザーの値を読み込み時に破棄する。

## 検証

回帰テストは**修正前のコードに当てて実際に落ちることを確認済み**。

- `bracket view does not pin the shared target date...` — 修正前は League が `2024-11-02` (JLeagueCup 2024 決勝日) を表示
- `bracket preseason slider position does not leak...` — 修正前は prefs に `1970/01/01` が保存される

当初 1a のテストは localStorage を検証していたが修正前でも通ってしまった。自動充填は `onViewerChange()` を呼ばず即時永続化しないため、二次症状しか見ていなかった。一次症状 (League の表示日付) を検証する形に改めている。

- `npm test` 584 passed
- `npm run typecheck` / `npm run build` 通過
- `npx playwright test --grep-invert @full-render` 90 passed

## スコープ外

`scale` / `futureOpacity` の所有権整理 (View 別 pref への分離) は後続対応。本 PR では `targetDate` 以外の共有キーの意味論は変更していない。