### PR TITLE
Discard stale CSV responses in the Bracket View

### DIFF
--- a/frontend/e2e/view-stale-response.spec.ts
+++ b/frontend/e2e/view-stale-response.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from './helpers/test-base';
+import { waitForRender } from './helpers/invariants';
+
+async function waitForBracketRender(page: import('@playwright/test').Page): Promise<void> {
+  await page.locator('#bracket_status_msg').filter({ hasText: /\d+/ }).waitFor({ timeout: 15000 });
+  await page.locator('#bracket_container .bracket-match').first().waitFor({ timeout: 10000 });
+}
+
+/**
+ * #300: a CSV response that lands after the user moved on used to be applied
+ * unconditionally, so a slow competition could overwrite the one on screen.
+ */
+test.describe('Stale CSV response handling', () => {
+  const SLOW_MS = 3000;
+
+  test('a slow competition response does not overwrite the one selected after it', async ({ page }) => {
+    // Hold back EmperorsCup so JLeagueCup, selected afterwards, resolves first.
+    await page.route('**/csv/*EmperorsCup*.csv*', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, SLOW_MS));
+      await route.continue();
+    });
+
+    await page.goto('/matches.html?competition=J1&season=2024');
+    await waitForRender(page);
+
+    await page.selectOption('#competition_key', 'EmperorsCup');
+    await page.selectOption('#competition_key', 'JLeagueCup');
+    await waitForBracketRender(page);
+
+    const settled = await page.locator('#bracket_status_msg').textContent();
+
+    // Outlast the delayed response, then confirm nothing changed under us.
+    await page.waitForTimeout(SLOW_MS + 1000);
+
+    expect(await page.locator('#competition_key').inputValue()).toBe('JLeagueCup');
+    expect(await page.locator('#bracket_status_msg').textContent()).toBe(settled);
+  });
+
+  test('a response arriving after leaving the bracket view does not render into it', async ({ page }) => {
+    await page.route('**/csv/*EmperorsCup*.csv*', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, SLOW_MS));
+      await route.continue();
+    });
+
+    await page.goto('/matches.html?competition=J1&season=2024');
+    await waitForRender(page);
+
+    await page.selectOption('#competition_key', 'EmperorsCup');
+    await page.selectOption('#competition_key', 'J1');
+    await waitForRender(page);
+
+    await page.waitForTimeout(SLOW_MS + 1000);
+
+    await expect(page.locator('#view_root')).toHaveAttribute('data-active', 'league');
+    await expect(page.locator('#league_view')).toBeVisible();
+    expect(await page.locator('#bracket_container .bracket-match').count()).toBe(0);
+  });
+});

--- a/frontend/src/bracket-view.ts
+++ b/frontend/src/bracket-view.ts
@@ -87,6 +87,13 @@ const EMPTY_BRACKET_ROOT: BracketNode = {
 
 let currentState: BracketState | null = null;
 
+/**
+ * Incremented on every load and on deactivate, so a CSV response that arrives
+ * after the user switched competition or left the view is discarded instead of
+ * overwriting the current state (mirrors league-view's AppState.renderVersion).
+ */
+let renderVersion = 0;
+
 /** Cache buildBracket results to avoid redundant rebuilds on slider/layout changes. */
 let bracketCache = new Map<string, BracketNode>();
 
@@ -808,6 +815,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
 
   const filename = getCsvFilename(competition, season);
   const cachebuster = Math.floor(Date.now() / 1000 / CACHE_BUST_WINDOW_SEC);
+  const version = ++renderVersion;
   setStatus(t('status.loading'));
 
   Papa.parse<RawMatchRow>(filename + '?_=' + cachebuster, {
@@ -815,6 +823,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
     skipEmptyLines: 'greedy',
     download: true,
     complete: (results) => {
+      if (version !== renderVersion) return;
       const inferredOrder = inferBracketOrderFromRows(results.data);
       const rawSections = entry.bracket_blocks;
       const tournamentSeasonInfo = resolveTournamentSeasonInfo(
@@ -935,6 +944,7 @@ function loadAndRender(seasonMap: SeasonMap): void {
       }));
     },
     error: (err: unknown) => {
+      if (version !== renderVersion) return;
       setStatus(t('status.error', { detail: String(err) }));
     },
   });
@@ -1031,6 +1041,9 @@ export function initBracketView(
       loadAndRender(seasonMap);
     },
     deactivate() {
+      // Discard any load still in flight: its response would render into the
+      // now-hidden DOM and clobber roundStart for the next activate.
+      renderVersion++;
       unpinTooltip();
     },
   };

--- a/frontend/src/league-view.ts
+++ b/frontend/src/league-view.ts
@@ -776,7 +776,8 @@ export function initLeagueView(ids: LeagueViewIds, ctx: LeagueViewContext): Leag
       loadAndRender();
     },
     deactivate() {
-      // League view currently has no transient UI state to clean up.
+      // Discard any load still in flight so it cannot render into the hidden view.
+      state.renderVersion++;
     },
   };
 }


### PR DESCRIPTION
Fixes #300

> **注**: #299 の上に積んでいます (同じ `bracket-view.ts` を触るため)。base は #299 のブランチで、#299 マージ後に自動で main 相当の差分になります。

## 概要

Bracket View が CSV 応答を無条件に適用していたため、遅い大会の応答が後から届いて画面上の大会を上書きしていた。League と同じ `renderVersion` パターンを導入する。

## 修正内容

- Bracket に `renderVersion` カウンタを追加し、`complete` / `error` の先頭でガード
- 両 View の `deactivate()` で version をインクリメントし、View 離脱後に届いた応答を破棄

## 検証

Playwright の route interception で EmperorsCup の CSV を3秒遅延させ、実際のレースを再現。**両テストとも修正前のコードで落ちることを確認済み**。

- `a slow competition response does not overwrite the one selected after it` — 修正前は後から届いた EmperorsCup が JLeagueCup の表示を上書き
- `a response arriving after leaving the bracket view does not render into it` — 修正前は League 表示中の hidden な bracket DOM に **87 個の `.bracket-match` が描画される**

- `npm test` 584 passed
- `npm run typecheck` / `npm run build` 通過
- `npx playwright test --grep-invert @full-render` 94 passed

## スコープ外

League / Bracket の CSV ロードは「`getCsvFilename` + cachebuster + `Papa.parse(download: true)` + version guard」がほぼ同形の重複コード。本 PR は最小差分に留め、共通 `loadCsv()` ヘルパーへの抽出は後続で検討する。