### PR TITLE
Clean up view switch orchestration leftovers

### DIFF
--- a/frontend/e2e/unified-viewer.spec.ts
+++ b/frontend/e2e/unified-viewer.spec.ts
@@ -90,6 +90,45 @@ test.describe('Unified league and bracket viewer', () => {
     await expect(page.locator('#league_current_opacity')).toHaveText('0.45');
   });
 
+  // #304: the saved season belongs to the competition it was viewed in.
+  test('switching competition selects that competition latest season', async ({ page }) => {
+    await page.selectOption('#season_key', '2024');
+    await waitForRender(page);
+
+    await page.selectOption('#competition_key', 'J2');
+    await waitForRender(page);
+    await page.selectOption('#competition_key', 'J1');
+    await waitForRender(page);
+
+    const seasons = await page.locator('#season_key option').evaluateAll(
+      (options) => options.map((o) => (o as HTMLOptionElement).value),
+    );
+    expect(await page.locator('#season_key').inputValue()).toBe(seasons[0]);
+  });
+
+  test('a season given in the URL is still restored', async ({ page }) => {
+    await page.goto('/matches.html?competition=J1&season=2024');
+    await waitForRender(page);
+
+    expect(await page.locator('#season_key').inputValue()).toBe('2024');
+  });
+
+  // #304: the bracket view now hides the timezone selector itself, and League
+  // re-shows it from its own data.
+  test('timezone selector visibility follows the active view', async ({ page }) => {
+    await page.goto('/matches.html?competition=WC_GS&season=2026');
+    await waitForRender(page);
+    await expect(page.locator('#display_timezone_label')).toBeVisible();
+
+    await page.selectOption('#competition_key', 'JLeagueCup');
+    await waitForBracketRender(page);
+    await expect(page.locator('#display_timezone_label')).toBeHidden();
+
+    await page.selectOption('#competition_key', 'WC_GS');
+    await waitForRender(page);
+    await expect(page.locator('#display_timezone_label')).toBeVisible();
+  });
+
   // #298: the bracket view used to write values the user never picked into the
   // shared target date, which League then displayed (and persisted).
   test('bracket view does not pin the shared target date to its own last match day', async ({ page }) => {

--- a/frontend/src/__tests__/matches-orchestration.test.ts
+++ b/frontend/src/__tests__/matches-orchestration.test.ts
@@ -3,7 +3,6 @@ import type { SeasonMap } from '../types/season';
 import {
   resolveInitialCompetition,
   resolveInitialSeason,
-  shouldShowTimezone,
 } from '../matches-orchestration';
 
 const seasonMap: SeasonMap = {
@@ -85,16 +84,17 @@ describe('resolveInitialSeason', () => {
   it('returns empty for an unknown competition', () => {
     expect(resolveInitialSeason(seasonMap, 'unknown', {}, {})).toBe('');
   });
-});
 
-describe('shouldShowTimezone', () => {
-  it('follows season timezone availability for league view', () => {
-    expect(shouldShowTimezone('league', true)).toBe(true);
-    expect(shouldShowTimezone('league', false)).toBe(false);
+  // #304: a competition switch passes no prefs, so the latest season wins.
+  // The saved season belongs to whichever competition was last viewed and
+  // must not follow the user into a different one.
+  it('selects the latest season when neither URL nor prefs supply one', () => {
+    expect(resolveInitialSeason(seasonMap, 'J1', {}, {}, ['2026', '2025'])).toBe('2026');
   });
 
-  it('always hides timezone control for bracket view', () => {
-    expect(shouldShowTimezone('bracket', true)).toBe(false);
-    expect(shouldShowTimezone('bracket', false)).toBe(false);
+  it('still honours a season supplied by the URL', () => {
+    expect(resolveInitialSeason(seasonMap, 'J1', { season: '2025' }, {}, ['2026', '2025']))
+      .toBe('2025');
   });
 });
+

--- a/frontend/src/__tests__/tournament/bracket-view.test.ts
+++ b/frontend/src/__tests__/tournament/bracket-view.test.ts
@@ -224,6 +224,39 @@ describe('bracket-view helpers', () => {
     });
   });
 
+  // #304: keying the build cache on bracket_order alone collided when two
+  // sections shared an order but filtered different rounds, so the second
+  // section rendered the first section's tree.
+  describe('bracket build cache key', () => {
+    const state = {
+      csvRows: [makeRow()],
+      seasonInfo: { aggregateTiebreakOrder: [], cssFiles: [] },
+      matchDates: ['2025/03/15', '2025/03/22'],
+    } as unknown as Parameters<typeof __testables.createSingleBracketRenderInput>[0];
+    const order = ['TeamA', 'TeamB'];
+
+    test('the same order in different sections gets different cache keys', () => {
+      const first = __testables.createSingleBracketRenderInput(state, order, '準決勝');
+      const second = __testables.createSingleBracketRenderInput(state, order, '３位決定戦');
+
+      expect(first?.cacheKey).not.toBe(second?.cacheKey);
+    });
+
+    test('the same order in the same section reuses one cache key', () => {
+      const first = __testables.createSingleBracketRenderInput(state, order, '準決勝');
+      const second = __testables.createSingleBracketRenderInput(state, order, '準決勝');
+
+      expect(first?.cacheKey).toBe(second?.cacheKey);
+    });
+
+    test('different orders in the same section stay distinct', () => {
+      const first = __testables.createSingleBracketRenderInput(state, order, 'S');
+      const second = __testables.createSingleBracketRenderInput(state, ['TeamC', 'TeamD'], 'S');
+
+      expect(first?.cacheKey).not.toBe(second?.cacheKey);
+    });
+  });
+
   describe('shared target date boundary (#298)', () => {
     // matchDates always starts with the preseason sentinel (collectMatchDates
     // prepends it), so index 0 is the "before any match" slider position.

--- a/frontend/src/bracket-view.ts
+++ b/frontend/src/bracket-view.ts
@@ -80,6 +80,13 @@ interface SingleBracketRenderInput {
   targetDate: string | null;
   lastDate: string;
   cssFiles: string[];
+  /**
+   * Identifies the tree being built. The bracket_order alone is not unique:
+   * two sections can share an order but filter different rounds out of the
+   * CSV, and keying on the order alone would serve the first section's tree
+   * to the second (#304).
+   */
+  cacheKey: string;
 }
 
 const MULTI_SECTION_VALUE = '__multi_section__';
@@ -149,9 +156,8 @@ export interface BracketViewHandle {
 }
 
 export interface BracketViewIds {
-  competition: string;
-  season: string;
   roundStart: string;
+  displayTimezoneLabel: string;
   dateSlider: string;
   dateSliderDown: string;
   dateSliderUp: string;
@@ -168,9 +174,8 @@ export interface BracketViewIds {
 }
 
 export const BRACKET_STANDALONE_IDS: BracketViewIds = {
-  competition: 'competition_key',
-  season: 'season_key',
   roundStart: 'round_start_key',
+  displayTimezoneLabel: 'display_timezone_label',
   dateSlider: 'date_slider',
   dateSliderDown: 'date_slider_down',
   dateSliderUp: 'date_slider_up',
@@ -201,9 +206,8 @@ export const BRACKET_NAMESPACED_IDS: BracketViewIds = {
 };
 
 interface BracketViewRefs {
-  competition: HTMLSelectElement;
-  season: HTMLSelectElement;
   roundStart: HTMLSelectElement;
+  displayTimezoneLabel: HTMLElement;
   dateSlider: HTMLInputElement;
   dateSliderDown: HTMLElement;
   dateSliderUp: HTMLElement;
@@ -231,9 +235,8 @@ function requireElement<T extends HTMLElement>(id: string): T {
 
 function resolveRefs(ids: BracketViewIds): BracketViewRefs {
   return {
-    competition: requireElement(ids.competition),
-    season: requireElement(ids.season),
     roundStart: requireElement(ids.roundStart),
+    displayTimezoneLabel: requireElement(ids.displayTimezoneLabel),
     dateSlider: requireElement(ids.dateSlider),
     dateSliderDown: requireElement(ids.dateSliderDown),
     dateSliderUp: requireElement(ids.dateSliderUp),
@@ -303,7 +306,7 @@ function hasBracketMetadata(entry: RawSeasonEntry): boolean {
 export function populateBracketSeasonPulldown(
   seasonMap: SeasonMap,
   competition: string,
-  select: HTMLSelectElement = refs.season,
+  select: HTMLSelectElement,
 ): void {
   select.replaceChildren();
   const found = findCompetition(seasonMap, competition);
@@ -425,6 +428,7 @@ function collectRoundsFromCsv(rows: RawMatchRow[]): string[] {
 
 export const __testables = {
   createControlStateFromPrefs,
+  createSingleBracketRenderInput,
   effectiveTargetDate,
   resolveSliderSelection,
   resolveMainBlockOrder,
@@ -573,9 +577,8 @@ function buildAndRenderBracket(
   container: HTMLElement,
   input: SingleBracketRenderInput,
 ): void {
-  const { rows, order, aggregateTiebreakOrder, targetDate, lastDate, cssFiles } = input;
+  const { rows, order, aggregateTiebreakOrder, targetDate, lastDate, cssFiles, cacheKey } = input;
   if (order.length < 2) return;
-  const cacheKey = JSON.stringify(order);
   let fullRoot = bracketCache.get(cacheKey);
   if (!fullRoot) {
     fullRoot = buildBracket(rows, order, aggregateTiebreakOrder);
@@ -589,6 +592,7 @@ function buildAndRenderBracket(
 function createSingleBracketRenderInput(
   state: Pick<BracketState, 'csvRows' | 'seasonInfo' | 'matchDates'>,
   order: (string | null)[],
+  scope = '',
 ): SingleBracketRenderInput | null {
   if (order.length < 2 || state.matchDates.length === 0) return null;
   return {
@@ -598,6 +602,7 @@ function createSingleBracketRenderInput(
     targetDate: getTargetDate(),
     lastDate: state.matchDates[state.matchDates.length - 1],
     cssFiles: state.seasonInfo.cssFiles,
+    cacheKey: `${scope}\u0000${JSON.stringify(order)}`,
   };
 }
 
@@ -681,6 +686,7 @@ function renderMultiSections(): void {
         const input = createSingleBracketRenderInput(
           { ...currentState, csvRows: rows },
           pair,
+          `${section.label}#${i}`,
         );
         if (input) buildAndRenderBracket(sectionWrapper, input);
       }
@@ -688,6 +694,7 @@ function renderMultiSections(): void {
       const input = createSingleBracketRenderInput(
         { ...currentState, csvRows: rows },
         sectionOrder,
+        section.label,
       );
       if (input) buildAndRenderBracket(sectionWrapper, input);
     }
@@ -1039,11 +1046,12 @@ export function initBracketView(
 
   return {
     activate(seasonMap, selection) {
+      // Bracket rows never carry a source timezone, so the selector stays
+      // hidden here; League re-shows it when its own data has one (#304).
+      refs.displayTimezoneLabel.hidden = true;
       activeSelection = selection;
       // Preseason is a transient slider position, not a restored preference.
       controlState.bracket.preseason = false;
-      refs.competition.value = selection.competition;
-      refs.season.value = selection.season;
       // Clamp for display only: the stored value stays as the user set it, so
       // visiting a view with a narrower slider range cannot ratchet it (#302).
       controlState.bracket.scale = clampToSlider(controlState.bracket.scale, refs.scaleSlider);

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -36,6 +36,7 @@ export const en: Record<MessageKey, string> = {
   'status.cached': '{league} {season} (cached)',
   'status.error': 'CSV load error: {detail}',
   'status.noSeason': 'No season info: {competition}/{season}',
+  'status.noDisplayableSeason': 'No displayable season: {competition}',
   'status.seasonMapError': 'Failed to load season_map.yaml',
   'status.dataSource': 'Data source: ',
 

--- a/frontend/src/i18n/messages/ja.ts
+++ b/frontend/src/i18n/messages/ja.ts
@@ -34,6 +34,7 @@ export const ja = {
   'status.cached': '{league} {season} (cached)',
   'status.error': 'CSV読み込みエラー: {detail}',
   'status.noSeason': 'シーズン情報なし: {competition}/{season}',
+  'status.noDisplayableSeason': '表示可能なシーズンがありません: {competition}',
   'status.seasonMapError': 'season_map.yaml の読み込みに失敗しました',
   'status.dataSource': 'データ参照元: ',
 

--- a/frontend/src/matches-app.ts
+++ b/frontend/src/matches-app.ts
@@ -31,7 +31,6 @@ import { t } from './i18n';
 import {
   resolveInitialCompetition,
   resolveInitialSeason,
-  shouldShowTimezone,
 } from './matches-orchestration';
 
 interface CompetitionOption {
@@ -131,7 +130,6 @@ async function main(): Promise<void> {
   const viewRoot = document.getElementById('view_root');
   const competitionSelect = document.getElementById('competition_key') as HTMLSelectElement | null;
   const seasonSelect = document.getElementById('season_key') as HTMLSelectElement | null;
-  const timezoneLabel = document.getElementById('display_timezone_label');
   if (!viewRoot || !competitionSelect || !seasonSelect) {
     throw new Error('Unified viewer shell is incomplete');
   }
@@ -176,11 +174,21 @@ async function main(): Promise<void> {
     }
     if (activeViewType !== viewType) {
       viewRoot.dataset.active = viewType;
-      if (timezoneLabel && viewType === 'bracket') {
-        timezoneLabel.hidden = !shouldShowTimezone(viewType, false);
-      }
     }
     activeViewType = viewType;
+
+    // #11: a competition with no displayable season would otherwise persist an
+    // empty season and leave the previous view's status on screen.
+    if (!selection.season) {
+      const status = document.getElementById(`${viewType}_status_msg`);
+      if (status) {
+        status.textContent = t('status.noDisplayableSeason', {
+          competition: selection.competition,
+        });
+      }
+      return;
+    }
+
     writeUrlParams(selection.competition, selection.season);
     savePrefs(selection);
     handles[viewType].activate(seasonMap, selection);
@@ -201,11 +209,14 @@ async function main(): Promise<void> {
     const viewType = selectedViewType(competitionSelect);
     if (!viewType) return;
     populateSeasons(viewType);
+    // Switching competition selects that competition's latest season. The
+    // saved season belongs to whichever competition the user last viewed, so
+    // carrying it across meant J1 could open on J2's year (#304).
     seasonSelect.value = resolveInitialSeason(
       seasonMap,
       competitionSelect.value,
       {},
-      loadPrefs(),
+      {},
       Array.from(seasonSelect.options).map(option => option.value),
     );
     activate(viewType);

--- a/frontend/src/matches-orchestration.ts
+++ b/frontend/src/matches-orchestration.ts
@@ -1,5 +1,5 @@
 import { findCompetition } from './config/season-map';
-import type { SeasonMap, ViewType } from './types/season';
+import type { SeasonMap } from './types/season';
 
 export interface InitialSelectionSource {
   competition?: string;
@@ -36,8 +36,4 @@ export function resolveInitialSeason(
   return availableSeasons?.[0]
     ?? Object.keys(found.competition.seasons).sort().reverse()[0]
     ?? '';
-}
-
-export function shouldShowTimezone(viewType: ViewType, hasTimezone: boolean): boolean {
-  return viewType === 'league' && hasTimezone;
 }


### PR DESCRIPTION
Fixes #304

> **注**: #303 の上に積んでいます。マージ順は #299 → #301 → #303 → 本PR。

## 概要

レビュー指摘の Low 5件 (#7-#11) をまとめて回収する。Low #12 (League activate の stale prefs 参照) は #303 で `setSpace` のシグネチャ変更に伴い解消済み。

## 修正内容

### #9. ブラケット構築キャッシュのキー衝突 (時限バグ)

キャッシュキーが `JSON.stringify(order)` のみで round_filter 適用後の rows を含まず、「同一 bracket_order・異なる round_filter」のセクションが並ぶと**後段セクションに前段の木が使われる**。キーにセクション識別子を含めた。現行 season_map では顕在化していないが、条件が揃えば壊れる。

### #10. 大会切替時のシーズン引き継ぎ (挙動変更)

保存済み season は「最後に見ていた大会」のものなので、別大会に持ち込むのは誤り。大会プルダウン切替時は常にその大会の最新シーズンを選ぶようにした。URL パラメータ指定時の復元は従来どおり。

### #11. 空シーズン時の無言失敗

表示可能なシーズンが 1 つもない大会を選ぶと、空 season が URL/prefs に永続化されたうえ status が前の表示のまま残っていた。書き込みをスキップし、status にメッセージを出す (i18n キー `status.noDisplayableSeason` を追加)。season_map の設定ミス検知にもなる。

### #7. timezone ラベル制御の整理

`shouldShowTimezone(viewType, false)` は bracket では常に false で、実質 `hidden = true` を回りくどく書いていただけ。Bracket の `activate()` が自分で隠し、League は従来どおり描画時に自分のデータから判定する形に寄せた。orchestrator から参照を削除し、不要になった `shouldShowTimezone` は関数ごと削除。

### #8. standalone 時代の名残の削除

Bracket `activate()` の `refs.competition.value` / `refs.season.value` は統合ページでは no-op の二重管理。削除に伴い `competition` / `season` refs も未使用になったため ids/refs から除去し、`populateBracketSeasonPulldown` の standalone 用デフォルト引数も廃止した。

## 検証

**#10 の E2E は修正前のコードで落ちることを確認済み** — J1 で 2024 を選択 → J2 → J1 と戻ると `26-27` ではなく `2024` のままだった。

#9 は現行データで再現しないため、キャッシュキーの分離をユニットテストで固定した (同一 order × 異なるセクションで別キーになること)。

- `npm test` 593 passed
- `npm run typecheck` / `npm run build` 通過
- `npx playwright test --grep-invert @full-render` 104 passed

## 挙動変更 (リリースノート向け)

- 大会を切り替えると、その大会の**最新シーズン**が選ばれるようになった。従来は直前の大会で見ていた年度が引き継がれていた。URL で年度を指定した場合は従来どおり復元される