### PR TITLE
Separate scale and future opacity per view

### DIFF
--- a/frontend/e2e/unified-viewer.spec.ts
+++ b/frontend/e2e/unified-viewer.spec.ts
@@ -36,7 +36,10 @@ test.describe('Unified league and bracket viewer', () => {
     await expect(page.locator('#bracket_view')).toBeHidden();
   });
 
-  test('shares viewer controls and canonical target date across views', async ({ page }) => {
+  // #302: the target date is shared so a competition's stages can be read at
+  // the same point in time; scale and opacity are per-view because their
+  // ranges and defaults differ.
+  test('shares the target date across views but keeps appearance per view', async ({ page }) => {
     await page.locator('#league_scale_slider').fill('0.6');
     await page.locator('#league_scale_slider').dispatchEvent('input');
     await page.locator('#league_future_opacity').fill('0.3');
@@ -48,14 +51,43 @@ test.describe('Unified league and bracket viewer', () => {
     await page.selectOption('#competition_key', 'JLeagueCup');
     await waitForBracketRender(page);
 
-    await expect(page.locator('#bracket_scale_slider')).toHaveValue('0.6');
-    await expect(page.locator('#bracket_future_opacity')).toHaveValue('0.3');
+    // The bracket keeps its own appearance rather than inheriting League's.
+    await expect(page.locator('#bracket_future_opacity')).toHaveValue('0.2');
+
     const prefs = await page.evaluate(() => JSON.parse(
       localStorage.getItem('jleague_viewer_prefs') ?? '{}',
     ) as Record<string, string>);
     expect(prefs.targetDate).toBe('2024/05/03');
-    expect(prefs.scale).toBe('0.6');
-    expect(prefs.futureOpacity).toBe('0.3');
+    expect(prefs.leagueScale).toBe('0.6');
+    expect(prefs.leagueFutureOpacity).toBe('0.3');
+  });
+
+  test('league scale below the bracket minimum survives a round trip', async ({ page }) => {
+    await page.locator('#league_scale_slider').fill('0.2');
+    await page.locator('#league_scale_slider').dispatchEvent('input');
+    await waitForRender(page);
+
+    // The bracket slider starts at 0.3, so a shared value used to be clamped
+    // up and persisted, silently destroying the league's setting (#302).
+    await page.selectOption('#competition_key', 'JLeagueCup');
+    await waitForBracketRender(page);
+    await page.selectOption('#competition_key', 'J1');
+    await waitForRender(page);
+
+    await expect(page.locator('#league_scale_slider')).toHaveValue('0.2');
+    await expect(page.locator('#league_current_scale')).toHaveText('0.2');
+  });
+
+  test('league scale and opacity displays track their sliders', async ({ page }) => {
+    // css-utils updated these by hardcoded id, which resolved to nothing once
+    // the unified page namespaced them, so both displays were frozen (#302).
+    await page.locator('#league_scale_slider').fill('0.7');
+    await page.locator('#league_scale_slider').dispatchEvent('input');
+    await expect(page.locator('#league_current_scale')).toHaveText('0.7');
+
+    await page.locator('#league_future_opacity').fill('0.45');
+    await page.locator('#league_future_opacity').dispatchEvent('input');
+    await expect(page.locator('#league_current_opacity')).toHaveText('0.45');
   });
 
   // #298: the bracket view used to write values the user never picked into the

--- a/frontend/src/__tests__/tournament/bracket-view.test.ts
+++ b/frontend/src/__tests__/tournament/bracket-view.test.ts
@@ -171,39 +171,56 @@ describe('bracket-view helpers', () => {
   });
 
   describe('createControlStateFromPrefs', () => {
-    test('separates viewer-common prefs from bracket-specific prefs', () => {
+    test('separates the shared date from bracket-owned appearance', () => {
       const state = __testables.createControlStateFromPrefs({
-        scale: '1.5',
-        futureOpacity: '0.35',
+        bracketScale: '1.5',
+        bracketFutureOpacity: '0.35',
         targetDate: '2025/03/20',
         roundStart: '準決勝',
       });
 
-      expect(state.viewer).toEqual({
-        scale: 1.5,
-        futureOpacity: 0.35,
-        targetDate: '2025/03/20',
-      });
+      expect(state.viewer).toEqual({ targetDate: '2025/03/20' });
       expect(state.bracket).toEqual({
         layout: 'horizontal',
         roundStart: '準決勝',
         preseason: false,
+        scale: 1.5,
+        futureOpacity: 0.35,
       });
     });
 
     test('falls back to current defaults when prefs are absent', () => {
       const state = __testables.createControlStateFromPrefs({});
 
-      expect(state.viewer).toEqual({
-        scale: 1,
-        futureOpacity: 0.2,
-        targetDate: null,
-      });
+      expect(state.viewer).toEqual({ targetDate: null });
       expect(state.bracket).toEqual({
         layout: 'horizontal',
         roundStart: null,
         preseason: false,
+        scale: 1,
+        // The bracket's own default, which the shared state used to override
+        // with the league's 0.1 (#302).
+        futureOpacity: 0.2,
       });
+    });
+
+    test('migrates legacy shared keys into the bracket-owned values', () => {
+      const state = __testables.createControlStateFromPrefs({
+        scale: '0.5',
+        futureOpacity: '0.4',
+      });
+
+      expect(state.bracket.scale).toBe(0.5);
+      expect(state.bracket.futureOpacity).toBe(0.4);
+    });
+
+    test('prefers the bracket key over the legacy shared key', () => {
+      const state = __testables.createControlStateFromPrefs({
+        scale: '0.5',
+        bracketScale: '0.9',
+      });
+
+      expect(state.bracket.scale).toBe(0.9);
     });
   });
 

--- a/frontend/src/__tests__/view-bootstrap.test.ts
+++ b/frontend/src/__tests__/view-bootstrap.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   clampToSlider,
-  createSharedViewerControlState,
+  createSharedDateState,
+  readViewNumberPref,
   normalizeTargetDate,
   restoreTargetDate,
   toInputDate,
@@ -22,7 +23,7 @@ describe('viewer preference normalization', () => {
   });
 
   it('migrates a legacy saved targetDate when creating shared state', () => {
-    expect(createSharedViewerControlState({ targetDate: '2026-06-28' }).targetDate)
+    expect(createSharedDateState({ targetDate: '2026-06-28' }).targetDate)
       .toBe('2026/06/28');
   });
 });
@@ -40,7 +41,7 @@ describe('restoreTargetDate', () => {
   );
 
   it('drops a persisted sentinel when creating shared state', () => {
-    expect(createSharedViewerControlState({ targetDate: '1970/01/01' }).targetDate)
+    expect(createSharedDateState({ targetDate: '1970/01/01' }).targetDate)
       .toBeNull();
   });
 });
@@ -54,5 +55,23 @@ describe('clampToSlider', () => {
 
   it('keeps values inside the slider range', () => {
     expect(clampToSlider(0.7, slider)).toBe(0.7);
+  });
+});
+
+describe('readViewNumberPref', () => {
+  it('prefers the per-view key', () => {
+    expect(readViewNumberPref('0.9', '0.5', 1)).toBe(0.9);
+  });
+
+  it('falls back to the legacy shared key so existing settings carry over', () => {
+    expect(readViewNumberPref(undefined, '0.5', 1)).toBe(0.5);
+  });
+
+  it("falls back to the view's own default when neither is stored", () => {
+    expect(readViewNumberPref(undefined, undefined, 0.2)).toBe(0.2);
+  });
+
+  it('ignores unparseable stored values', () => {
+    expect(readViewNumberPref('abc', undefined, 0.2)).toBe(0.2);
   });
 });

--- a/frontend/src/bracket-view.ts
+++ b/frontend/src/bracket-view.ts
@@ -31,8 +31,8 @@ import { renderBracketInto, unpinTooltip } from './bracket/bracket-renderer';
 import { loadPrefs, savePrefs } from './storage/local-storage';
 import type { ViewerPrefs } from './storage/local-storage';
 import { t } from './i18n';
-import { clampToSlider, createSharedViewerControlState } from './view-bootstrap';
-import type { SharedViewerControlState } from './view-bootstrap';
+import { clampToSlider, createSharedDateState, readViewNumberPref } from './view-bootstrap';
+import type { SharedDateState } from './view-bootstrap';
 import type { BracketNode } from './bracket/bracket-types';
 
 // ---- State ------------------------------------------------------------------
@@ -49,11 +49,16 @@ interface BracketState {
   season: string;
 }
 
-type ViewerControlState = SharedViewerControlState;
+type ViewerControlState = SharedDateState;
+
+const DEFAULT_BRACKET_SCALE = 1;
+const DEFAULT_BRACKET_FUTURE_OPACITY = 0.2;
 
 interface BracketControlState {
   layout: 'horizontal' | 'vertical';
   roundStart: string | null;
+  scale: number;           // bracket-owned: its slider range starts at 0.3
+  futureOpacity: number;   // bracket-owned: default is lighter than the league's
   /**
    * Slider parked on the "before any match" position. Kept here rather than in
    * `viewer.targetDate` because the sentinel date is a bracket-only display
@@ -99,20 +104,20 @@ let bracketCache = new Map<string, BracketNode>();
 
 let controlState: ControlState = {
   viewer: {
-    scale: 1,
-    futureOpacity: 0.2,
     targetDate: null,
   },
   bracket: {
     layout: 'horizontal',
     roundStart: null,
     preseason: false,
+    scale: DEFAULT_BRACKET_SCALE,
+    futureOpacity: DEFAULT_BRACKET_FUTURE_OPACITY,
   },
 };
 
 function createControlStateFromPrefs(
   prefs: ViewerPrefs,
-  shared = createSharedViewerControlState(prefs, { futureOpacity: 0.2 }),
+  shared = createSharedDateState(prefs),
 ): ControlState {
   return {
     viewer: shared,
@@ -120,6 +125,10 @@ function createControlStateFromPrefs(
       layout: 'horizontal',
       roundStart: prefs.roundStart ?? null,
       preseason: false,
+      scale: readViewNumberPref(prefs.bracketScale, prefs.scale, DEFAULT_BRACKET_SCALE),
+      futureOpacity: readViewNumberPref(
+        prefs.bracketFutureOpacity, prefs.futureOpacity, DEFAULT_BRACKET_FUTURE_OPACITY,
+      ),
     },
   };
 }
@@ -130,7 +139,7 @@ export interface BracketViewSelection {
 }
 
 export interface BracketViewContext {
-  shared: SharedViewerControlState;
+  shared: SharedDateState;
   onViewerChange(): void;
 }
 
@@ -762,10 +771,11 @@ function updateSliderDisplay(): void {
 /** Apply futureOpacity from controlState to all .bracket-future elements. */
 function applyFutureOpacity(): void {
   const container = refs.container;
-  const value = String(controlState.viewer.futureOpacity);
+  const value = String(controlState.bracket.futureOpacity);
   for (const el of Array.from(container.querySelectorAll('.bracket-future'))) {
     (el as HTMLElement).style.opacity = value;
   }
+  refs.futureOpacity.value = value;
   refs.currentOpacity.textContent = value;
 }
 
@@ -789,10 +799,11 @@ function syncBracketContainerHeight(container: HTMLElement): void {
 /** Apply scale from controlState to bracket container. */
 function applyScale(): void {
   const container = refs.container;
-  const value = String(controlState.viewer.scale);
+  const value = String(controlState.bracket.scale);
   container.style.transform = `scale(${value})`;
   container.style.transformOrigin = 'top left';
   syncBracketContainerHeight(container);
+  refs.scaleSlider.value = value;
   refs.currentScale.textContent = value;
 }
 
@@ -1003,14 +1014,14 @@ export function initBracketView(
     viewContext.onViewerChange();
   });
   refs.futureOpacity.addEventListener('input', () => {
-    controlState.viewer.futureOpacity = parseFloat(refs.futureOpacity.value);
+    controlState.bracket.futureOpacity = parseFloat(refs.futureOpacity.value);
     applyFutureOpacity();
-    viewContext.onViewerChange();
+    savePrefs({ bracketFutureOpacity: refs.futureOpacity.value });
   });
   refs.scaleSlider.addEventListener('input', () => {
-    controlState.viewer.scale = parseFloat(refs.scaleSlider.value);
+    controlState.bracket.scale = parseFloat(refs.scaleSlider.value);
     applyScale();
-    viewContext.onViewerChange();
+    savePrefs({ bracketScale: refs.scaleSlider.value });
   });
   refs.layout.addEventListener('change', () => {
     controlState.bracket.layout = refs.layout.value as 'horizontal' | 'vertical';
@@ -1033,11 +1044,9 @@ export function initBracketView(
       controlState.bracket.preseason = false;
       refs.competition.value = selection.competition;
       refs.season.value = selection.season;
-      refs.futureOpacity.value = String(controlState.viewer.futureOpacity);
-      const previousScale = controlState.viewer.scale;
-      controlState.viewer.scale = clampToSlider(previousScale, refs.scaleSlider);
-      refs.scaleSlider.value = String(controlState.viewer.scale);
-      if (controlState.viewer.scale !== previousScale) viewContext.onViewerChange();
+      // Clamp for display only: the stored value stays as the user set it, so
+      // visiting a view with a narrower slider range cannot ratchet it (#302).
+      controlState.bracket.scale = clampToSlider(controlState.bracket.scale, refs.scaleSlider);
       loadAndRender(seasonMap);
     },
     deactivate() {

--- a/frontend/src/graph/css-utils.ts
+++ b/frontend/src/graph/css-utils.ts
@@ -63,35 +63,26 @@ export function getHeightUnit(): number {
 
 /**
  * Sets the opacity of the `.future` CSS class.
- * updateSlider=true (default) → also updates #future_opacity slider value and
- * writes current value to #current_opacity display span.
+ * Control and display elements are the caller's responsibility: this module
+ * used to update them by hardcoded id, which silently did nothing once the
+ * unified page namespaced them (#302).
  */
-export function setFutureOpacity(value: string, updateSlider = true): void {
+export function setFutureOpacity(value: string): void {
   const rule = getCssRule('.future');
   if (!rule) return;
   rule.style.opacity = value;
-  const display = document.getElementById('current_opacity');
-  if (display) display.textContent = value;
-  if (updateSlider) {
-    const slider = document.getElementById('future_opacity') as HTMLInputElement | null;
-    if (slider) slider.value = value;
-  }
 }
 
 /**
  * Sets the background color of the `.space` CSS class.
  * Automatically chooses black or white text based on perceived brightness.
- * updateColorPicker=true (default) → also updates #space_color picker value.
+ * The colour picker is the caller's responsibility (see setFutureOpacity).
  */
-export function setSpace(value: string, updateColorPicker = true): void {
+export function setSpace(value: string): void {
   const rule = getCssRule('.space');
   if (!rule) return;
   rule.style.backgroundColor = value;
   rule.style.color = getBright(value, RGB_MOD) > 0.5 ? 'black' : 'white';
-  if (updateColorPicker) {
-    const picker = document.getElementById('space_color') as HTMLInputElement | null;
-    if (picker) picker.value = value;
-  }
 }
 
 // Vertical gap below each block row; keep in sync with the
@@ -112,9 +103,9 @@ function maxPointColumnHeight(root: ParentNode): number {
  * Height is set to the unscaled content height × scale to prevent overflow.
  * Single row → max .point_column height. Multi-group block rows (.group_block_row)
  * → sum of each row's max height plus the inter-row gaps.
- * updateSlider=true (default) → also updates #scale_slider value and #current_scale display.
+ * The slider and its display are the caller's responsibility (see setFutureOpacity).
  */
-export function setScale(boxCon: HTMLElement, value: string, updateSlider = true): void {
+export function setScale(boxCon: HTMLElement, value: string): void {
   boxCon.style.transform = `scale(${value})`;
   const blockRows = Array.from(boxCon.querySelectorAll('.group_block_row'));
   let contentHeight = 0;
@@ -127,11 +118,5 @@ export function setScale(boxCon: HTMLElement, value: string, updateSlider = true
   }
   if (contentHeight > 0) {
     boxCon.style.height = `${contentHeight * parseFloat(value)}px`;
-  }
-  if (updateSlider) {
-    const slider = document.getElementById('scale_slider') as HTMLInputElement | null;
-    if (slider) slider.value = value;
-    const display = document.getElementById('current_scale');
-    if (display) display.textContent = value;
   }
 }

--- a/frontend/src/league-view.ts
+++ b/frontend/src/league-view.ts
@@ -35,9 +35,9 @@ import { loadPrefs, savePrefs } from './storage/local-storage';
 import type { ViewerPrefs } from './storage/local-storage';
 import { t } from './i18n';
 import {
-  clampToSlider, normalizeTargetDate, toInputDate,
+  clampToSlider, normalizeTargetDate, readViewNumberPref, toInputDate,
 } from './view-bootstrap';
-import type { SharedViewerControlState } from './view-bootstrap';
+import type { SharedDateState } from './view-bootstrap';
 
 // ---- Application state ------------------------------------------------
 
@@ -69,12 +69,17 @@ const state: AppState = {
 
 // ---- Control state (symmetric with bracket-view.ts) --------------------
 
+const DEFAULT_LEAGUE_SCALE = 1;
+const DEFAULT_LEAGUE_FUTURE_OPACITY = 0.1;
+
 interface LeagueControlState {
   teamSortKey: string;
   matchSortKey: string;
   spaceColor: string;
   displayTimezone: string;  // '' = browser default; otherwise an IANA TZ name
   hiddenColumns: Set<string>;  // rank table column data-ids hidden by the user
+  scale: number;           // league-owned: its slider range starts at 0.1
+  futureOpacity: number;   // league-owned: default differs from the bracket's
 }
 
 interface ControlState {
@@ -84,13 +89,13 @@ interface ControlState {
    * it (see bracket-view for the symmetric arrangement). League-specific prefs
    * live in `league` below.
    */
-  viewer: SharedViewerControlState;
+  viewer: SharedDateState;
   league: LeagueControlState;
 }
 
 function createControlStateFromPrefs(
   prefs: ViewerPrefs,
-  shared: SharedViewerControlState,
+  shared: SharedDateState,
 ): ControlState {
   return {
     viewer: shared,
@@ -100,6 +105,10 @@ function createControlStateFromPrefs(
       spaceColor: prefs.spaceColor ?? '#cccccc',
       displayTimezone: prefs.displayTimezone ?? '',
       hiddenColumns: new Set(prefs.hiddenColumns ?? []),
+      scale: readViewNumberPref(prefs.leagueScale, prefs.scale, DEFAULT_LEAGUE_SCALE),
+      futureOpacity: readViewNumberPref(
+        prefs.leagueFutureOpacity, prefs.futureOpacity, DEFAULT_LEAGUE_FUTURE_OPACITY,
+      ),
     },
   };
 }
@@ -119,7 +128,7 @@ export interface LeagueViewSelection {
 }
 
 export interface LeagueViewContext {
-  shared: SharedViewerControlState;
+  shared: SharedDateState;
   onViewerChange(): void;
 }
 
@@ -142,7 +151,9 @@ export interface LeagueViewIds {
   postDateSlider: string;
   targetDate: string;
   scaleSlider: string;
+  currentScale: string;
   futureOpacity: string;
+  currentOpacity: string;
   spaceColor: string;
   columnToggleList: string;
   status: string;
@@ -168,7 +179,9 @@ export const LEAGUE_STANDALONE_IDS: LeagueViewIds = {
   postDateSlider: 'post_date_slider',
   targetDate: 'target_date',
   scaleSlider: 'scale_slider',
+  currentScale: 'current_scale',
   futureOpacity: 'future_opacity',
+  currentOpacity: 'current_opacity',
   spaceColor: 'space_color',
   columnToggleList: 'column_toggle_list',
   status: 'status_msg',
@@ -187,7 +200,9 @@ export const LEAGUE_NAMESPACED_IDS: LeagueViewIds = {
   dateSliderUp: 'league_date_slider_up',
   postDateSlider: 'league_post_date_slider',
   scaleSlider: 'league_scale_slider',
+  currentScale: 'league_current_scale',
   futureOpacity: 'league_future_opacity',
+  currentOpacity: 'league_current_opacity',
   status: 'league_status_msg',
   seasonNotes: 'league_season_notes',
 };
@@ -206,7 +221,9 @@ interface LeagueViewRefs {
   postDateSlider: HTMLElement;
   targetDate: HTMLInputElement;
   scaleSlider: HTMLInputElement;
+  currentScale: HTMLElement;
   futureOpacity: HTMLInputElement;
+  currentOpacity: HTMLElement;
   spaceColor: HTMLInputElement;
   columnToggleList: HTMLElement;
   status: HTMLElement;
@@ -244,7 +261,9 @@ function resolveRefs(ids: LeagueViewIds): LeagueViewRefs {
     postDateSlider: requireElement(ids.postDateSlider),
     targetDate: requireElement(ids.targetDate),
     scaleSlider: requireElement(ids.scaleSlider),
+    currentScale: requireElement(ids.currentScale),
     futureOpacity: requireElement(ids.futureOpacity),
+    currentOpacity: requireElement(ids.currentOpacity),
     spaceColor: requireElement(ids.spaceColor),
     columnToggleList: requireElement(ids.columnToggleList),
     status: requireElement(ids.status),
@@ -661,6 +680,24 @@ function loadAndRender(): void {
   });
 }
 
+// ---- Appearance application -------------------------------------------
+
+/** Apply the league-owned scale to the graph and its display. */
+function applyScale(): void {
+  const value = String(controlState.league.scale);
+  refs.scaleSlider.value = value;
+  refs.currentScale.textContent = value;
+  setScale(refs.boxContainer, value);
+}
+
+/** Apply the league-owned future opacity to the CSS rule and its display. */
+function applyFutureOpacity(): void {
+  const value = String(controlState.league.futureOpacity);
+  refs.futureOpacity.value = value;
+  refs.currentOpacity.textContent = value;
+  setFutureOpacity(value);
+}
+
 // ---- Initialization & event wiring ------------------------------------
 
 export function initLeagueView(ids: LeagueViewIds, ctx: LeagueViewContext): LeagueViewHandle {
@@ -736,14 +773,14 @@ export function initLeagueView(ids: LeagueViewIds, ctx: LeagueViewContext): Leag
   });
 
   refs.scaleSlider.addEventListener('input', () => {
-    controlState.viewer.scale = parseFloat(refs.scaleSlider.value);
-    setScale(refs.boxContainer, refs.scaleSlider.value);
-    ctx.onViewerChange();
+    controlState.league.scale = parseFloat(refs.scaleSlider.value);
+    applyScale();
+    savePrefs({ leagueScale: refs.scaleSlider.value });
   });
   refs.futureOpacity.addEventListener('input', () => {
-    controlState.viewer.futureOpacity = parseFloat(refs.futureOpacity.value);
-    setFutureOpacity(refs.futureOpacity.value);
-    ctx.onViewerChange();
+    controlState.league.futureOpacity = parseFloat(refs.futureOpacity.value);
+    applyFutureOpacity();
+    savePrefs({ leagueFutureOpacity: refs.futureOpacity.value });
   });
   refs.spaceColor.addEventListener('input', () => {
     controlState.league.spaceColor = refs.spaceColor.value;
@@ -764,15 +801,14 @@ export function initLeagueView(ids: LeagueViewIds, ctx: LeagueViewContext): Leag
       activeSelection = selection;
       if (selectionChanged) state.teamMapCache = null;
 
-      const previousScale = controlState.viewer.scale;
-      const clampedScale = clampToSlider(previousScale, refs.scaleSlider);
-      refs.scaleSlider.value = String(clampedScale);
-      controlState.viewer.scale = parseFloat(refs.scaleSlider.value);
-      if (controlState.viewer.scale !== previousScale) ctx.onViewerChange();
-      refs.futureOpacity.value = String(controlState.viewer.futureOpacity);
+      // Clamp for display only: the stored value stays as the user set it, so
+      // visiting a view with a narrower slider range cannot ratchet it (#302).
+      controlState.league.scale = clampToSlider(controlState.league.scale, refs.scaleSlider);
+      applyScale();
+      applyFutureOpacity();
       refs.targetDate.value = toInputDate(controlState.viewer.targetDate) || dateFormat(new Date(), '-');
-      setFutureOpacity(refs.futureOpacity.value, false);
-      if (prefs.spaceColor) setSpace(controlState.league.spaceColor, false);
+      refs.spaceColor.value = controlState.league.spaceColor;
+      setSpace(controlState.league.spaceColor);
       loadAndRender();
     },
     deactivate() {

--- a/frontend/src/matches-app.ts
+++ b/frontend/src/matches-app.ts
@@ -20,12 +20,13 @@ import type {
   ViewType,
 } from './types/season';
 import {
-  createSharedViewerControlState,
+  createSharedDateState,
   normalizeTargetDate,
   readUrlParams,
   restoreLocaleAndApplyI18n,
   writeUrlParams,
 } from './view-bootstrap';
+import type { SharedDateState } from './view-bootstrap';
 import { t } from './i18n';
 import {
   resolveInitialCompetition,
@@ -104,15 +105,13 @@ function selectedViewType(select: HTMLSelectElement): ViewType | undefined {
   return select.selectedOptions[0]?.dataset.viewType as ViewType | undefined;
 }
 
-function persistSharedViewerState(
-  shared: ReturnType<typeof createSharedViewerControlState>,
-): void {
+/**
+ * Persist the one piece of viewer state both views share. Scale and future
+ * opacity are owned and saved by each view under its own key (#302).
+ */
+function persistSharedDateState(shared: SharedDateState): void {
   shared.targetDate = normalizeTargetDate(shared.targetDate);
-  savePrefs({
-    scale: String(shared.scale),
-    futureOpacity: String(shared.futureOpacity),
-    targetDate: shared.targetDate ?? undefined,
-  });
+  savePrefs({ targetDate: shared.targetDate ?? undefined });
 }
 
 async function main(): Promise<void> {
@@ -137,13 +136,13 @@ async function main(): Promise<void> {
     throw new Error('Unified viewer shell is incomplete');
   }
 
-  const shared = createSharedViewerControlState(prefs);
+  const shared = createSharedDateState(prefs);
   if (prefs.targetDate && prefs.targetDate !== shared.targetDate) {
     savePrefs({ targetDate: shared.targetDate ?? undefined });
   }
   const context = {
     shared,
-    onViewerChange: () => persistSharedViewerState(shared),
+    onViewerChange: () => persistSharedDateState(shared),
   };
   const leagueView = initLeagueView(LEAGUE_NAMESPACED_IDS, context);
   const bracketView = initBracketView(BRACKET_NAMESPACED_IDS, context);

--- a/frontend/src/storage/local-storage.ts
+++ b/frontend/src/storage/local-storage.ts
@@ -11,9 +11,18 @@ export interface ViewerPrefs {
   targetDate?: string;   // Canonical YYYY/MM/DD (CSV date format)
   teamSortKey?: string;
   matchSortKey?: string;
+  /** @deprecated Legacy shared value; read as a fallback for the per-view keys below. */
   futureOpacity?: string;
   spaceColor?: string;
+  /** @deprecated Legacy shared value; read as a fallback for the per-view keys below. */
   scale?: string;
+  // Per-view appearance. scale ranges and opacity defaults differ between the
+  // views, so sharing one value let the bracket's clamp destroy the league's
+  // setting (#302). Legacy keys above seed these on first load only.
+  leagueScale?: string;
+  bracketScale?: string;
+  leagueFutureOpacity?: string;
+  bracketFutureOpacity?: string;
   locale?: string;
   displayTimezone?: string;  // display IANA TZ name ('' or absent = browser default)
   roundStart?: string;   // bracket round start selection (or '__multi_section__')

--- a/frontend/src/view-bootstrap.ts
+++ b/frontend/src/view-bootstrap.ts
@@ -38,18 +38,17 @@ export function restoreLocaleAndApplyI18n(savedLocale: string | undefined): Loca
   return locale;
 }
 
-// ---- Shared viewer control state -----------------------------------------
+// ---- Shared viewer state --------------------------------------------------
 
-export interface SharedViewerControlState {
-  scale: number;
-  futureOpacity: number;
+/**
+ * The only viewer state both views share. Scale and future opacity used to
+ * live here too, but their ranges and defaults differ per view, so sharing
+ * them let one view's clamp overwrite the other's setting (#302). The target
+ * date stays shared so a competition's group and knockout stages can be read
+ * at the same point in time.
+ */
+export interface SharedDateState {
   targetDate: string | null;
-}
-
-/** Defaults differ slightly between views (e.g. bracket's default futureOpacity is 0.2). */
-export interface SharedViewerControlDefaults {
-  scale?: number;
-  futureOpacity?: number;
 }
 
 export function normalizeTargetDate(value: string | null | undefined): string | null {
@@ -83,13 +82,22 @@ export function clampToSlider(value: number, slider: HTMLInputElement): number {
   return Math.min(max, Math.max(min, finiteValue));
 }
 
-export function createSharedViewerControlState(
-  prefs: ViewerPrefs,
-  defaults: SharedViewerControlDefaults = {},
-): SharedViewerControlState {
-  return {
-    scale: prefs.scale ? parseFloat(prefs.scale) : (defaults.scale ?? 1),
-    futureOpacity: prefs.futureOpacity ? parseFloat(prefs.futureOpacity) : (defaults.futureOpacity ?? 0.1),
-    targetDate: restoreTargetDate(prefs.targetDate),
-  };
+export function createSharedDateState(prefs: ViewerPrefs): SharedDateState {
+  return { targetDate: restoreTargetDate(prefs.targetDate) };
+}
+
+/**
+ * Read a per-view numeric pref, falling back to the legacy shared key and then
+ * to the view's own default. The legacy key is only ever read: once the user
+ * touches a control, the per-view key is written and takes over from then on.
+ */
+export function readViewNumberPref(
+  value: string | undefined,
+  legacyValue: string | undefined,
+  fallback: number,
+): number {
+  const raw = value ?? legacyValue;
+  if (raw == null || raw === '') return fallback;
+  const parsed = parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
 }


### PR DESCRIPTION
Fixes #302

> **注**: #301 の上に積んでいます。マージ順は #299 → #301 → 本PR。

## 概要

レビュー指摘の Medium 3件 (#4 / #5 / #6) を回収する。3件はいずれも「scale / futureOpacity を View 間で共有すべきか」という 1 つの仕様問題に帰着するため、**View 別 pref への分離** (ユーザー承認済み) で構造ごと解決した。

共有状態は `targetDate` のみになり、型名も `SharedViewerControlState` → `SharedDateState` に実態を合わせた。

## 修正内容

### #6. scale ラチェットの解消

各 View が自分の scale を所有する。activate 時の `clampToSlider` は**表示用のみ**に適用し、保存値には書き戻さない。保存はユーザーがスライダーを操作した時だけ。

### #5. Bracket の futureOpacity デフォルト

`matches-app.ts` が生成する共有状態が League の 0.1 を両 View に配っていた。各 View がコード側に自分のデフォルト (League 0.1 / Bracket 0.2) を持つ形にした。

### #4. css-utils の DOM 副作用除去

`setFutureOpacity` / `setScale` / `setSpace` から `getElementById` による slider / display / picker 更新を削除し、責務を CSS ルール操作のみにした。League には Bracket と対称の `applyScale()` / `applyFutureOpacity()` を追加し、`league_current_scale` / `league_current_opacity` を refs 経由で更新する。

### マイグレーション

`ViewerPrefs` に `leagueScale` / `bracketScale` / `leagueFutureOpacity` / `bracketFutureOpacity` を追加。旧 `scale` / `futureOpacity` は**読み取り時のみ** fallback として使い、書き戻さない (二重管理の防止)。既存ユーザーの設定はそのまま引き継がれる。

## 検証

**追加/変更した E2E 3本すべて、修正前のコードで落ちることを確認済み**。失敗内容が指摘そのもの:

- `keeps appearance per view` — 修正前は Bracket が League の `0.3` を継承 (期待 `0.2`) = #5
- `league scale below the bracket minimum survives a round trip` — 修正前は `0.2` → `0.3` にラチェット = #6
- `league scale and opacity displays track their sliders` — 修正前は表示が `1` のまま固定 (期待 `0.7`) = #4

- `npm test` 590 passed
- `npm run typecheck` / `npm run build` 通過
- `npx playwright test --grep-invert @full-render` 98 passed

## 挙動変更 (リリースノート向け)

- 拡大率と未実施試合の透明度が **League / Bracket で別々に記憶される**ようになった。従来の設定値は初回のみ両 View に引き継がれる
- 既存 E2E `shares viewer controls and canonical target date across views` は共有前提だったため、`shares the target date across views but keeps appearance per view` に更新した

## 随伴

`setSpace` のシグネチャ変更に伴い、League activate の `if (prefs.spaceColor)` ガード (初期化時にキャプチャした prefs を参照し続ける stale 参照) も `controlState.league.spaceColor` 基準の無条件適用に置き換えた。レビュー指摘 Low #12 に相当する。